### PR TITLE
refactor: remove 9 unused exports from internal modules

### DIFF
--- a/main/flow-helpers.js
+++ b/main/flow-helpers.js
@@ -138,6 +138,6 @@ module.exports = {
   SCHEDULER_INTERVAL_MS, SHELL_INIT_DELAY_MS, MAX_RUN_HISTORY,
   DEFAULT_PTY_COLS, DEFAULT_PTY_ROWS,
   flowPath, logPath,
-  AGENT_COMMANDS, getLastRun, shouldRun, buildFlowCommand,
+  getLastRun, shouldRun, buildFlowCommand,
   createOutputProcessor,
 };

--- a/main/fs-manager-helpers.js
+++ b/main/fs-manager-helpers.js
@@ -58,4 +58,4 @@ function dirFirstCompare(a, b) {
   return a.name.localeCompare(b.name);
 }
 
-module.exports = { MAX_FILE_SIZE, safeAsync, pathExists, findUniqueCopyPath, doCopy, dirFirstCompare };
+module.exports = { MAX_FILE_SIZE, safeAsync, doCopy, dirFirstCompare };

--- a/main/pty-helpers.js
+++ b/main/pty-helpers.js
@@ -32,7 +32,6 @@ function parseCwdFromLsof(lsofOutput) {
 }
 
 module.exports = {
-  KNOWN_AGENTS,
   EXEC_TIMEOUT_MS,
   CWD_TIMEOUT_MS,
   DEFAULT_COLS,

--- a/main/usage-helpers.js
+++ b/main/usage-helpers.js
@@ -237,11 +237,6 @@ function collectUniqueCwds(flowRuns, sessions) {
 }
 
 module.exports = {
-  TOKEN_FIELD_MAP,
-  TOKEN_KEYS,
-  PERDAY_KEYS,
-  MAX_RUN_DURATION_MS,
-  TOP_PROJECTS_LIMIT,
   CACHE_TTL,
   TOP_FILES_LIMIT,
   GIT_TIMEOUT_MS,


### PR DESCRIPTION
## Refactoring

Suppression de 9 exports inutilisés qui ne sont jamais importés en dehors de leur module :

- **usage-helpers.js** : `TOKEN_FIELD_MAP`, `TOKEN_KEYS`, `PERDAY_KEYS`, `MAX_RUN_DURATION_MS`, `TOP_PROJECTS_LIMIT`
- **fs-manager-helpers.js** : `pathExists`, `findUniqueCopyPath`
- **flow-helpers.js** : `AGENT_COMMANDS`
- **pty-helpers.js** : `KNOWN_AGENTS`

`countByStatus` et `MAX_SESSIONS` ont été conservés car utilisés dans les tests.

Closes #5

## Fichier(s) modifié(s)

- `main/usage-helpers.js`
- `main/fs-manager-helpers.js`
- `main/flow-helpers.js`
- `main/pty-helpers.js`

## Vérifications

- [x] Build OK
- [x] Tests OK (200/200)

---

📂 Path local : `/Users/rekta/projet/coding/refactor-pikagent`
🤖 PR créée automatiquement par l'Agent Refactor