### PR TITLE
refactor: eliminate duplicated code across modules

### DIFF
--- a/main/config-manager.js
+++ b/main/config-manager.js
@@ -1,7 +1,7 @@
 const fsp = require('fs/promises');
 const path = require('path');
 const { CONFIG_DIR, META_FILE } = require('./paths');
-const { readJson, ensureDirOnce, readDirJson } = require('./fs-utils');
+const { readJson, writeJson, ensureDirOnce, readDirJson } = require('./fs-utils');
 const { DEFAULT_META, sanitizeName, buildConfigRecord, formatConfigList } = require('./config-helpers');
 
 const ensureDir = ensureDirOnce(CONFIG_DIR);
@@ -20,14 +20,14 @@ async function readMeta() {
 async function writeMeta(meta) {
   await ensureDir();
   _metaCache = meta;
-  await fsp.writeFile(META_FILE, JSON.stringify(meta, null, 2), 'utf-8');
+  await writeJson(META_FILE, meta);
 }
 
 async function save(name, data) {
   await ensureDir();
   const existing = await readJson(configPath(name));
   const config = buildConfigRecord(name, data, existing, new Date().toISOString());
-  await fsp.writeFile(configPath(name), JSON.stringify(config, null, 2), 'utf-8');
+  await writeJson(configPath(name), config);
   return config;
 }
 

--- a/main/flow-manager.js
+++ b/main/flow-manager.js
@@ -2,13 +2,14 @@ const fsp = require('fs/promises');
 const path = require('path');
 const os = require('os');
 const { FLOWS_DIR, LOGS_DIR, FLOW_CATEGORIES_FILE } = require('./paths');
-const { readJson, ensureDirOnce, readDirJson } = require('./fs-utils');
+const { readJson, writeJson, ensureDirOnce, readDirJson } = require('./fs-utils');
 const {
   SCHEDULER_INTERVAL_MS, SHELL_INIT_DELAY_MS, MAX_RUN_HISTORY,
   DEFAULT_PTY_COLS, DEFAULT_PTY_ROWS,
   flowPath, logPath,
   shouldRun, buildFlowCommand, createOutputProcessor,
 } = require('./flow-helpers');
+const { safeSend } = require('./ipc-helpers');
 
 const ensureDir = ensureDirOnce(LOGS_DIR);
 
@@ -37,10 +38,7 @@ class FlowManager {
   // --- Window IPC helper ---
 
   _sendToWindow(channel, payload) {
-    const win = this._getWindow?.();
-    if (win && !win.isDestroyed()) {
-      win.webContents.send(channel, payload);
-    }
+    if (this._getWindow) safeSend(this._getWindow, channel, payload);
   }
 
   // --- CRUD ---
@@ -55,7 +53,7 @@ class FlowManager {
     };
     if (!data.runs) data.runs = [];
     if (data.enabled === undefined) data.enabled = true;
-    await fsp.writeFile(flowPath(flow.id), JSON.stringify(data, null, 2), 'utf-8');
+    await writeJson(flowPath(flow.id), data);
     return data;
   }
 
@@ -109,7 +107,7 @@ class FlowManager {
 
   async saveCategories(data) {
     await ensureDir();
-    await fsp.writeFile(FLOW_CATEGORIES_FILE, JSON.stringify(data, null, 2), 'utf-8');
+    await writeJson(FLOW_CATEGORIES_FILE, data);
     return data;
   }
 

--- a/main/fs-utils.js
+++ b/main/fs-utils.js
@@ -29,4 +29,8 @@ async function readDirJson(dirPath) {
   }
 }
 
-module.exports = { readJson, ensureDirOnce, readDirJson };
+async function writeJson(filePath, data) {
+  await fsp.writeFile(filePath, JSON.stringify(data, null, 2), 'utf-8');
+}
+
+module.exports = { readJson, writeJson, ensureDirOnce, readDirJson };

--- a/main/session-manager.js
+++ b/main/session-manager.js
@@ -1,7 +1,6 @@
-const fsp = require('fs/promises');
 const os = require('os');
 const { BASE_DIR, SESSIONS_FILE } = require('./paths');
-const { readJson, ensureDirOnce } = require('./fs-utils');
+const { readJson, writeJson, ensureDirOnce } = require('./fs-utils');
 const { generateSessionId, durationSec, isFlowTerminal, buildEndedRecord, buildActiveRecord, trimSessions } = require('./session-helpers');
 
 const POLL_INTERVAL_MS = 5000;
@@ -100,7 +99,7 @@ class SessionManager {
 
     this._sessionsCache = trimSessions([...(this._sessionsCache || []), record]);
 
-    fsp.writeFile(SESSIONS_FILE, JSON.stringify(this._sessionsCache, null, 2), 'utf-8')
+    writeJson(SESSIONS_FILE, this._sessionsCache)
       .catch((err) => console.warn('session-manager: write failed:', err.message));
   }
 

--- a/src/components/tab-manager.js
+++ b/src/components/tab-manager.js
@@ -10,6 +10,7 @@ import { contextMenu } from './context-menu.js';
 import { ConfigManager } from './config-manager.js';
 import { _el, showConfirmDialog, setupInlineInput } from '../utils/dom.js';
 import { trackMouse } from '../utils/drag-helpers.js';
+import { extractFolderName } from '../utils/file-tree-helpers.js';
 import {
   DRAG_THRESHOLD, PANEL_MIN_WIDTH, FIT_DELAY_MS,
   ACTIVITY_BUTTONS, COLOR_GROUPS, SIDE_VIEWS, TAB_DISPOSABLES, WORKSPACE_PANELS, WorkspaceTab,
@@ -111,7 +112,7 @@ export class TabManager {
       }],
       ['layout:changed', () => this.configManager.scheduleAutoSave()],
       ['workspace:openFromFolder', ({ cwd }) => {
-        const folderName = cwd.split('/').filter(Boolean).pop() || '/';
+        const folderName = extractFolderName(cwd);
         this.createTab(folderName, cwd);
       }],
     ];


### PR DESCRIPTION
## Refactoring

Élimination de 3 patterns de duplication dans le codebase :

1. **`_sendToWindow()` → `safeSend()`** : `FlowManager._sendToWindow()` délègue maintenant à `safeSend()` de `ipc-helpers.js` au lieu de dupliquer la logique de vérification window
2. **`extractFolderName()`** : `tab-manager.js` importe et utilise `extractFolderName()` de `file-tree-helpers.js` au lieu de dupliquer le code inline
3. **`writeJson()`** : Nouvelle fonction dans `fs-utils.js` remplaçant 4 occurrences de `fsp.writeFile(path, JSON.stringify(data, null, 2), 'utf-8')` dans config-manager, flow-manager et session-manager

Closes #4

## Fichier(s) modifié(s)

- `main/fs-utils.js` (ajout `writeJson`)
- `main/flow-manager.js` (use safeSend + writeJson)
- `main/config-manager.js` (use writeJson)
- `main/session-manager.js` (use writeJson, remove unused fsp import)
- `src/components/tab-manager.js` (use extractFolderName)

## Vérifications

- [x] Build OK
- [x] Tests OK (200/200)

---

📂 Path local : `/Users/rekta/projet/coding/refactor-pikagent`
🤖 PR créée automatiquement par l'Agent Refactor