### PR TITLE
refactor: extract pure logic from large components

### DIFF
--- a/src/components/file-viewer.js
+++ b/src/components/file-viewer.js
@@ -5,13 +5,7 @@ import { WebviewInstance } from './webview-panel.js';
 import { contextMenu } from './context-menu.js';
 import { generateId } from '../utils/id.js';
 import { _el, setupInlineInput } from '../utils/dom.js';
-import { getCursorPosition, insertTab, parseWebviewUrl, SAVE_FLASH_MS, TAB_SPACES, EMPTY_MESSAGE, STATIC_MODES, MODE_CONFIG, ALL_STATIC_ELEMENTS, pinnedFiles } from '../utils/editor-helpers.js';
-
-/** Declarative map for mode activation — drives switchMode behavior per static mode. */
-const MODE_ACTIVATE = {
-  files: (viewer) => { if (viewer.activeFile) viewer.renderEditor(); },
-  git: (viewer) => viewer.gitChanges.loadChanges(),
-};
+import { getCursorPosition, insertTab, parseWebviewUrl, SAVE_FLASH_MS, TAB_SPACES, EMPTY_MESSAGE, STATIC_MODES, MODE_CONFIG, ALL_STATIC_ELEMENTS, MODE_ACTIVATE, pinnedFiles } from '../utils/editor-helpers.js';
 
 export class FileViewer {
   constructor(container, isActive) {

--- a/src/utils/editor-helpers.js
+++ b/src/utils/editor-helpers.js
@@ -25,6 +25,12 @@ export const ALL_STATIC_ELEMENTS = [...new Set(Object.values(MODE_CONFIG).flatMa
 /** Global pinned files: path → { name } */
 export const pinnedFiles = new Map();
 
+/** Declarative map for mode activation — drives switchMode behavior per static mode. */
+export const MODE_ACTIVATE = {
+  files: (viewer) => { if (viewer.activeFile) viewer.renderEditor(); },
+  git: (viewer) => viewer.gitChanges.loadChanges(),
+};
+
 // ===== Helpers =====
 
 /**

--- a/tests/utils/editor-helpers.test.js
+++ b/tests/utils/editor-helpers.test.js
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   getCursorPosition, insertTab, parseWebviewUrl,
-  SAVE_FLASH_MS, TAB_SPACES, EMPTY_MESSAGE, STATIC_MODES,
+  SAVE_FLASH_MS, TAB_SPACES, EMPTY_MESSAGE, STATIC_MODES, MODE_ACTIVATE,
 } from '../../src/utils/editor-helpers.js';
 
 describe('editor-helpers', () => {
@@ -23,6 +23,29 @@ describe('editor-helpers', () => {
         { key: 'files', label: 'Files' },
         { key: 'git', label: 'Git Changes' },
       ]);
+    });
+
+    it('MODE_ACTIVATE has entries for files and git', () => {
+      expect(typeof MODE_ACTIVATE.files).toBe('function');
+      expect(typeof MODE_ACTIVATE.git).toBe('function');
+    });
+
+    it('MODE_ACTIVATE.files calls renderEditor when activeFile is set', () => {
+      const viewer = { activeFile: '/test.js', renderEditor: () => { viewer._called = true; }, _called: false };
+      MODE_ACTIVATE.files(viewer);
+      expect(viewer._called).toBe(true);
+    });
+
+    it('MODE_ACTIVATE.files does not call renderEditor when activeFile is null', () => {
+      const viewer = { activeFile: null, renderEditor: () => { viewer._called = true; }, _called: false };
+      MODE_ACTIVATE.files(viewer);
+      expect(viewer._called).toBe(false);
+    });
+
+    it('MODE_ACTIVATE.git calls gitChanges.loadChanges', () => {
+      const viewer = { gitChanges: { loadChanges: () => { viewer._called = true; } }, _called: false };
+      MODE_ACTIVATE.git(viewer);
+      expect(viewer._called).toBe(true);
     });
   });
 


### PR DESCRIPTION
## Refactoring

Extraction de la logique pure restante des composants volumineux :

- **file-viewer.js** : `MODE_ACTIVATE` (table déclarative d'activation des modes) déplacé vers `editor-helpers.js` (476 → 470 lignes)
- 4 tests ajoutés pour `MODE_ACTIVATE`

**Note** : `terminal-panel.js`, `file-tree.js` et `settings-modal.js` avaient déjà des fichiers helpers complets (`terminal-panel-helpers.js`, `split-helpers.js`, `file-tree-helpers.js`, `settings-helpers.js`) couvrant toute la logique pure extractible. Le code restant dans ces composants est du DOM ou des méthodes liées à `this`.

Closes #3

## Fichier(s) modifié(s)

- `src/utils/editor-helpers.js` (ajout `MODE_ACTIVATE`)
- `src/components/file-viewer.js` (import au lieu de définition locale)
- `tests/utils/editor-helpers.test.js` (4 nouveaux tests)

## Vérifications

- [x] Build OK
- [x] Tests OK (204/204)

---

📂 Path local : `/Users/rekta/projet/coding/refactor-pikagent`
🤖 PR créée automatiquement par l'Agent Refactor