### PR TITLE
refactor: extract tab drag-drop logic from tab-manager.js

### DIFF
--- a/src/components/tab-manager.js
+++ b/src/components/tab-manager.js
@@ -11,8 +11,9 @@ import { ConfigManager } from './config-manager.js';
 import { _el, showConfirmDialog, setupInlineInput } from '../utils/dom.js';
 import { trackMouse } from '../utils/drag-helpers.js';
 import { extractFolderName } from '../utils/file-tree-helpers.js';
+import { setupTabDrag } from '../utils/tab-drag.js';
 import {
-  DRAG_THRESHOLD, PANEL_MIN_WIDTH, FIT_DELAY_MS,
+  PANEL_MIN_WIDTH, FIT_DELAY_MS,
   ACTIVITY_BUTTONS, COLOR_GROUPS, SIDE_VIEWS, TAB_DISPOSABLES, WORKSPACE_PANELS, WorkspaceTab,
   clampPanelWidth, panelArrowState, reorderEntries,
   findCycleTarget, findColorGroupTarget,
@@ -481,7 +482,7 @@ export class TabManager {
     }
 
     tabEl.addEventListener('click', () => this.switchTo(id));
-    this.setupTabDrag(tabEl, id);
+    setupTabDrag(this, tabEl, id);
     this._bindTabContextMenu(tabEl, id, tab, nameEl);
 
     return tabEl;
@@ -530,134 +531,6 @@ export class TabManager {
     const addBtn = _el('div', 'tab tab-add', '+');
     addBtn.addEventListener('click', () => this.createTab());
     this.tabBar.appendChild(addBtn);
-  }
-
-  // ===== Tab Drag & Drop Reorder =====
-
-  setupTabDrag(tabEl, tabId) {
-    let startX = 0;
-    let dragging = false;
-    let ghost = null;
-    let offsetX = 0;
-
-    tabEl.addEventListener('mousedown', (e) => {
-      if (e.button !== 0) return;
-      startX = e.clientX;
-      const rect = tabEl.getBoundingClientRect();
-      offsetX = e.clientX - rect.left;
-      dragging = false;
-
-      const onMouseMove = (ev) => {
-        if (!dragging && Math.abs(ev.clientX - startX) > DRAG_THRESHOLD) {
-          dragging = true;
-          tabEl.classList.add('tab-dragging');
-          document.body.style.cursor = 'grabbing';
-          document.body.style.userSelect = 'none';
-
-          // Create floating ghost clone
-          ghost = tabEl.cloneNode(true);
-          ghost.className = 'tab tab-ghost';
-          if (tabEl.classList.contains('active')) ghost.classList.add('active');
-          const r = tabEl.getBoundingClientRect();
-          ghost.style.width = `${r.width}px`;
-          ghost.style.height = `${r.height}px`;
-          ghost.style.top = `${r.top}px`;
-          document.body.appendChild(ghost);
-        }
-        if (dragging && ghost) {
-          ghost.style.left = `${ev.clientX - offsetX}px`;
-          this._updateTabDropTarget(ev.clientX, tabId);
-        }
-      };
-
-      const onMouseUp = () => {
-        document.removeEventListener('mousemove', onMouseMove);
-        document.removeEventListener('mouseup', onMouseUp);
-
-        if (dragging) {
-          tabEl.classList.remove('tab-dragging');
-          document.body.style.cursor = '';
-          document.body.style.userSelect = '';
-          if (ghost) { ghost.remove(); ghost = null; }
-          this._clearTabShifts();
-
-          if (this._tabDropTargetId && this._tabDropTargetId !== tabId) {
-            this.reorderTab(tabId, this._tabDropTargetId, this._tabDropBefore);
-          }
-          this._tabDropTargetId = null;
-          this._tabDropBefore = null;
-        }
-      };
-
-      document.addEventListener('mousemove', onMouseMove);
-      document.addEventListener('mouseup', onMouseUp);
-    });
-  }
-
-  _clearTabShifts() {
-    for (const [, el] of this._tabElements) {
-      el.style.transform = '';
-      el.style.transition = '';
-    }
-  }
-
-  _updateTabDropTarget(mx, dragId) {
-    this._tabDropTargetId = null;
-    this._tabDropBefore = true;
-
-    // Get ordered tab IDs
-    const orderedIds = Array.from(this._tabElements.keys());
-
-    // Find the dragged tab's width for shift amount
-    const dragEl = this._tabElements.get(dragId);
-    const shiftAmount = dragEl ? dragEl.getBoundingClientRect().width : 0;
-
-    // Determine insertion index based on mouse position
-    let insertIdx = -1;
-    const dragIdx = orderedIds.indexOf(dragId);
-
-    for (let i = 0; i < orderedIds.length; i++) {
-      const id = orderedIds[i];
-      if (id === dragId) continue;
-      const el = this._tabElements.get(id);
-      const rect = el.getBoundingClientRect();
-      const midX = rect.left + rect.width / 2;
-
-      if (mx < midX) {
-        this._tabDropTargetId = id;
-        this._tabDropBefore = true;
-        insertIdx = i;
-        break;
-      }
-    }
-
-    // If no target found, insert after last
-    if (insertIdx === -1) {
-      const lastId = orderedIds.filter((id) => id !== dragId).pop();
-      if (lastId) {
-        this._tabDropTargetId = lastId;
-        this._tabDropBefore = false;
-        insertIdx = orderedIds.length;
-      }
-    }
-
-    // Shift tabs to make visual gap
-    for (let i = 0; i < orderedIds.length; i++) {
-      const id = orderedIds[i];
-      if (id === dragId) continue;
-      const el = this._tabElements.get(id);
-      el.style.transition = 'transform 0.2s ease';
-
-      if (dragIdx < insertIdx) {
-        // Dragging right: shift left the tabs between old and new position
-        el.style.transform = (i > dragIdx && i < insertIdx) ? `translateX(${-shiftAmount}px)` : '';
-      } else if (dragIdx > insertIdx) {
-        // Dragging left: shift right the tabs between new and old position
-        el.style.transform = (i >= insertIdx && i < dragIdx) ? `translateX(${shiftAmount}px)` : '';
-      } else {
-        el.style.transform = '';
-      }
-    }
   }
 
   reorderTab(fromId, toId, before) {

--- a/src/utils/tab-drag.js
+++ b/src/utils/tab-drag.js
@@ -1,0 +1,154 @@
+/**
+ * Tab drag-and-drop reorder logic — extracted from TabManager to keep the
+ * component file focused on workspace orchestration.
+ *
+ * Exports a single factory that wires drag behaviour onto tab elements,
+ * reading / writing shared state through a thin `ctx` interface.
+ *
+ * ctx shape (provided by TabManager):
+ *   _tabElements   : Map<tabId, HTMLElement>   — live tab DOM elements
+ *   reorderTab(fromId, toId, before): void      — commit the reorder
+ */
+
+import { DRAG_THRESHOLD } from './tab-manager-helpers.js';
+
+// ── Internal helpers ────────────────────────────────────────────────
+
+/** Reset CSS transforms on every tab element. */
+function clearTabShifts(ctx) {
+  for (const [, el] of ctx._tabElements) {
+    el.style.transform = '';
+    el.style.transition = '';
+  }
+}
+
+/**
+ * While dragging, determine which tab the cursor is over and shift
+ * surrounding tabs to open a visual gap.
+ */
+function updateTabDropTarget(ctx, state, mx, dragId) {
+  state.dropTargetId = null;
+  state.dropBefore = true;
+
+  const orderedIds = Array.from(ctx._tabElements.keys());
+  const dragEl = ctx._tabElements.get(dragId);
+  const shiftAmount = dragEl ? dragEl.getBoundingClientRect().width : 0;
+
+  let insertIdx = -1;
+  const dragIdx = orderedIds.indexOf(dragId);
+
+  for (let i = 0; i < orderedIds.length; i++) {
+    const id = orderedIds[i];
+    if (id === dragId) continue;
+    const el = ctx._tabElements.get(id);
+    const rect = el.getBoundingClientRect();
+    const midX = rect.left + rect.width / 2;
+
+    if (mx < midX) {
+      state.dropTargetId = id;
+      state.dropBefore = true;
+      insertIdx = i;
+      break;
+    }
+  }
+
+  // If no target found, insert after last
+  if (insertIdx === -1) {
+    const lastId = orderedIds.filter((id) => id !== dragId).pop();
+    if (lastId) {
+      state.dropTargetId = lastId;
+      state.dropBefore = false;
+      insertIdx = orderedIds.length;
+    }
+  }
+
+  // Shift tabs to make visual gap
+  for (let i = 0; i < orderedIds.length; i++) {
+    const id = orderedIds[i];
+    if (id === dragId) continue;
+    const el = ctx._tabElements.get(id);
+    el.style.transition = 'transform 0.2s ease';
+
+    if (dragIdx < insertIdx) {
+      // Dragging right: shift left the tabs between old and new position
+      el.style.transform = (i > dragIdx && i < insertIdx) ? `translateX(${-shiftAmount}px)` : '';
+    } else if (dragIdx > insertIdx) {
+      // Dragging left: shift right the tabs between new and old position
+      el.style.transform = (i >= insertIdx && i < dragIdx) ? `translateX(${shiftAmount}px)` : '';
+    } else {
+      el.style.transform = '';
+    }
+  }
+}
+
+// ── Public API ──────────────────────────────────────────────────────
+
+/**
+ * Wire drag-to-reorder behaviour on a single tab element.
+ *
+ * @param {object} ctx       — TabManager instance (provides _tabElements & reorderTab)
+ * @param {HTMLElement} tabEl — the tab DOM element
+ * @param {string} tabId     — the tab's unique id
+ */
+export function setupTabDrag(ctx, tabEl, tabId) {
+  let startX = 0;
+  let dragging = false;
+  let ghost = null;
+  let offsetX = 0;
+
+  // Per-drag transient state (not stored on ctx)
+  const state = { dropTargetId: null, dropBefore: true };
+
+  tabEl.addEventListener('mousedown', (e) => {
+    if (e.button !== 0) return;
+    startX = e.clientX;
+    const rect = tabEl.getBoundingClientRect();
+    offsetX = e.clientX - rect.left;
+    dragging = false;
+
+    const onMouseMove = (ev) => {
+      if (!dragging && Math.abs(ev.clientX - startX) > DRAG_THRESHOLD) {
+        dragging = true;
+        tabEl.classList.add('tab-dragging');
+        document.body.style.cursor = 'grabbing';
+        document.body.style.userSelect = 'none';
+
+        // Create floating ghost clone
+        ghost = tabEl.cloneNode(true);
+        ghost.className = 'tab tab-ghost';
+        if (tabEl.classList.contains('active')) ghost.classList.add('active');
+        const r = tabEl.getBoundingClientRect();
+        ghost.style.width = `${r.width}px`;
+        ghost.style.height = `${r.height}px`;
+        ghost.style.top = `${r.top}px`;
+        document.body.appendChild(ghost);
+      }
+      if (dragging && ghost) {
+        ghost.style.left = `${ev.clientX - offsetX}px`;
+        updateTabDropTarget(ctx, state, ev.clientX, tabId);
+      }
+    };
+
+    const onMouseUp = () => {
+      document.removeEventListener('mousemove', onMouseMove);
+      document.removeEventListener('mouseup', onMouseUp);
+
+      if (dragging) {
+        tabEl.classList.remove('tab-dragging');
+        document.body.style.cursor = '';
+        document.body.style.userSelect = '';
+        if (ghost) { ghost.remove(); ghost = null; }
+        clearTabShifts(ctx);
+
+        if (state.dropTargetId && state.dropTargetId !== tabId) {
+          ctx.reorderTab(tabId, state.dropTargetId, state.dropBefore);
+        }
+        state.dropTargetId = null;
+        state.dropBefore = null;
+      }
+    };
+
+    document.addEventListener('mousemove', onMouseMove);
+    document.addEventListener('mouseup', onMouseUp);
+  });
+}


### PR DESCRIPTION
## Refactoring

Extraction de la logique de drag-drop des onglets de `tab-manager.js` dans un module dédié `tab-drag.js` :

- **`setupTabDrag(ctx, tabEl, tabId)`** : gestion mousedown/mousemove/mouseup, création du clone fantôme, seuil de drag
- **`clearTabShifts(tabBar)`** : reset des transforms CSS après un drag
- **`updateTabDropTarget(state, ctx, mouseX)`** : calcul de la position d'insertion, shift visuel des onglets

**Résultat** : `tab-manager.js` réduit de **1006 → 879 lignes** (-127 lignes, -12.6%)

**Amélioration** : l'état de drag est maintenant local par session de drag au lieu d'être stocké sur l'instance TabManager.

Closes #2

## Fichier(s) modifié(s)

- `src/utils/tab-drag.js` (nouveau, 154 lignes)
- `src/components/tab-manager.js` (879 lignes, -127)

## Vérifications

- [x] Build OK
- [x] Tests OK (200/200)

---

📂 Path local : `/Users/rekta/projet/coding/refactor-pikagent`
🤖 PR créée automatiquement par l'Agent Refactor