### PR TITLE
refactor: extract log modal from flow-view, add terminal defaults constant

### DIFF
--- a/src/components/flow-log-viewer.js
+++ b/src/components/flow-log-viewer.js
@@ -1,0 +1,40 @@
+/**
+ * Standalone modal viewer for past flow run logs.
+ * Self-contained — creates overlay, terminal, and handles lifecycle.
+ */
+import { _el } from '../utils/dom.js';
+import { createTerminal } from '../utils/terminal-factory.js';
+import {
+  LOG_SCROLLBACK, NO_LOG_MODAL_MESSAGE, STATUS_LABELS,
+  FLOW_TERMINAL_DEFAULTS, formatRunDateTime,
+} from '../utils/flow-view-helpers.js';
+
+function buildHeader(flow, run) {
+  const header = _el('div', 'flow-log-header');
+  header.appendChild(_el('span', 'flow-log-title', `${flow.name} — ${formatRunDateTime(run.date, run.timestamp)}`));
+  header.appendChild(_el('span', `flow-log-status flow-log-status-${run.status}`, STATUS_LABELS[run.status] || run.status));
+  header.appendChild(_el('button', 'flow-log-close', '✕'));
+  return header;
+}
+
+export async function showRunLogModal(flow, run) {
+  const log = await window.api.flow.getRunLog(flow.id, run.logTimestamp);
+
+  const overlay = _el('div', 'flow-modal-overlay');
+  const modal = _el('div', 'flow-log-modal');
+  const termContainer = _el('div', 'flow-log-terminal');
+  modal.append(buildHeader(flow, run), termContainer);
+  overlay.appendChild(modal);
+  document.body.appendChild(overlay);
+
+  const { term, resizeObs } = createTerminal(termContainer, {
+    ...FLOW_TERMINAL_DEFAULTS,
+    scrollback: LOG_SCROLLBACK,
+  });
+
+  term.write(log || NO_LOG_MODAL_MESSAGE);
+
+  const close = () => { resizeObs.disconnect(); term.dispose(); overlay.remove(); };
+  modal.querySelector('.flow-log-close').addEventListener('click', close);
+  overlay.addEventListener('click', (e) => { if (e.target === overlay) close(); });
+}

--- a/src/components/flow-view.js
+++ b/src/components/flow-view.js
@@ -515,7 +515,6 @@ export class FlowView {
     const containerEl = _el('div', 'flow-card-terminal');
 
     const { term, fitAddon, resizeObs } = this._createReadonlyTerminal(containerEl, {
-      scrollback: LIVE_SCROLLBACK,
       cursorStyle: 'bar',
     });
 

--- a/src/components/flow-view.js
+++ b/src/components/flow-view.js
@@ -1,14 +1,16 @@
 import { openFlowModal } from './flow-modal.js';
-import { SCHEDULE_LABELS, DAY_NAMES, formatSchedule } from '../utils/flow-schedule-helpers.js';
+import { showRunLogModal } from './flow-log-viewer.js';
+import { formatSchedule } from '../utils/flow-schedule-helpers.js';
 import { _el, _safeFit, showPromptDialog, setupInlineInput } from '../utils/dom.js';
 import { createTerminal, disposeTerminal } from '../utils/terminal-factory.js';
 import { generateId } from '../utils/id.js';
 import {
-  FIT_DELAY_MS, LOG_SCROLLBACK, LIVE_SCROLLBACK,
-  STATUS_LABELS, NO_LOG_MESSAGE, NO_LOG_MODAL_MESSAGE,
+  FIT_DELAY_MS, LOG_SCROLLBACK,
+  NO_LOG_MESSAGE,
   EMPTY_LIST_MESSAGE, MAX_VISIBLE_RUNS, UNCATEGORIZED,
   HEADER_BUTTONS, CATEGORY_ACTIONS,
-  formatRunDateTime, buildDotTooltip, buildCardActionEntries,
+  FLOW_TERMINAL_DEFAULTS,
+  buildDotTooltip, buildCardActionEntries,
   getFlowsForCategory, getUncategorizedFlows,
   removeFlowFromOrder, moveFlowInOrder, deleteCategoryData,
   getLastRun,
@@ -413,7 +415,7 @@ export class FlowView {
       dot.title = buildDotTooltip(run);
       dot.addEventListener('click', (e) => {
         e.stopPropagation();
-        this._showRunLog(flow, run);
+        showRunLogModal(flow, run);
       });
       dots.appendChild(dot);
     }
@@ -500,16 +502,7 @@ export class FlowView {
   }
 
   _createReadonlyTerminal(containerEl, termOpts = {}) {
-    return createTerminal(containerEl, {
-      fontSize: 12,
-      lineHeight: 1.3,
-      cursorBlink: false,
-      disableStdin: true,
-      scrollback: LIVE_SCROLLBACK,
-      autoResize: true,
-      fitDelay: FIT_DELAY_MS,
-      ...termOpts,
-    });
+    return createTerminal(containerEl, { ...FLOW_TERMINAL_DEFAULTS, ...termOpts });
   }
 
   _createLiveTerminal(flowId, ptyId) {
@@ -565,36 +558,7 @@ export class FlowView {
     this._disposeTerminalEntry(this._logTerminals, flowId);
   }
 
-  // === Past Run Log Viewer (modal) ===
-
-  _buildLogModalHeader(flow, run) {
-    const header = _el('div', 'flow-log-header');
-    header.appendChild(_el('span', 'flow-log-title', `${flow.name} — ${formatRunDateTime(run.date, run.timestamp)}`));
-    header.appendChild(_el('span', `flow-log-status flow-log-status-${run.status}`, STATUS_LABELS[run.status] || run.status));
-    header.appendChild(_el('button', 'flow-log-close', '✕'));
-    return header;
-  }
-
-  async _showRunLog(flow, run) {
-    const log = await window.api.flow.getRunLog(flow.id, run.logTimestamp);
-
-    const overlay = _el('div', 'flow-modal-overlay');
-    const modal = _el('div', 'flow-log-modal');
-    const termContainer = _el('div', 'flow-log-terminal');
-    modal.append(this._buildLogModalHeader(flow, run), termContainer);
-    overlay.appendChild(modal);
-    document.body.appendChild(overlay);
-
-    const { term, resizeObs } = this._createReadonlyTerminal(termContainer, {
-      scrollback: LOG_SCROLLBACK,
-    });
-
-    term.write(log || NO_LOG_MODAL_MESSAGE);
-
-    const close = () => { resizeObs.disconnect(); term.dispose(); overlay.remove(); };
-    modal.querySelector('.flow-log-close').addEventListener('click', close);
-    overlay.addEventListener('click', (e) => { if (e.target === overlay) close(); });
-  }
+  // === Past Run Log Viewer (modal — delegated to flow-log-viewer.js) ===
 
   // ===== Creation / Edit Modal =====
 

--- a/src/utils/flow-view-helpers.js
+++ b/src/utils/flow-view-helpers.js
@@ -7,6 +7,17 @@ export const FIT_DELAY_MS = 50;
 export const LOG_SCROLLBACK = 50000;
 export const LIVE_SCROLLBACK = 10000;
 
+/** Default terminal options shared by all flow terminals (live, log, modal). */
+export const FLOW_TERMINAL_DEFAULTS = {
+  fontSize: 12,
+  lineHeight: 1.3,
+  cursorBlink: false,
+  disableStdin: true,
+  scrollback: LIVE_SCROLLBACK,
+  autoResize: true,
+  fitDelay: FIT_DELAY_MS,
+};
+
 export const STATUS_LABELS = { success: 'Succès', error: 'Erreur' };
 export const NO_LOG_MESSAGE = '\r\n  Log non disponible pour ce run.\r\n';
 export const NO_LOG_MODAL_MESSAGE = '\r\n  Log non disponible.\r\n';


### PR DESCRIPTION
## Refactoring

- Extracted the past run log modal viewer from `flow-view.js` into a standalone `flow-log-viewer.js` module (follows the existing pattern of `flow-modal.js`)
- Added `FLOW_TERMINAL_DEFAULTS` constant to `flow-view-helpers.js` to centralize terminal config shared by all flow terminals (live, log, modal)
- Simplified `_createReadonlyTerminal` to use the shared defaults
- Removed unused imports (`SCHEDULE_LABELS`, `DAY_NAMES`, `STATUS_LABELS`, `NO_LOG_MODAL_MESSAGE`, `LIVE_SCROLLBACK`, `formatRunDateTime`)

**Result**: `flow-view.js` reduced from 635 to 599 lines.

**Note on the other 4 files** (terminal-panel, file-viewer, file-tree, settings-modal): all already have helpers extracted. The remaining code is inherently DOM/event/state code that belongs in the component. No further extraction provides clear benefit.

Closes #3

## Fichier(s) modifié(s)

- `src/components/flow-log-viewer.js` (new — standalone log modal)
- `src/components/flow-view.js` (reduced)
- `src/utils/flow-view-helpers.js` (added `FLOW_TERMINAL_DEFAULTS`)

## Vérifications

- [x] Build OK
- [x] Tests OK (204/204 passed)

---

📂 Path local : `/Users/rekta/projet/coding/refactor-pikagent`
🤖 PR créée automatiquement par l'Agent Refactor