### PR TITLE
refactor: decouple ipc-handlers with registry pattern

### DIFF
--- a/main/config-manager.js
+++ b/main/config-manager.js
@@ -79,4 +79,21 @@ async function loadDefault() {
   return load(name);
 }
 
-module.exports = { save, load, list, remove, setDefault, getDefault, loadDefault };
+function registerHandlers(ipcMain) {
+  const { registerForward, registerSpread } = require('./ipc-helpers');
+
+  registerForward(ipcMain, { load, list, remove, setDefault, getDefault, loadDefault }, [
+    ['config:load',        'load'],
+    ['config:list',        'list'],
+    ['config:delete',      'remove'],
+    ['config:setDefault',  'setDefault'],
+    ['config:getDefault',  'getDefault'],
+    ['config:loadDefault', 'loadDefault'],
+  ]);
+
+  registerSpread(ipcMain, { save }, [
+    ['config:save', 'save', ['name', 'data']],
+  ]);
+}
+
+module.exports = { save, load, list, remove, setDefault, getDefault, loadDefault, registerHandlers };

--- a/main/electron-handlers.js
+++ b/main/electron-handlers.js
@@ -1,0 +1,25 @@
+const { shell, clipboard, dialog } = require('electron');
+const { registerForward } = require('./ipc-helpers');
+
+function registerHandlers(ipcMain, { getWindow }) {
+  registerForward(ipcMain, shell, [
+    ['shell:showInFolder', 'showItemInFolder'],
+    ['shell:openExternal', 'openExternal'],
+    ['shell:openPath',     'openPath'],
+  ]);
+
+  registerForward(ipcMain, clipboard, [
+    ['clipboard:write', 'writeText'],
+  ]);
+
+  ipcMain.handle('dialog:openFolder', async () => {
+    const win = getWindow();
+    const result = await dialog.showOpenDialog(win, {
+      properties: ['openDirectory'],
+    });
+    if (result.canceled || !result.filePaths.length) return null;
+    return result.filePaths[0];
+  });
+}
+
+module.exports = { registerHandlers };

--- a/main/flow-manager.js
+++ b/main/flow-manager.js
@@ -225,6 +225,28 @@ class FlowManager {
     flow.runs = runs.length > MAX_RUN_HISTORY ? runs.slice(-MAX_RUN_HISTORY) : runs;
     await this.save(flow);
   }
+
+  registerHandlers(ipcMain, { getWindow, ptyManager }) {
+    const { registerForward, registerSpread } = require('./ipc-helpers');
+
+    registerForward(ipcMain, this, [
+      ['flow:save',       'save'],
+      ['flow:get',        'get'],
+      ['flow:list',       'list'],
+      ['flow:delete',     'remove'],
+      ['flow:toggle',     'toggleEnabled'],
+      ['flow:runNow',     'runNow'],
+      ['flow:getRunning',    'getRunning'],
+      ['flow:getCategories', 'getCategories'],
+      ['flow:saveCategories', 'saveCategories'],
+    ]);
+
+    registerSpread(ipcMain, this, [
+      ['flow:getRunLog', 'getRunLog', ['flowId', 'logTimestamp']],
+    ]);
+
+    this.start(getWindow, ptyManager);
+  }
 }
 
 module.exports = new FlowManager();

--- a/main/fs-manager.js
+++ b/main/fs-manager.js
@@ -100,4 +100,39 @@ function getHomedir() {
   return os.homedir();
 }
 
-module.exports = { readDirectory, readFile, writeFile, makeDir, copyEntry, copyFileTo, renameEntry, getHomedir, watchDir, unwatchDir, unwatchAll };
+function registerHandlers(ipcMain, { getWindow }) {
+  const { shell } = require('electron');
+  const { safeSend, registerForward, registerSpread } = require('./ipc-helpers');
+
+  registerForward(ipcMain, { readDirectory, readFile, makeDir, getHomedir, copyEntry }, [
+    ['fs:readdir',  'readDirectory'],
+    ['fs:readfile', 'readFile'],
+    ['fs:mkdir',    'makeDir'],
+    ['fs:homedir',  'getHomedir'],
+    ['fs:copy',     'copyEntry'],
+  ]);
+
+  registerSpread(ipcMain, { writeFile, renameEntry, copyFileTo, unwatchDir }, [
+    ['fs:writefile', 'writeFile',  ['filePath', 'content']],
+    ['fs:rename',    'renameEntry', ['oldPath', 'newName']],
+    ['fs:copyTo',    'copyFileTo', ['srcPath', 'destDir']],
+    ['fs:unwatch',   'unwatchDir', ['id']],
+  ]);
+
+  ipcMain.handle('fs:watch', (_, { id, dirPath }) => {
+    watchDir(id, dirPath, (change) => {
+      safeSend(getWindow, 'fs:changed', change);
+    });
+  });
+
+  ipcMain.handle('fs:trash', async (_, filePath) => {
+    try {
+      await shell.trashItem(filePath);
+      return { success: true };
+    } catch (err) {
+      return { error: err.message };
+    }
+  });
+}
+
+module.exports = { readDirectory, readFile, writeFile, makeDir, copyEntry, copyFileTo, renameEntry, getHomedir, watchDir, unwatchDir, unwatchAll, registerHandlers };

--- a/main/git-manager.js
+++ b/main/git-manager.js
@@ -57,4 +57,18 @@ async function getFileDiff(cwd, filePath, isStaged) {
   return result;
 }
 
-module.exports = { getBranch, getRemoteUrl, getLocalChanges, getFileDiff };
+function registerHandlers(ipcMain) {
+  const { registerForward, registerSpread } = require('./ipc-helpers');
+
+  registerForward(ipcMain, { getBranch, getRemoteUrl, getLocalChanges }, [
+    ['git:branch',       'getBranch'],
+    ['git:remote',       'getRemoteUrl'],
+    ['git:localChanges', 'getLocalChanges'],
+  ]);
+
+  registerSpread(ipcMain, { getFileDiff }, [
+    ['git:fileDiff', 'getFileDiff', ['cwd', 'filePath', 'isStaged']],
+  ]);
+}
+
+module.exports = { getBranch, getRemoteUrl, getLocalChanges, getFileDiff, registerHandlers };

--- a/main/ipc-handlers.js
+++ b/main/ipc-handlers.js
@@ -1,77 +1,43 @@
-const { ipcMain, shell, clipboard, dialog } = require('electron');
+const { ipcMain } = require('electron');
 const PtyManager = require('./pty-manager');
-const fsManager = require('./fs-manager');
-const gitManager = require('./git-manager');
-const configManager = require('./config-manager');
-const flowManager = require('./flow-manager');
-const sessionManager = require('./session-manager');
-const usageManager = require('./usage-manager');
-const { safeSend, FORWARD_TABLE, SPREAD_TABLE } = require('./ipc-helpers');
 
 const ptyManager = new PtyManager();
 
-const TARGETS = {
-  pty: ptyManager,
-  fs: fsManager,
-  git: gitManager,
-  config: configManager,
-  flow: flowManager,
-  usage: usageManager,
-  shell,
-  clipboard,
-};
+/**
+ * Handler modules registry.
+ * Each module must export a registerHandlers(ipcMain, context) function.
+ * To add a new manager, simply append it to this array.
+ */
+const HANDLER_MODULES = [
+  require('./session-manager'),
+  ptyManager,
+  require('./fs-manager'),
+  require('./git-manager'),
+  require('./config-manager'),
+  require('./flow-manager'),
+  require('./usage-manager'),
+  require('./electron-handlers'),
+];
 
 function register(getWindow) {
-  for (const [channel, key, method] of FORWARD_TABLE) {
-    ipcMain.handle(channel, (_, arg) => TARGETS[key][method](arg));
+  const sessionManager = require('./session-manager');
+
+  const context = {
+    getWindow,
+    ptyManager,
+    sessionManager,
+  };
+
+  for (const mod of HANDLER_MODULES) {
+    mod.registerHandlers(ipcMain, context);
   }
-
-  for (const [channel, key, method, keys] of SPREAD_TABLE) {
-    ipcMain.handle(channel, (_, arg) => TARGETS[key][method](...keys.map(k => arg[k])));
-  }
-
-  // --- Custom handlers (require special logic) ---
-
-  ipcMain.handle('pty:create', (_, { id, cwd, cols, rows }) => {
-    const proc = ptyManager.create({ id, cwd, cols, rows });
-    proc.onData((data) => safeSend(getWindow, 'pty:data', { id, data }));
-    proc.onExit(({ exitCode }) => {
-      ptyManager.processes.delete(id);
-      sessionManager.onTerminalExit(id);
-      safeSend(getWindow, 'pty:exit', { id, exitCode });
-    });
-    return { pid: proc.pid };
-  });
-
-  ipcMain.handle('fs:watch', (_, { id, dirPath }) => {
-    fsManager.watchDir(id, dirPath, (change) => {
-      safeSend(getWindow, 'fs:changed', change);
-    });
-  });
-
-  ipcMain.handle('fs:trash', async (_, filePath) => {
-    try {
-      await shell.trashItem(filePath);
-      return { success: true };
-    } catch (err) {
-      return { error: err.message };
-    }
-  });
-
-  ipcMain.handle('dialog:openFolder', async () => {
-    const win = getWindow();
-    const result = await dialog.showOpenDialog(win, {
-      properties: ['openDirectory'],
-    });
-    if (result.canceled || !result.filePaths.length) return null;
-    return result.filePaths[0];
-  });
-
-  flowManager.start(getWindow, ptyManager);
-  sessionManager.start(ptyManager);
 }
 
 function cleanup() {
+  const sessionManager = require('./session-manager');
+  const flowManager = require('./flow-manager');
+  const fsManager = require('./fs-manager');
+
   sessionManager.stop();
   flowManager.stop();
   ptyManager.killAll();

--- a/main/ipc-helpers.js
+++ b/main/ipc-helpers.js
@@ -79,4 +79,28 @@ const SPREAD_TABLE = [
   ['flow:getRunLog', 'flow', 'getRunLog', ['flowId', 'logTimestamp']],
 ];
 
-module.exports = { safeSend, FORWARD_TABLE, SPREAD_TABLE };
+/**
+ * Register forward-style handlers on ipcMain for a given target.
+ * @param {object} ipc - Electron ipcMain
+ * @param {object} target - The object whose methods will be called
+ * @param {Array} entries - Array of [channel, method] tuples
+ */
+function registerForward(ipc, target, entries) {
+  for (const [channel, method] of entries) {
+    ipc.handle(channel, (_, arg) => target[method](arg));
+  }
+}
+
+/**
+ * Register spread-style handlers on ipcMain for a given target.
+ * @param {object} ipc - Electron ipcMain
+ * @param {object} target - The object whose methods will be called
+ * @param {Array} entries - Array of [channel, method, keys] tuples
+ */
+function registerSpread(ipc, target, entries) {
+  for (const [channel, method, keys] of entries) {
+    ipc.handle(channel, (_, arg) => target[method](...keys.map(k => arg[k])));
+  }
+}
+
+module.exports = { safeSend, FORWARD_TABLE, SPREAD_TABLE, registerForward, registerSpread };

--- a/main/pty-manager.js
+++ b/main/pty-manager.js
@@ -111,6 +111,32 @@ class PtyManager {
     }
     this.processes.clear();
   }
+
+  registerHandlers(ipcMain, { getWindow, sessionManager }) {
+    const { safeSend, registerForward, registerSpread } = require('./ipc-helpers');
+
+    registerForward(ipcMain, this, [
+      ['pty:checkAgents', 'checkAgents'],
+    ]);
+
+    registerSpread(ipcMain, this, [
+      ['pty:write',  'write',  ['id', 'data']],
+      ['pty:resize', 'resize', ['id', 'cols', 'rows']],
+      ['pty:kill',   'kill',   ['id']],
+      ['pty:getcwd', 'getCwd', ['id']],
+    ]);
+
+    ipcMain.handle('pty:create', (_, { id, cwd, cols, rows }) => {
+      const proc = this.create({ id, cwd, cols, rows });
+      proc.onData((data) => safeSend(getWindow, 'pty:data', { id, data }));
+      proc.onExit(({ exitCode }) => {
+        this.processes.delete(id);
+        sessionManager.onTerminalExit(id);
+        safeSend(getWindow, 'pty:exit', { id, exitCode });
+      });
+      return { pid: proc.pid };
+    });
+  }
 }
 
 module.exports = PtyManager;

--- a/main/session-manager.js
+++ b/main/session-manager.js
@@ -114,6 +114,10 @@ class SessionManager {
   getActiveSessions() {
     return Object.values(this._activeSessions).map(buildActiveRecord);
   }
+
+  registerHandlers(_ipcMain, { ptyManager }) {
+    this.start(ptyManager);
+  }
 }
 
 module.exports = new SessionManager();

--- a/main/usage-manager.js
+++ b/main/usage-manager.js
@@ -2,7 +2,6 @@ const fsp = require('fs/promises');
 const path = require('path');
 const { execFile } = require('child_process');
 const { promisify } = require('util');
-const sessionManager = require('./session-manager');
 const { FLOWS_DIR, CLAUDE_PROJECTS_DIR } = require('./paths');
 const { readDirJson } = require('./fs-utils');
 const { DEFAULT_DAYS, dayLabels } = require('./stats-helpers');
@@ -24,8 +23,13 @@ const {
 
 const execFileAsync = promisify(execFile);
 
+let _sessionManager = null;
 let _metricsCache = null;
 let _metricsCacheTime = 0;
+
+function init(sessionMgr) {
+  _sessionManager = sessionMgr;
+}
 
 // ===== I/O =====
 
@@ -110,8 +114,8 @@ async function getMetrics() {
   const flows = await getAllFlows();
   const flowRuns = getFlowRuns(flows);
 
-  const sessions = sessionManager.getSessions();
-  const activeSessions = sessionManager.getActiveSessions();
+  const sessions = _sessionManager.getSessions();
+  const activeSessions = _sessionManager.getActiveSessions();
   const allSessions = [...sessions, ...activeSessions];
 
   const agentMetrics = buildAgentMetrics(sessions, activeSessions);
@@ -135,4 +139,14 @@ async function getMetrics() {
   return result;
 }
 
-module.exports = { getMetrics };
+function registerHandlers(ipcMain, { sessionManager }) {
+  const { registerForward } = require('./ipc-helpers');
+
+  init(sessionManager);
+
+  registerForward(ipcMain, { getMetrics }, [
+    ['usage:getMetrics', 'getMetrics'],
+  ]);
+}
+
+module.exports = { init, getMetrics, registerHandlers };


### PR DESCRIPTION
## Refactoring

### 1. Dynamic registry pattern pour ipc-handlers.js
Chaque manager enregistre maintenant ses propres handlers IPC via `registerHandlers(ipcMain, context)`. L'ajout d'un nouveau manager ne nécessite plus que l'ajout d'une ligne dans `HANDLER_MODULES`.

### 2. Injection de dépendance pour usage-manager.js
`sessionManager` est injecté via `init(sessionMgr)` au lieu d'un import direct, permettant une meilleure testabilité.

Closes #14

## Fichier(s) modifié(s)

- `main/ipc-handlers.js` — remplacé le dispatcher central par un registry loop
- `main/ipc-helpers.js` — ajout de `registerForward()` et `registerSpread()`
- `main/pty-manager.js` — ajout de `registerHandlers()`
- `main/fs-manager.js` — ajout de `registerHandlers()`
- `main/git-manager.js` — ajout de `registerHandlers()`
- `main/config-manager.js` — ajout de `registerHandlers()`
- `main/flow-manager.js` — ajout de `registerHandlers()`
- `main/session-manager.js` — ajout de `registerHandlers()`
- `main/usage-manager.js` — injection de sessionManager via `init()`
- `main/electron-handlers.js` — **nouveau** — handlers shell/clipboard/dialog extraits

## Vérifications

- [x] Build OK
- [x] Tests OK (204 passed)

---

📂 Path local : `/Users/rekta/projet/coding/refactor-pikagent`
🤖 PR créée automatiquement par l'Agent Refactor