### PR TITLE
refactor: split tab-manager into registry, layout and sidebar modules

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6313,7 +6313,6 @@
       "integrity": "sha512-xjR1dMTVHlFLh98JE3i/f/WePqJsah4A0FK9cc8Ehp9Udk0AZk6ccpIZhh1qJ/yxVWRZ+Q54ocnD8TXmkhspGg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.2",
         "@vitest/mocker": "4.1.2",

--- a/src/components/board-view.js
+++ b/src/components/board-view.js
@@ -3,6 +3,7 @@ import { subscribeBus, unsubscribeBus } from '../utils/events.js';
 import { FilePathLinkProvider } from '../utils/file-link-provider.js';
 import { _el, _safeFit } from '../utils/dom.js';
 import { createTerminal, disposeTerminal, disposeTerminalMap } from '../utils/terminal-factory.js';
+import { registerComponent } from '../utils/component-registry.js';
 import {
   DATA_VOLUME_THRESHOLD, POLL_INTERVAL_MS, FIT_SETTLE_DELAY_MS, FIT_UNHIDE_DELAY_MS,
   STATUS_CONFIG, ALL_CARD_CLASSES, EVT_CREATED, EVT_REMOVED, EVT_EXITED,
@@ -262,3 +263,5 @@ export class BoardView {
     disposeTerminalMap(this.cards);
   }
 }
+
+registerComponent('BoardView', BoardView);

--- a/src/components/file-tree.js
+++ b/src/components/file-tree.js
@@ -7,6 +7,7 @@ import {
   SVG_ICONS, HEADER_ACTIONS,
   computeIndent, getRelativePath, extractFolderName, resolveWatchCwd,
 } from '../utils/file-tree-helpers.js';
+import { registerComponent } from '../utils/component-registry.js';
 
 function _parseSvg(svgStr) {
   const doc = new DOMParser().parseFromString(svgStr, 'image/svg+xml');
@@ -410,3 +411,5 @@ export class FileTree {
     this.termCwds.clear();
   }
 }
+
+registerComponent('FileTree', FileTree);

--- a/src/components/file-viewer.js
+++ b/src/components/file-viewer.js
@@ -6,6 +6,7 @@ import { contextMenu } from './context-menu.js';
 import { generateId } from '../utils/id.js';
 import { _el, setupInlineInput } from '../utils/dom.js';
 import { getCursorPosition, insertTab, parseWebviewUrl, SAVE_FLASH_MS, TAB_SPACES, EMPTY_MESSAGE, STATIC_MODES, MODE_CONFIG, ALL_STATIC_ELEMENTS, MODE_ACTIVATE, pinnedFiles } from '../utils/editor-helpers.js';
+import { registerComponent } from '../utils/component-registry.js';
 
 export class FileViewer {
   constructor(container, isActive) {
@@ -467,3 +468,5 @@ export class FileViewer {
     this._webviewEls.clear();
   }
 }
+
+registerComponent('FileViewer', FileViewer);

--- a/src/components/flow-view.js
+++ b/src/components/flow-view.js
@@ -3,6 +3,7 @@ import { SCHEDULE_LABELS, DAY_NAMES, formatSchedule } from '../utils/flow-schedu
 import { _el, _safeFit, showPromptDialog, setupInlineInput } from '../utils/dom.js';
 import { createReadonlyTerminal, disposeTerminal, disposeTerminalMap } from '../utils/terminal-factory.js';
 import { generateId } from '../utils/id.js';
+import { registerComponent } from '../utils/component-registry.js';
 import {
   FIT_DELAY_MS, LOG_SCROLLBACK, LIVE_SCROLLBACK,
   STATUS_LABELS, NO_LOG_MESSAGE, NO_LOG_MODAL_MESSAGE,
@@ -622,3 +623,5 @@ export class FlowView {
     disposeTerminalMap(this._logTerminals);
   }
 }
+
+registerComponent('FlowView', FlowView);

--- a/src/components/tab-manager.js
+++ b/src/components/tab-manager.js
@@ -1,51 +1,25 @@
 import { generateId } from '../utils/id.js';
-import { TerminalPanel } from './terminal-panel.js';
-import { FileTree } from './file-tree.js';
-import { FileViewer } from './file-viewer.js';
-import { BoardView } from './board-view.js';
-import { FlowView } from './flow-view.js';
-import { UsageView } from './usage-view.js';
 import { bus, subscribeBus, unsubscribeBus } from '../utils/events.js';
 import { contextMenu } from './context-menu.js';
 import { ConfigManager } from './config-manager.js';
 import { _el, showConfirmDialog, setupInlineInput } from '../utils/dom.js';
-import { trackMouse } from '../utils/drag-helpers.js';
 import { extractFolderName } from '../utils/file-tree-helpers.js';
 import { setupTabDrag } from '../utils/tab-drag.js';
 import {
-  PANEL_MIN_WIDTH, FIT_DELAY_MS,
-  ACTIVITY_BUTTONS, COLOR_GROUPS, SIDE_VIEWS, TAB_DISPOSABLES, WORKSPACE_PANELS, WorkspaceTab,
-  clampPanelWidth, panelArrowState, reorderEntries,
-  findCycleTarget, findColorGroupTarget,
+  COLOR_GROUPS, WorkspaceTab,
+  reorderEntries, findCycleTarget, findColorGroupTarget,
 } from '../utils/tab-manager-helpers.js';
 
-/**
- * Declarative map for sidebar view rendering — single source of truth for
- * ViewClass, constructor args, and post-reattach behavior per sidebar mode.
- * Lives here (not in helpers) because it references DOM component classes.
- */
-const SIDE_VIEW_RENDERERS = {
-  board: {
-    ViewClass: BoardView,
-    ctorArgs: (self) => [self],
-    onReattach: (self) => {
-      for (const [, card] of self.boardView.cards) {
-        try { card.fitAddon.fit(); } catch {}
-      }
-      self.boardView.resume();
-    },
-  },
-  flow: {
-    ViewClass: FlowView,
-    ctorArgs: (self) => [self],
-    onReattach: (self) => self.flowView.refresh(),
-  },
-  usage: {
-    ViewClass: UsageView,
-    ctorArgs: () => [],
-    onReattach: (self) => self.usageView.refresh(),
-  },
-};
+// Extracted modules
+import {
+  renderActivityBar, detachSidebarView, activateSideView,
+  disposeSideView, disposeAllSideViews,
+} from '../utils/sidebar-manager.js';
+import {
+  renderWorkspace as doRenderWorkspace, reattachLayout, syncFileTree,
+  serialize as doSerialize, restoreConfig as doRestoreConfig,
+  capturePanelWidths, disposeTab, disposeAllTabs,
+} from '../utils/workspace-layout.js';
 
 export { COLOR_GROUPS };
 
@@ -131,158 +105,36 @@ export class TabManager {
     return this.tabs.get(this.activeTabId);
   }
 
-  _reattachLayout(tab) {
-    this.workspaceContainer.replaceChildren();
-    this.workspaceContainer.appendChild(tab.layoutElement);
-    if (tab.terminalPanel) {
-      tab.terminalPanel.fitAll();
-      if (tab.terminalPanel.activeTerminal) {
-        tab.terminalPanel.activeTerminal.terminal.focus();
-      }
-    }
-  }
-
-  _syncFileTree(tab) {
-    if (tab.fileTree && tab.terminalPanel) {
-      // Remove stale entries (e.g. ghost terminal from TerminalPanel.init() before restoreFromTree)
-      const activeTermIds = new Set(tab.terminalPanel.terminals.keys());
-      for (const termId of [...tab.fileTree.termCwds.keys()]) {
-        if (!activeTermIds.has(termId)) {
-          tab.fileTree.removeTerminal(termId);
-        }
-      }
-      for (const [termId, node] of tab.terminalPanel.terminals) {
-        tab.fileTree.setTerminalRoot(termId, node.terminal.cwd);
-      }
-    }
-  }
-
-  /** Reattach or create a side-panel view (board, flow, usage). Returns true if reattached. */
-  _renderSideView(viewKey, containerKey, ViewClass, ...ctorArgs) {
-    this.workspaceContainer.replaceChildren();
-
-    if (this[viewKey] && this[containerKey]) {
-      this.workspaceContainer.appendChild(this[containerKey]);
-      return true;
-    }
-
-    const container = _el('div');
-    container.style.height = '100%';
-    this.workspaceContainer.appendChild(container);
-    this[containerKey] = container;
-    this[viewKey] = new ViewClass(container, ...ctorArgs);
-    return false;
-  }
-
-  // ===== Activity Bar =====
-
-  renderActivityBar() {
-    const activityBar = document.getElementById('activity-bar');
-    if (!activityBar) return;
-    activityBar.replaceChildren();
-
-    const topSection = _el('div', 'activity-bar-top');
-
-    for (const { label, mode } of ACTIVITY_BUTTONS) {
-      const btn = _el('button', 'activity-btn', label);
-      if (this.sidebarMode === mode) btn.classList.add('active');
-      btn.addEventListener('click', () => this.setSidebarMode(mode));
-      topSection.appendChild(btn);
-    }
-
-    topSection.appendChild(_el('button', 'activity-btn', '\u2026'));
-    activityBar.appendChild(topSection);
-
-    // Bottom section with settings
-    const bottomSection = _el('div', 'activity-bar-bottom');
-    const settingsBtn = _el('button', 'activity-btn activity-btn-settings');
-    settingsBtn.append(_el('span', 'activity-btn-icon', '\u2699'), 'Settings');
-    settingsBtn.addEventListener('click', () => {
-      if (this.onOpenSettings) this.onOpenSettings();
-    });
-    bottomSection.appendChild(settingsBtn);
-
-    activityBar.appendChild(bottomSection);
-  }
-
-  _detachSidebarView(mode) {
-    if (mode === 'work') {
-      const prev = this._activeTab();
-      if (prev?.layoutElement) {
-        this._capturePanelWidths(prev);
-        prev.layoutElement.remove();
-      }
-      return;
-    }
-    const cfg = SIDE_VIEWS[mode];
-    if (!cfg) return;
-    if (cfg.pauseOnDetach) {
-      this[cfg.viewKey]?.pause();
-      this[cfg.containerKey]?.remove();
-    } else {
-      this._disposeSideView(mode);
-    }
-  }
+  renderActivityBar() { renderActivityBar(this); }
 
   setSidebarMode(mode) {
     if (mode === this.sidebarMode) return;
 
-    this._detachSidebarView(this.sidebarMode);
+    detachSidebarView(this, this.sidebarMode);
     this.sidebarMode = mode;
 
-    if (SIDE_VIEWS[mode]) {
-      this._activateSideView(mode);
+    if (mode !== 'work') {
+      activateSideView(this, mode);
     } else {
       const tab = this._activeTab();
-      if (tab?.layoutElement) this._reattachLayout(tab);
+      if (tab?.layoutElement) reattachLayout(this, tab);
       else if (tab) this.renderWorkspace(tab);
     }
 
     this.renderActivityBar();
   }
 
-  switchToBoard() {
-    this.setSidebarMode('board');
-  }
+  switchToBoard() { this.setSidebarMode('board'); }
 
-  // ===== Side view disposal (table-driven) =====
+  _capturePanelWidths(tab) { capturePanelWidths(tab); }
 
-  _disposeSideView(mode) {
-    const cfg = SIDE_VIEWS[mode];
-    if (!cfg) return;
-    if (this[cfg.viewKey]) {
-      this[cfg.viewKey].dispose();
-      this[cfg.viewKey] = null;
-    }
-    if (this[cfg.containerKey]) {
-      this[cfg.containerKey].remove();
-      this[cfg.containerKey] = null;
-    }
-  }
+  async renderWorkspace(tab) { return doRenderWorkspace(this, tab); }
 
-  _disposeAllSideViews() {
-    for (const mode of Object.keys(SIDE_VIEWS)) this._disposeSideView(mode);
-  }
+  serialize() { return doSerialize(this); }
 
-  /** Activate a side view by mode using SIDE_VIEW_RENDERERS config. */
-  _activateSideView(mode) {
-    const sideView = SIDE_VIEWS[mode];
-    const renderer = SIDE_VIEW_RENDERERS[mode];
-    if (!sideView || !renderer) return;
-    const reattached = this._renderSideView(
-      sideView.viewKey, sideView.containerKey,
-      renderer.ViewClass, ...renderer.ctorArgs(this),
-    );
-    if (reattached) renderer.onReattach(this);
-  }
+  async restoreConfig(config) { return doRestoreConfig(this, config); }
 
-  // ===== Auto Save (delegated to ConfigManager) =====
-
-  autoSave() {
-    return this.configManager.autoSave();
-  }
-
-  // ===== Tab Management =====
+  autoSave() { return this.configManager.autoSave(); }
 
   createTab(name = null, cwd = null) {
     const id = generateId('tab');
@@ -306,7 +158,7 @@ export class TabManager {
     );
     if (!ok) return;
 
-    this._disposeTab(tab);
+    disposeTab(tab);
     this.tabs.delete(id);
 
     if (this.tabs.size === 0) {
@@ -329,15 +181,15 @@ export class TabManager {
 
     // If in a non-work mode, switch back to work mode
     if (this.sidebarMode !== 'work') {
-      this._detachSidebarView(this.sidebarMode);
+      detachSidebarView(this, this.sidebarMode);
       this.sidebarMode = 'work';
       this.renderActivityBar();
 
       // If this tab is already active, just re-show its layout
       if (id === this.activeTabId) {
         if (tab.layoutElement) {
-          this._reattachLayout(tab);
-          this._syncFileTree(tab);
+          reattachLayout(this, tab);
+          syncFileTree(tab);
           bus.emit('workspace:activated');
         }
         this.renderTabBar();
@@ -352,7 +204,7 @@ export class TabManager {
       const prev = this.tabs.get(this.activeTabId);
       if (prev && prev.layoutElement) {
         // Capture panel widths before detaching (needs attached DOM)
-        this._capturePanelWidths(prev);
+        capturePanelWidths(prev);
         prev.layoutElement.remove();
       }
     }
@@ -361,27 +213,14 @@ export class TabManager {
     this.renderTabBar();
 
     if (tab.layoutElement) {
-      this._reattachLayout(tab);
-      this._syncFileTree(tab);
+      reattachLayout(this, tab);
+      syncFileTree(tab);
       bus.emit('workspace:activated');
     } else {
       // First time rendering this tab
       this.renderWorkspace(tab);
     }
   }
-
-  _capturePanelWidths(tab) {
-    if (!tab.layoutElement) return;
-    tab._panelWidths = {};
-    for (const { side, widthKey, collapsedKey } of WORKSPACE_PANELS) {
-      const el = tab.layoutElement.querySelector(`.panel-${side}`);
-      if (!el) continue;
-      tab._panelWidths[widthKey] = el.getBoundingClientRect().width;
-      tab._panelWidths[collapsedKey] = el.classList.contains('collapsed');
-    }
-  }
-
-  // ===== Tab Bar Rendering =====
 
   setColorFilter(colorGroupId) {
     this.excludedColors.clear();
@@ -556,152 +395,6 @@ export class TabManager {
     });
   }
 
-  // ===== Workspace Rendering (called only once per tab) =====
-
-  _buildSidePanel({ side, contentCls, title }) {
-    const panel = _el('div', `panel panel-${side}`);
-    if (title) {
-      const header = _el('div', 'panel-header');
-      header.appendChild(_el('span', 'panel-title', title));
-      panel.appendChild(header);
-    }
-    const content = _el('div', contentCls);
-    panel.appendChild(content);
-    const handle = _el('div', 'panel-resize-handle');
-    this.setupPanelResize(handle, panel, side);
-    return { panel, handle, content };
-  }
-
-  _buildCenterPanel(tab, leftPanel, rightPanel) {
-    const panel = _el('div', 'panel panel-center');
-    const header = _el('div', 'panel-header');
-
-    const pathInfo = _el('div', 'path-info');
-
-    const pathArrowLeft = _el('span', 'path-arrow', '\u2190');
-    pathArrowLeft.title = 'Collapse left panel';
-    pathArrowLeft.addEventListener('click', () => this.togglePanel(leftPanel, 'left', pathArrowLeft));
-
-    const pathText = _el('span', 'path-text', tab.cwd);
-    const branchBadge = _el('span', 'branch-badge', '');
-
-    const pathArrowRight = _el('span', 'path-arrow', '\u2192');
-    pathArrowRight.title = 'Collapse right panel';
-    pathArrowRight.addEventListener('click', () => this.togglePanel(rightPanel, 'right', pathArrowRight));
-
-    pathInfo.append(pathArrowLeft, pathText, branchBadge, pathArrowRight);
-    header.appendChild(pathInfo);
-    header.appendChild(_el('div', 'term-label', 'Terminal'));
-    panel.appendChild(header);
-
-    const termContainer = _el('div', 'terminal-area');
-    panel.appendChild(termContainer);
-
-    tab.pathTextEl = pathText;
-    tab.branchBadgeEl = branchBadge;
-
-    return { panel, termContainer };
-  }
-
-  _restorePanelSizes(panels, panelEls) {
-    if (!panels) return;
-    for (const { widthKey, collapsedKey, side } of WORKSPACE_PANELS) {
-      const el = panelEls[side];
-      if (!el) continue;
-      if (panels[widthKey] && !panels[collapsedKey]) {
-        el.style.width = `${panels[widthKey]}px`;
-        el.style.flex = 'none';
-      }
-      if (panels[collapsedKey]) el.classList.add('collapsed');
-    }
-  }
-
-  async renderWorkspace(tab) {
-    this.workspaceContainer.replaceChildren();
-
-    const layout = _el('div', 'workspace-layout');
-
-    // Build side panels from declarative config
-    const sides = {};
-    for (const def of WORKSPACE_PANELS) {
-      sides[def.side] = this._buildSidePanel(def);
-    }
-
-    const { panel: centerPanel, termContainer } = this._buildCenterPanel(tab, sides.left.panel, sides.right.panel);
-
-    layout.append(
-      sides.left.panel, sides.left.handle,
-      centerPanel,
-      sides.right.handle, sides.right.panel,
-    );
-    this.workspaceContainer.appendChild(layout);
-
-    tab.layoutElement = layout;
-    tab.fileTree = new FileTree(sides.left.content);
-    tab.fileViewer = new FileViewer(sides.right.content, () => tab.id === this.activeTabId);
-
-    if (tab._restoreData?.splitTree) {
-      tab.terminalPanel = new TerminalPanel(termContainer, tab.cwd);
-      tab.terminalPanel.restoreFromTree(tab._restoreData.splitTree);
-      this._restorePanelSizes(tab._restoreData.panels, { left: sides.left.panel, right: sides.right.panel });
-      this._syncFileTree(tab);
-      if (tab._restoreData.webviewTabs && tab.fileViewer) {
-        tab.fileViewer.setWebviewTabs(tab._restoreData.webviewTabs);
-      }
-      delete tab._restoreData;
-    } else {
-      tab.terminalPanel = new TerminalPanel(termContainer, tab.cwd);
-      const firstTermId = tab.terminalPanel.activeTerminal?.terminal?.id;
-      if (firstTermId) tab.fileTree.setTerminalRoot(firstTermId, tab.cwd);
-    }
-
-    const branch = await window.api.git.branch(tab.cwd);
-    if (branch) tab.branchBadgeEl.textContent = ` ${branch}`;
-
-    bus.emit('workspace:activated');
-  }
-
-  togglePanel(panel, side, arrowEl) {
-    panel.classList.add('animating');
-    panel.classList.toggle('collapsed');
-    const isCollapsed = panel.classList.contains('collapsed');
-
-    if (arrowEl) {
-      const arrow = panelArrowState(side, isCollapsed);
-      arrowEl.textContent = arrow.text;
-      arrowEl.title = arrow.title;
-    }
-
-    setTimeout(() => {
-      panel.classList.remove('animating');
-      this._activeTab()?.terminalPanel?.fitAll();
-    }, FIT_DELAY_MS);
-    this.configManager.scheduleAutoSave();
-  }
-
-  setupPanelResize(handle, panel, side) {
-    let startX = 0;
-    let startWidth = 0;
-
-    handle.addEventListener('mousedown', (e) => {
-      e.preventDefault();
-      startX = e.clientX;
-      startWidth = panel.getBoundingClientRect().width;
-      trackMouse('col-resize',
-        (ev) => {
-          const dx = ev.clientX - startX;
-          const newWidth = side === 'left' ? startWidth + dx : startWidth - dx;
-          panel.style.width = `${clampPanelWidth(newWidth, side)}px`;
-          panel.style.flex = 'none';
-          this._activeTab()?.terminalPanel?.fitAll();
-        },
-        () => this.configManager.scheduleAutoSave(),
-      );
-    });
-  }
-
-  // ===== Terminal CWD tracking =====
-
   _onTerminalCwdChanged(termId, cwd) {
     // Find the tab that owns this terminal
     const tab = this._findTabForTerminal(termId);
@@ -729,96 +422,18 @@ export class TabManager {
     }
   }
 
-  // ===== Serialization =====
+  _disposeSideView(mode) { disposeSideView(this, mode); }
 
-  serialize() {
-    const tabs = [];
-    let activeTabIndex = 0;
-    let i = 0;
+  _disposeAllSideViews() { disposeAllSideViews(this); }
 
-    for (const [id, tab] of this.tabs) {
-      if (id === this.activeTabId) activeTabIndex = i;
-
-      const tabData = {
-        name: tab.name,
-        cwd: tab.cwd,
-        noShortcut: tab.noShortcut || false,
-        colorGroup: tab.colorGroup || null,
-        splitTree: null,
-        panels: {},
-      };
-
-      // Serialize terminal tree (works for both active and detached layouts)
-      if (tab.terminalPanel) {
-        tabData.splitTree = tab.terminalPanel.serialize();
-      }
-
-      // Serialize webview tabs
-      if (tab.fileViewer) {
-        tabData.webviewTabs = tab.fileViewer.getWebviewTabs();
-      }
-
-      // Panel widths — active tab: snapshot from live DOM; inactive: use cached
-      if (id === this.activeTabId) this._capturePanelWidths(tab);
-      if (tab._panelWidths) tabData.panels = { ...tab._panelWidths };
-
-      tabs.push(tabData);
-      i++;
-    }
-
-    return { tabs, activeTabIndex };
-  }
-
-  _disposeTab(tab) {
-    for (const key of TAB_DISPOSABLES) if (tab[key]) tab[key].dispose();
-    if (tab.layoutElement) tab.layoutElement.remove();
-  }
-
-  _disposeAllTabs() {
-    for (const [id, tab] of [...this.tabs]) {
-      this._disposeTab(tab);
-      this.tabs.delete(id);
-    }
-    this.activeTabId = null;
-  }
+  _disposeAllTabs() { disposeAllTabs(this); }
 
   dispose() {
     unsubscribeBus(this._busListeners);
     this._busListeners = [];
-    this._disposeAllSideViews();
-    this._disposeAllTabs();
+    disposeAllSideViews(this);
+    disposeAllTabs(this);
   }
-
-  async restoreConfig(config) {
-    if (!config || !config.tabs || config.tabs.length === 0) return;
-
-    this.configManager.isRestoring = true;
-
-    // Reset side views (old terminal IDs will be invalid)
-    this._disposeAllSideViews();
-    this._disposeAllTabs();
-
-    // Create tabs from config
-    for (const tabData of config.tabs) {
-      const id = generateId('tab');
-      const tab = new WorkspaceTab(id, tabData.name, tabData.cwd || this.defaultCwd || '/');
-      tab.noShortcut = tabData.noShortcut || false;
-      tab.colorGroup = tabData.colorGroup || null;
-      tab._restoreData = tabData;
-      this.tabs.set(id, tab);
-    }
-
-    this.renderTabBar();
-
-    // Switch to the active tab
-    const tabIds = Array.from(this.tabs.keys());
-    const activeIdx = Math.min(config.activeTabIndex || 0, tabIds.length - 1);
-    this.switchTo(tabIds[activeIdx]);
-
-    this.configManager.isRestoring = false;
-  }
-
-  // ===== Color Groups =====
 
   setTabColorGroup(id, colorGroupId) {
     const tab = this.tabs.get(id);
@@ -833,8 +448,6 @@ export class TabManager {
     if (target) this.switchTo(target);
   }
 
-  // ===== NoShortcut =====
-
   toggleNoShortcut(id) {
     const tab = this.tabs.get(id);
     if (!tab) return;
@@ -846,8 +459,6 @@ export class TabManager {
   isActiveNoShortcut() {
     return this._activeTab()?.noShortcut ?? false;
   }
-
-  // ===== Shortcut helpers =====
 
   splitHorizontal() {
     this._activeTab()?.terminalPanel?.splitActive('horizontal');

--- a/src/components/terminal-panel.js
+++ b/src/components/terminal-panel.js
@@ -11,6 +11,7 @@ import {
   directionFromSide,
   isInsertBefore,
 } from '../utils/split-helpers.js';
+import { registerComponent } from '../utils/component-registry.js';
 
 export class TerminalPanel {
   constructor(container, cwd) {
@@ -552,3 +553,5 @@ export class TerminalPanel {
     this.terminals.clear();
   }
 }
+
+registerComponent('TerminalPanel', TerminalPanel);

--- a/src/components/usage-view.js
+++ b/src/components/usage-view.js
@@ -1,5 +1,6 @@
 import { _el } from '../utils/dom.js';
 import { TABS, getTabConfig, createSection } from '../utils/usage-view-helpers.js';
+import { registerComponent } from '../utils/component-registry.js';
 
 // --- Component ---
 
@@ -140,5 +141,6 @@ export class UsageView {
     ));
     parent.appendChild(section);
   }
-
 }
+
+registerComponent('UsageView', UsageView);

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -4,6 +4,14 @@ import { ShortcutManager } from './components/shortcuts.js';
 import { SettingsModal } from './components/settings-modal.js';
 import { applyAppTheme } from './utils/app-theme.js';
 
+// Side-effect imports: register tab components in the component registry
+import './components/terminal-panel.js';
+import './components/file-tree.js';
+import './components/file-viewer.js';
+import './components/board-view.js';
+import './components/flow-view.js';
+import './components/usage-view.js';
+
 // Expose hljs globally for file-viewer
 window.hljs = hljs;
 

--- a/src/utils/component-registry.js
+++ b/src/utils/component-registry.js
@@ -1,0 +1,20 @@
+/**
+ * Component Registry — decouples tab-manager from concrete component imports.
+ *
+ * Each component module registers itself via `registerComponent(name, Class)`.
+ * tab-manager and other orchestrators resolve components via `getComponent(name)`.
+ */
+
+const _registry = new Map();
+
+/** Register a component class under a unique name. */
+export function registerComponent(name, ComponentClass) {
+  _registry.set(name, ComponentClass);
+}
+
+/** Retrieve a registered component class by name. Throws if not found. */
+export function getComponent(name) {
+  const cls = _registry.get(name);
+  if (!cls) throw new Error(`Component "${name}" not registered`);
+  return cls;
+}

--- a/src/utils/sidebar-manager.js
+++ b/src/utils/sidebar-manager.js
@@ -1,0 +1,140 @@
+/**
+ * Sidebar Manager — extracted from tab-manager.js.
+ *
+ * Handles activity-bar rendering, sidebar mode switching, and
+ * side-view lifecycle (board, flow, usage).
+ *
+ * All methods receive or operate on a `ctx` (TabManager instance).
+ */
+
+import { getComponent } from './component-registry.js';
+import { _el } from './dom.js';
+import { ACTIVITY_BUTTONS, SIDE_VIEWS } from './tab-manager-helpers.js';
+
+/**
+ * Declarative map for sidebar view rendering — single source of truth for
+ * component name (resolved via registry), constructor args, and post-reattach behavior.
+ */
+const SIDE_VIEW_RENDERERS = {
+  board: {
+    componentName: 'BoardView',
+    ctorArgs: (ctx) => [ctx],
+    onReattach: (ctx) => {
+      for (const [, card] of ctx.boardView.cards) {
+        try { card.fitAddon.fit(); } catch {}
+      }
+      ctx.boardView.resume();
+    },
+  },
+  flow: {
+    componentName: 'FlowView',
+    ctorArgs: (ctx) => [ctx],
+    onReattach: (ctx) => ctx.flowView.refresh(),
+  },
+  usage: {
+    componentName: 'UsageView',
+    ctorArgs: () => [],
+    onReattach: (ctx) => ctx.usageView.refresh(),
+  },
+};
+
+// ── Activity Bar ──
+
+export function renderActivityBar(ctx) {
+  const activityBar = document.getElementById('activity-bar');
+  if (!activityBar) return;
+  activityBar.replaceChildren();
+
+  const topSection = _el('div', 'activity-bar-top');
+
+  for (const { label, mode } of ACTIVITY_BUTTONS) {
+    const btn = _el('button', 'activity-btn', label);
+    if (ctx.sidebarMode === mode) btn.classList.add('active');
+    btn.addEventListener('click', () => ctx.setSidebarMode(mode));
+    topSection.appendChild(btn);
+  }
+
+  topSection.appendChild(_el('button', 'activity-btn', '\u2026'));
+  activityBar.appendChild(topSection);
+
+  // Bottom section with settings
+  const bottomSection = _el('div', 'activity-bar-bottom');
+  const settingsBtn = _el('button', 'activity-btn activity-btn-settings');
+  settingsBtn.append(_el('span', 'activity-btn-icon', '\u2699'), 'Settings');
+  settingsBtn.addEventListener('click', () => {
+    if (ctx.onOpenSettings) ctx.onOpenSettings();
+  });
+  bottomSection.appendChild(settingsBtn);
+
+  activityBar.appendChild(bottomSection);
+}
+
+// ── Side view rendering ──
+
+/** Reattach or create a side-panel view (board, flow, usage). Returns true if reattached. */
+export function renderSideView(ctx, viewKey, containerKey, ViewClass, ...ctorArgs) {
+  ctx.workspaceContainer.replaceChildren();
+
+  if (ctx[viewKey] && ctx[containerKey]) {
+    ctx.workspaceContainer.appendChild(ctx[containerKey]);
+    return true;
+  }
+
+  const container = _el('div');
+  container.style.height = '100%';
+  ctx.workspaceContainer.appendChild(container);
+  ctx[containerKey] = container;
+  ctx[viewKey] = new ViewClass(container, ...ctorArgs);
+  return false;
+}
+
+/** Activate a side view by mode using SIDE_VIEW_RENDERERS config. */
+export function activateSideView(ctx, mode) {
+  const sideView = SIDE_VIEWS[mode];
+  const renderer = SIDE_VIEW_RENDERERS[mode];
+  if (!sideView || !renderer) return;
+  const ViewClass = getComponent(renderer.componentName);
+  const reattached = renderSideView(
+    ctx, sideView.viewKey, sideView.containerKey,
+    ViewClass, ...renderer.ctorArgs(ctx),
+  );
+  if (reattached) renderer.onReattach(ctx);
+}
+
+// ── Side view detach / disposal ──
+
+export function detachSidebarView(ctx, mode) {
+  if (mode === 'work') {
+    const prev = ctx._activeTab();
+    if (prev?.layoutElement) {
+      ctx._capturePanelWidths(prev);
+      prev.layoutElement.remove();
+    }
+    return;
+  }
+  const cfg = SIDE_VIEWS[mode];
+  if (!cfg) return;
+  if (cfg.pauseOnDetach) {
+    ctx[cfg.viewKey]?.pause();
+    ctx[cfg.containerKey]?.remove();
+  } else {
+    disposeSideView(ctx, mode);
+  }
+}
+
+export function disposeSideView(ctx, mode) {
+  const cfg = SIDE_VIEWS[mode];
+  if (!cfg) return;
+  if (ctx[cfg.viewKey]) {
+    ctx[cfg.viewKey].dispose();
+    ctx[cfg.viewKey] = null;
+  }
+  if (ctx[cfg.containerKey]) {
+    ctx[cfg.containerKey].remove();
+    ctx[cfg.containerKey] = null;
+  }
+}
+
+export function disposeAllSideViews(ctx) {
+  for (const mode of Object.keys(SIDE_VIEWS)) disposeSideView(ctx, mode);
+}

--- a/src/utils/workspace-layout.js
+++ b/src/utils/workspace-layout.js
@@ -1,0 +1,297 @@
+/**
+ * Workspace Layout Manager — extracted from tab-manager.js.
+ *
+ * Handles workspace panel building, resize, serialization, and restoration.
+ * All functions receive a `ctx` (TabManager instance) as their first argument.
+ */
+
+import { getComponent } from './component-registry.js';
+import { bus } from './events.js';
+import { _el } from './dom.js';
+import { trackMouse } from './drag-helpers.js';
+import { generateId } from './id.js';
+import {
+  PANEL_MIN_WIDTH, FIT_DELAY_MS,
+  WORKSPACE_PANELS, WorkspaceTab, TAB_DISPOSABLES,
+  clampPanelWidth, panelArrowState,
+} from './tab-manager-helpers.js';
+import { disposeAllSideViews } from './sidebar-manager.js';
+
+// ── Panel building ──
+
+export function buildSidePanel(ctx, { side, contentCls, title }) {
+  const panel = _el('div', `panel panel-${side}`);
+  if (title) {
+    const header = _el('div', 'panel-header');
+    header.appendChild(_el('span', 'panel-title', title));
+    panel.appendChild(header);
+  }
+  const content = _el('div', contentCls);
+  panel.appendChild(content);
+  const handle = _el('div', 'panel-resize-handle');
+  setupPanelResize(ctx, handle, panel, side);
+  return { panel, handle, content };
+}
+
+export function buildCenterPanel(ctx, tab, leftPanel, rightPanel) {
+  const panel = _el('div', 'panel panel-center');
+  const header = _el('div', 'panel-header');
+
+  const pathInfo = _el('div', 'path-info');
+
+  const pathArrowLeft = _el('span', 'path-arrow', '\u2190');
+  pathArrowLeft.title = 'Collapse left panel';
+  pathArrowLeft.addEventListener('click', () => togglePanel(ctx, leftPanel, 'left', pathArrowLeft));
+
+  const pathText = _el('span', 'path-text', tab.cwd);
+  const branchBadge = _el('span', 'branch-badge', '');
+
+  const pathArrowRight = _el('span', 'path-arrow', '\u2192');
+  pathArrowRight.title = 'Collapse right panel';
+  pathArrowRight.addEventListener('click', () => togglePanel(ctx, rightPanel, 'right', pathArrowRight));
+
+  pathInfo.append(pathArrowLeft, pathText, branchBadge, pathArrowRight);
+  header.appendChild(pathInfo);
+  header.appendChild(_el('div', 'term-label', 'Terminal'));
+  panel.appendChild(header);
+
+  const termContainer = _el('div', 'terminal-area');
+  panel.appendChild(termContainer);
+
+  tab.pathTextEl = pathText;
+  tab.branchBadgeEl = branchBadge;
+
+  return { panel, termContainer };
+}
+
+// ── Panel resize / toggle ──
+
+export function setupPanelResize(ctx, handle, panel, side) {
+  let startX = 0;
+  let startWidth = 0;
+
+  handle.addEventListener('mousedown', (e) => {
+    e.preventDefault();
+    startX = e.clientX;
+    startWidth = panel.getBoundingClientRect().width;
+    trackMouse('col-resize',
+      (ev) => {
+        const dx = ev.clientX - startX;
+        const newWidth = side === 'left' ? startWidth + dx : startWidth - dx;
+        panel.style.width = `${clampPanelWidth(newWidth, side)}px`;
+        panel.style.flex = 'none';
+        ctx._activeTab()?.terminalPanel?.fitAll();
+      },
+      () => ctx.configManager.scheduleAutoSave(),
+    );
+  });
+}
+
+export function togglePanel(ctx, panel, side, arrowEl) {
+  panel.classList.add('animating');
+  panel.classList.toggle('collapsed');
+  const isCollapsed = panel.classList.contains('collapsed');
+
+  if (arrowEl) {
+    const arrow = panelArrowState(side, isCollapsed);
+    arrowEl.textContent = arrow.text;
+    arrowEl.title = arrow.title;
+  }
+
+  setTimeout(() => {
+    panel.classList.remove('animating');
+    ctx._activeTab()?.terminalPanel?.fitAll();
+  }, FIT_DELAY_MS);
+  ctx.configManager.scheduleAutoSave();
+}
+
+// ── Panel width capture / restore ──
+
+export function capturePanelWidths(tab) {
+  if (!tab.layoutElement) return;
+  tab._panelWidths = {};
+  for (const { side, widthKey, collapsedKey } of WORKSPACE_PANELS) {
+    const el = tab.layoutElement.querySelector(`.panel-${side}`);
+    if (!el) continue;
+    tab._panelWidths[widthKey] = el.getBoundingClientRect().width;
+    tab._panelWidths[collapsedKey] = el.classList.contains('collapsed');
+  }
+}
+
+export function restorePanelSizes(panels, panelEls) {
+  if (!panels) return;
+  for (const { widthKey, collapsedKey, side } of WORKSPACE_PANELS) {
+    const el = panelEls[side];
+    if (!el) continue;
+    if (panels[widthKey] && !panels[collapsedKey]) {
+      el.style.width = `${panels[widthKey]}px`;
+      el.style.flex = 'none';
+    }
+    if (panels[collapsedKey]) el.classList.add('collapsed');
+  }
+}
+
+// ── Workspace rendering ──
+
+export async function renderWorkspace(ctx, tab) {
+  ctx.workspaceContainer.replaceChildren();
+
+  const layout = _el('div', 'workspace-layout');
+
+  // Build side panels from declarative config
+  const sides = {};
+  for (const def of WORKSPACE_PANELS) {
+    sides[def.side] = buildSidePanel(ctx, def);
+  }
+
+  const { panel: centerPanel, termContainer } = buildCenterPanel(ctx, tab, sides.left.panel, sides.right.panel);
+
+  layout.append(
+    sides.left.panel, sides.left.handle,
+    centerPanel,
+    sides.right.handle, sides.right.panel,
+  );
+  ctx.workspaceContainer.appendChild(layout);
+
+  const FileTree = getComponent('FileTree');
+  const FileViewer = getComponent('FileViewer');
+  const TerminalPanel = getComponent('TerminalPanel');
+
+  tab.layoutElement = layout;
+  tab.fileTree = new FileTree(sides.left.content);
+  tab.fileViewer = new FileViewer(sides.right.content, () => tab.id === ctx.activeTabId);
+
+  if (tab._restoreData?.splitTree) {
+    tab.terminalPanel = new TerminalPanel(termContainer, tab.cwd);
+    tab.terminalPanel.restoreFromTree(tab._restoreData.splitTree);
+    restorePanelSizes(tab._restoreData.panels, { left: sides.left.panel, right: sides.right.panel });
+    syncFileTree(tab);
+    if (tab._restoreData.webviewTabs && tab.fileViewer) {
+      tab.fileViewer.setWebviewTabs(tab._restoreData.webviewTabs);
+    }
+    delete tab._restoreData;
+  } else {
+    tab.terminalPanel = new TerminalPanel(termContainer, tab.cwd);
+    const firstTermId = tab.terminalPanel.activeTerminal?.terminal?.id;
+    if (firstTermId) tab.fileTree.setTerminalRoot(firstTermId, tab.cwd);
+  }
+
+  const branch = await window.api.git.branch(tab.cwd);
+  if (branch) tab.branchBadgeEl.textContent = ` ${branch}`;
+
+  bus.emit('workspace:activated');
+}
+
+// ── Layout helpers ──
+
+export function reattachLayout(ctx, tab) {
+  ctx.workspaceContainer.replaceChildren();
+  ctx.workspaceContainer.appendChild(tab.layoutElement);
+  if (tab.terminalPanel) {
+    tab.terminalPanel.fitAll();
+    if (tab.terminalPanel.activeTerminal) {
+      tab.terminalPanel.activeTerminal.terminal.focus();
+    }
+  }
+}
+
+export function syncFileTree(tab) {
+  if (tab.fileTree && tab.terminalPanel) {
+    // Remove stale entries (e.g. ghost terminal from TerminalPanel.init() before restoreFromTree)
+    const activeTermIds = new Set(tab.terminalPanel.terminals.keys());
+    for (const termId of [...tab.fileTree.termCwds.keys()]) {
+      if (!activeTermIds.has(termId)) {
+        tab.fileTree.removeTerminal(termId);
+      }
+    }
+    for (const [termId, node] of tab.terminalPanel.terminals) {
+      tab.fileTree.setTerminalRoot(termId, node.terminal.cwd);
+    }
+  }
+}
+
+// ── Serialization ──
+
+export function serialize(ctx) {
+  const tabs = [];
+  let activeTabIndex = 0;
+  let i = 0;
+
+  for (const [id, tab] of ctx.tabs) {
+    if (id === ctx.activeTabId) activeTabIndex = i;
+
+    const tabData = {
+      name: tab.name,
+      cwd: tab.cwd,
+      noShortcut: tab.noShortcut || false,
+      colorGroup: tab.colorGroup || null,
+      splitTree: null,
+      panels: {},
+    };
+
+    // Serialize terminal tree (works for both active and detached layouts)
+    if (tab.terminalPanel) {
+      tabData.splitTree = tab.terminalPanel.serialize();
+    }
+
+    // Serialize webview tabs
+    if (tab.fileViewer) {
+      tabData.webviewTabs = tab.fileViewer.getWebviewTabs();
+    }
+
+    // Panel widths — active tab: snapshot from live DOM; inactive: use cached
+    if (id === ctx.activeTabId) capturePanelWidths(tab);
+    if (tab._panelWidths) tabData.panels = { ...tab._panelWidths };
+
+    tabs.push(tabData);
+    i++;
+  }
+
+  return { tabs, activeTabIndex };
+}
+
+// ── Restore ──
+
+export async function restoreConfig(ctx, config) {
+  if (!config || !config.tabs || config.tabs.length === 0) return;
+
+  ctx.configManager.isRestoring = true;
+
+  // Reset side views (old terminal IDs will be invalid)
+  disposeAllSideViews(ctx);
+  disposeAllTabs(ctx);
+
+  // Create tabs from config
+  for (const tabData of config.tabs) {
+    const id = generateId('tab');
+    const tab = new WorkspaceTab(id, tabData.name, tabData.cwd || ctx.defaultCwd || '/');
+    tab.noShortcut = tabData.noShortcut || false;
+    tab.colorGroup = tabData.colorGroup || null;
+    tab._restoreData = tabData;
+    ctx.tabs.set(id, tab);
+  }
+
+  ctx.renderTabBar();
+
+  // Switch to the active tab
+  const tabIds = Array.from(ctx.tabs.keys());
+  const activeIdx = Math.min(config.activeTabIndex || 0, tabIds.length - 1);
+  ctx.switchTo(tabIds[activeIdx]);
+
+  ctx.configManager.isRestoring = false;
+}
+
+// ── Tab disposal ──
+
+export function disposeTab(tab) {
+  for (const key of TAB_DISPOSABLES) if (tab[key]) tab[key].dispose();
+  if (tab.layoutElement) tab.layoutElement.remove();
+}
+
+export function disposeAllTabs(ctx) {
+  for (const [id, tab] of [...ctx.tabs]) {
+    disposeTab(tab);
+    ctx.tabs.delete(id);
+  }
+  ctx.activeTabId = null;
+}


### PR DESCRIPTION
## Refactoring

Décomposition de `tab-manager.js` (880 lignes, 15 imports) en 3 modules spécialisés :

| Métrique | Avant | Après |
|----------|-------|-------|
| Lignes tab-manager.js | 880 | 491 |
| Imports tab-manager.js | 15 | 10 |
| Imports directs de composants | 6 | 0 |

### Modules extraits

1. **`src/utils/component-registry.js`** (20 lignes) — registre de composants avec auto-enregistrement. Chaque composant s'enregistre lui-même, éliminant les imports directs.
2. **`src/utils/workspace-layout.js`** (297 lignes) — gestion du layout (build panels, resize, serialize/restore, dispose)
3. **`src/utils/sidebar-manager.js`** (140 lignes) — gestion de la sidebar (activity bar, side views, mode switching)

Closes #2

## Fichier(s) modifié(s)

- `src/components/tab-manager.js` — réduit de 880 à 491 lignes, délègue aux nouveaux modules
- `src/renderer.js` — imports side-effect pour l'auto-enregistrement des composants
- `src/components/{terminal-panel,file-tree,file-viewer,board-view,flow-view,usage-view}.js` — ajout auto-registration

## Fichier(s) créé(s)

- `src/utils/component-registry.js`
- `src/utils/workspace-layout.js`
- `src/utils/sidebar-manager.js`

## Vérifications

- [x] Build OK
- [x] Tests OK (204 passed)

---

📂 Path local : `/Users/rekta/projet/coding/refactor-pikagent`
🤖 PR créée automatiquement par l'Agent Refactor