### PR TITLE
refactor: split 5 large components into focused modules

### DIFF
--- a/src/components/file-tree.js
+++ b/src/components/file-tree.js
@@ -1,13 +1,13 @@
 import { bus } from '../utils/events.js';
-import { contextMenu } from './context-menu.js';
 import { _el, setupInlineInput } from '../utils/dom.js';
 import {
   CHEVRON_EXPANDED, CHEVRON_COLLAPSED,
   DEBOUNCE_DELAY, INPUT_BLUR_DELAY, WATCH_PREFIX,
   SVG_ICONS, HEADER_ACTIONS,
-  computeIndent, getRelativePath, extractFolderName, resolveWatchCwd,
+  computeIndent, extractFolderName, resolveWatchCwd,
 } from '../utils/file-tree-helpers.js';
 import { registerComponent } from '../utils/component-registry.js';
+import { showFileContextMenu, showDirContextMenu } from '../utils/file-tree-context-menu.js';
 
 function _parseSvg(svgStr) {
   const doc = new DOMParser().parseFromString(svgStr, 'image/svg+xml');
@@ -165,7 +165,9 @@ export class FileTree {
       onContextmenu: (e) => {
         e.preventDefault();
         e.stopPropagation();
-        this.showDirContextMenu(e.clientX, e.clientY, cwd, cwd, contentEl, 0, expandedDirs);
+        showDirContextMenu(e.clientX, e.clientY, cwd, cwd, contentEl, 0, expandedDirs, null,
+          (path, nameEl) => this.promptRename(path, nameEl),
+          (dirPath, cEl, depth, eDirs, type) => this.promptNewEntry(dirPath, cEl, depth, eDirs, type));
       },
     },
       chevron,
@@ -174,52 +176,13 @@ export class FileTree {
     );
   }
 
-  // --- Context menus ---
+  // --- Context menu helpers ---
 
   findRootCwd(entryPath) {
     for (const [cwd] of this.sections) {
       if (entryPath.startsWith(cwd)) return cwd;
     }
     return '';
-  }
-
-  _commonContextItems(entryPath, nameEl, deleteLabel) {
-    const rootCwd = this.findRootCwd(entryPath);
-    const displayName = entryPath.split('/').pop();
-    return [
-      { label: 'Rename', action: () => this.promptRename(entryPath, nameEl) },
-      { separator: true },
-      { label: 'Copy Path', action: () => window.api.clipboard.write(entryPath) },
-      { label: 'Copy Relative Path', action: () => window.api.clipboard.write(getRelativePath(entryPath, rootCwd)) },
-      { separator: true },
-      { label: 'Duplicate', action: () => window.api.fs.copy(entryPath) },
-      { label: 'Reveal in Finder', action: () => window.api.shell.showInFolder(entryPath) },
-      { separator: true },
-      {
-        label: 'Delete',
-        action: () => {
-          if (confirm(deleteLabel || `Delete "${displayName}"?`)) {
-            window.api.fs.trash(entryPath);
-          }
-        },
-      },
-    ];
-  }
-
-  showFileContextMenu(x, y, entryPath, nameEl) {
-    contextMenu.show(x, y, this._commonContextItems(entryPath, nameEl));
-  }
-
-  showDirContextMenu(x, y, dirPath, rootCwd, contentEl, depth, expandedDirs, nameEl) {
-    const dirName = dirPath.split('/').pop();
-    contextMenu.show(x, y, [
-      { label: 'New File', action: () => this.promptNewEntry(dirPath, contentEl, depth, expandedDirs, 'file') },
-      { label: 'New Folder', action: () => this.promptNewEntry(dirPath, contentEl, depth, expandedDirs, 'folder') },
-      { separator: true },
-      { label: 'Open as Workspace', action: () => bus.emit('workspace:openFromFolder', { cwd: dirPath }) },
-      { separator: true },
-      ...this._commonContextItems(dirPath, nameEl, `Delete folder "${dirName}" and all its contents?`),
-    ]);
   }
 
   // --- Rename inline input ---
@@ -369,7 +332,9 @@ export class FileTree {
       if (!expandedDirs.has(entry.path)) {
         await this._expandDir(entry.path, childContainer, chevron, depth, expandedDirs);
       }
-      this.showDirContextMenu(e.clientX, e.clientY, entry.path, this.findRootCwd(entry.path), childContainer, depth + 1, expandedDirs, name);
+      showDirContextMenu(e.clientX, e.clientY, entry.path, this.findRootCwd(entry.path), childContainer, depth + 1, expandedDirs, name,
+        (path, nameEl) => this.promptRename(path, nameEl),
+        (dirPath, cEl, d, eDirs, type) => this.promptNewEntry(dirPath, cEl, d, eDirs, type));
     });
   }
 
@@ -387,7 +352,8 @@ export class FileTree {
     row.addEventListener('contextmenu', (e) => {
       e.preventDefault();
       e.stopPropagation();
-      this.showFileContextMenu(e.clientX, e.clientY, entry.path, name);
+      showFileContextMenu(e.clientX, e.clientY, entry.path, name, this.findRootCwd(entry.path),
+        (path, nameEl) => this.promptRename(path, nameEl));
     });
   }
 

--- a/src/components/file-viewer-webview.js
+++ b/src/components/file-viewer-webview.js
@@ -1,0 +1,129 @@
+/**
+ * Webview tab management for FileViewer.
+ * Extracted from file-viewer.js to reduce component size.
+ */
+import { _el, setupInlineInput } from '../utils/dom.js';
+import { generateId } from '../utils/id.js';
+import { bus } from '../utils/events.js';
+import { parseWebviewUrl } from '../utils/editor-helpers.js';
+import { WebviewInstance } from './webview-panel.js';
+
+export class WebviewManager {
+  /**
+   * @param {HTMLElement} container - the file-viewer container element
+   * @param {HTMLElement} statusBar - the status bar element (webview containers insert before it)
+   * @param {function} switchModeFn - callback to switch the viewer mode
+   * @param {function} renderModeBarFn - callback to re-render the mode bar
+   */
+  constructor(container, statusBar, switchModeFn, renderModeBarFn) {
+    this._container = container;
+    this._statusBar = statusBar;
+    this._switchMode = switchModeFn;
+    this._renderModeBar = renderModeBarFn;
+    this.webviewTabs = [];         // [{ id, label, url }]
+    this._webviewEls = new Map();  // id -> { container, instance }
+  }
+
+  addWebview(label, url) {
+    const wt = { id: generateId('wv'), label, url };
+    this.webviewTabs.push(wt);
+    this._createWebviewContainer(wt);
+    this._switchMode(wt.id);
+    bus.emit('layout:changed');
+  }
+
+  removeWebview(webviewId) {
+    const idx = this.webviewTabs.findIndex(wt => wt.id === webviewId);
+    if (idx < 0) return;
+    this.webviewTabs.splice(idx, 1);
+
+    const wvData = this._webviewEls.get(webviewId);
+    if (wvData) {
+      if (wvData.instance) wvData.instance.dispose();
+      wvData.container.remove();
+      this._webviewEls.delete(webviewId);
+    }
+
+    return webviewId; // Return so caller knows which was removed
+  }
+
+  _createWebviewContainer(wt) {
+    const container = _el('div', 'webview-area');
+    container.style.display = 'none';
+    this._container.insertBefore(container, this._statusBar);
+    const instance = new WebviewInstance(container, wt.url);
+    this._webviewEls.set(wt.id, { container, instance });
+  }
+
+  getWebviewTabs() {
+    return this.webviewTabs.map(wt => ({ label: wt.label, url: wt.url }));
+  }
+
+  setWebviewTabs(tabs) {
+    if (!tabs || !tabs.length) return;
+    for (const t of tabs) {
+      const wt = { id: generateId('wv'), label: t.label, url: t.url };
+      this.webviewTabs.push(wt);
+      this._createWebviewContainer(wt);
+    }
+    this._renderModeBar();
+  }
+
+  /** Update visibility of all webview containers for the current mode. */
+  setModeVisibility(activeMode) {
+    for (const [id, wvData] of this._webviewEls) {
+      wvData.container.style.display = activeMode === id ? '' : 'none';
+    }
+  }
+
+  // --- Mode bar button builders ---
+
+  buildWebviewModeBtn(wt, currentMode) {
+    const btn = _el('button', `mode-btn mode-btn-webview${currentMode === wt.id ? ' active' : ''}`);
+    btn.appendChild(_el('span', null, wt.label));
+    const closeBtn = _el('span', 'mode-btn-close', { textContent: '\u00d7' });
+    closeBtn.addEventListener('click', (e) => {
+      e.stopPropagation();
+      const removedId = this.removeWebview(wt.id);
+      if (currentMode === removedId) this._switchMode('files');
+      else this._renderModeBar();
+      bus.emit('layout:changed');
+    });
+    btn.appendChild(closeBtn);
+    btn.addEventListener('click', () => this._switchMode(wt.id));
+    return btn;
+  }
+
+  buildAddWebviewBtn(modeBar) {
+    const btn = _el('button', 'mode-btn mode-btn-add', { textContent: '+', title: 'Add browser preview' });
+    btn.addEventListener('click', () => this._showAddWebviewInput(btn, modeBar));
+    return btn;
+  }
+
+  _showAddWebviewInput(addBtn, modeBar) {
+    const input = _el('input', 'mode-bar-url-input');
+    input.type = 'text';
+    input.placeholder = 'localhost:3000';
+    modeBar.replaceChild(input, addBtn);
+    input.focus();
+
+    setupInlineInput(input, {
+      onCommit: (val) => {
+        if (val) {
+          const { url, label } = parseWebviewUrl(val);
+          this.addWebview(label, url);
+        } else {
+          this._renderModeBar();
+        }
+      },
+      onCancel: () => this._renderModeBar(),
+    });
+  }
+
+  dispose() {
+    for (const [, wvData] of this._webviewEls) {
+      if (wvData.instance) wvData.instance.dispose();
+    }
+    this._webviewEls.clear();
+  }
+}

--- a/src/components/file-viewer.js
+++ b/src/components/file-viewer.js
@@ -1,12 +1,11 @@
 import { detectLanguage } from '../utils/file-icons.js';
 import { bus, subscribeBus, unsubscribeBus } from '../utils/events.js';
 import { GitChangesView } from './git-changes-view.js';
-import { WebviewInstance } from './webview-panel.js';
 import { contextMenu } from './context-menu.js';
-import { generateId } from '../utils/id.js';
-import { _el, setupInlineInput } from '../utils/dom.js';
-import { getCursorPosition, insertTab, parseWebviewUrl, SAVE_FLASH_MS, TAB_SPACES, EMPTY_MESSAGE, STATIC_MODES, MODE_CONFIG, ALL_STATIC_ELEMENTS, MODE_ACTIVATE, pinnedFiles } from '../utils/editor-helpers.js';
+import { _el } from '../utils/dom.js';
+import { getCursorPosition, insertTab, SAVE_FLASH_MS, TAB_SPACES, EMPTY_MESSAGE, STATIC_MODES, MODE_CONFIG, ALL_STATIC_ELEMENTS, MODE_ACTIVATE, pinnedFiles } from '../utils/editor-helpers.js';
 import { registerComponent } from '../utils/component-registry.js';
+import { WebviewManager } from './file-viewer-webview.js';
 
 export class FileViewer {
   constructor(container, isActive) {
@@ -19,9 +18,12 @@ export class FileViewer {
     this.highlightLayer = null;
     this.mode = 'files'; // 'files' | 'git' | webview id
     this.gitChanges = null;
-    this.webviewTabs = []; // [{ id, label, url }]
-    this._webviewEls = new Map(); // id -> { container, instance }
     this.render();
+    this._webviewMgr = new WebviewManager(
+      this.container, this.statusBar,
+      (mode) => this.switchMode(mode),
+      () => this._renderModeBar(),
+    );
     this._setupListeners();
   }
 
@@ -104,9 +106,7 @@ export class FileViewer {
     for (const key of ALL_STATIC_ELEMENTS) {
       this[key].style.display = visible.has(key) ? '' : 'none';
     }
-    for (const [id, wvData] of this._webviewEls) {
-      wvData.container.style.display = mode === id ? '' : 'none';
-    }
+    this._webviewMgr.setModeVisibility(mode);
   }
 
   switchMode(mode) {
@@ -358,114 +358,43 @@ export class FileViewer {
     return btn;
   }
 
-  _buildWebviewModeBtn(wt) {
-    const btn = _el('button', `mode-btn mode-btn-webview${this.mode === wt.id ? ' active' : ''}`);
-    btn.appendChild(_el('span', null, wt.label));
-    const closeBtn = _el('span', 'mode-btn-close', { textContent: '\u00d7' });
-    closeBtn.addEventListener('click', (e) => {
-      e.stopPropagation();
-      this.removeWebview(wt.id);
-    });
-    btn.appendChild(closeBtn);
-    btn.addEventListener('click', () => this.switchMode(wt.id));
-    return btn;
-  }
-
-  _buildAddWebviewBtn() {
-    const btn = _el('button', 'mode-btn mode-btn-add', { textContent: '+', title: 'Add browser preview' });
-    btn.addEventListener('click', () => this._showAddWebviewInput(btn));
-    return btn;
-  }
-
   _renderModeBar() {
     this.modeBar.replaceChildren();
 
     for (const mode of STATIC_MODES) {
       this.modeBar.appendChild(this._buildStaticModeBtn(mode));
     }
-    for (const wt of this.webviewTabs) {
-      this.modeBar.appendChild(this._buildWebviewModeBtn(wt));
+    for (const wt of this._webviewMgr.webviewTabs) {
+      this.modeBar.appendChild(this._webviewMgr.buildWebviewModeBtn(wt, this.mode));
     }
-    this.modeBar.appendChild(this._buildAddWebviewBtn());
+    this.modeBar.appendChild(this._webviewMgr.buildAddWebviewBtn(this.modeBar));
   }
 
-  _showAddWebviewInput(addBtn) {
-    const input = _el('input', 'mode-bar-url-input');
-    input.type = 'text';
-    input.placeholder = 'localhost:3000';
-    this.modeBar.replaceChild(input, addBtn);
-    input.focus();
-
-    setupInlineInput(input, {
-      onCommit: (val) => {
-        if (val) {
-          const { url, label } = parseWebviewUrl(val);
-          this.addWebview(label, url);
-        } else {
-          this._renderModeBar();
-        }
-      },
-      onCancel: () => this._renderModeBar(),
-    });
-  }
-
-  // ===== Webview Management =====
+  // ===== Webview Management (delegated) =====
 
   addWebview(label, url) {
-    const wt = { id: generateId('wv'), label, url };
-    this.webviewTabs.push(wt);
-    this._createWebviewContainer(wt);
-    this.switchMode(wt.id);
-    bus.emit('layout:changed');
+    this._webviewMgr.addWebview(label, url);
   }
 
   removeWebview(webviewId) {
-    const idx = this.webviewTabs.findIndex(wt => wt.id === webviewId);
-    if (idx < 0) return;
-    this.webviewTabs.splice(idx, 1);
-
-    const wvData = this._webviewEls.get(webviewId);
-    if (wvData) {
-      if (wvData.instance) wvData.instance.dispose();
-      wvData.container.remove();
-      this._webviewEls.delete(webviewId);
-    }
-
-    if (this.mode === webviewId) this.switchMode('files');
+    const removedId = this._webviewMgr.removeWebview(webviewId);
+    if (this.mode === removedId) this.switchMode('files');
     else this._renderModeBar();
     bus.emit('layout:changed');
   }
 
-  _createWebviewContainer(wt) {
-    const container = _el('div', 'webview-area');
-    container.style.display = 'none';
-    this.container.insertBefore(container, this.statusBar);
-    const instance = new WebviewInstance(container, wt.url);
-    this._webviewEls.set(wt.id, { container, instance });
-  }
-
   getWebviewTabs() {
-    return this.webviewTabs.map(wt => ({ label: wt.label, url: wt.url }));
+    return this._webviewMgr.getWebviewTabs();
   }
 
   setWebviewTabs(tabs) {
-    if (!tabs || !tabs.length) return;
-    for (const t of tabs) {
-      const wt = { id: generateId('wv'), label: t.label, url: t.url };
-      this.webviewTabs.push(wt);
-      this._createWebviewContainer(wt);
-    }
-    this._renderModeBar();
+    this._webviewMgr.setWebviewTabs(tabs);
   }
 
   dispose() {
     unsubscribeBus(this._busListeners);
     this._busListeners = [];
-
-    for (const [, wvData] of this._webviewEls) {
-      if (wvData.instance) wvData.instance.dispose();
-    }
-    this._webviewEls.clear();
+    this._webviewMgr.dispose();
   }
 }
 

--- a/src/components/flow-card-terminal.js
+++ b/src/components/flow-card-terminal.js
@@ -1,0 +1,137 @@
+/**
+ * Terminal management for flow cards: live terminals, inline log terminals, and log modal.
+ * Extracted from FlowView to reduce component size.
+ */
+import { _el, _safeFit } from '../utils/dom.js';
+import { createReadonlyTerminal, disposeTerminal } from '../utils/terminal-factory.js';
+import {
+  FIT_DELAY_MS, LOG_SCROLLBACK, LIVE_SCROLLBACK,
+  STATUS_LABELS, NO_LOG_MESSAGE, NO_LOG_MODAL_MESSAGE,
+  formatRunDateTime,
+} from '../utils/flow-view-helpers.js';
+
+export class FlowCardTerminalManager {
+  constructor() {
+    this._liveTerminals = new Map();
+    this._logTerminals = new Map();
+  }
+
+  // === Shared helpers ===
+
+  _createReadonlyTerminal(containerEl, termOpts = {}) {
+    return createReadonlyTerminal(containerEl, {
+      scrollback: LIVE_SCROLLBACK,
+      fitDelay: FIT_DELAY_MS,
+      ...termOpts,
+    });
+  }
+
+  _disposeTerminalEntry(map, flowId) {
+    const data = map.get(flowId);
+    if (!data) return;
+    disposeTerminal(data);
+    map.delete(flowId);
+  }
+
+  _disposeAllFromMap(map) {
+    for (const [flowId] of map) {
+      this._disposeTerminalEntry(map, flowId);
+    }
+  }
+
+  // === Live Terminal (for running flows) ===
+
+  createLiveTerminal(flowId, ptyId) {
+    const existing = this._liveTerminals.get(flowId);
+    if (existing) {
+      setTimeout(() => _safeFit(existing.fitAddon), FIT_DELAY_MS);
+      return existing.containerEl;
+    }
+
+    const containerEl = _el('div', 'flow-card-terminal');
+
+    const { term, fitAddon, resizeObs } = this._createReadonlyTerminal(containerEl, {
+      scrollback: LIVE_SCROLLBACK,
+      cursorStyle: 'bar',
+    });
+
+    const unsubData = window.api.pty.onData(ptyId, (data) => {
+      term.write(data);
+    });
+
+    this._liveTerminals.set(flowId, { term, fitAddon, unsubData, resizeObs, containerEl, ptyId });
+
+    return containerEl;
+  }
+
+  disposeLiveTerminal(flowId) {
+    this._disposeTerminalEntry(this._liveTerminals, flowId);
+  }
+
+  // === Inline Log Terminal (expanded card) ===
+
+  async loadLogIntoContainer(flowId, run, containerEl) {
+    const log = run.logTimestamp
+      ? await window.api.flow.getRunLog(flowId, run.logTimestamp)
+      : null;
+
+    const { term, fitAddon, resizeObs } = this._createReadonlyTerminal(containerEl, {
+      scrollback: LOG_SCROLLBACK,
+    });
+
+    term.write(log || NO_LOG_MESSAGE);
+    this._logTerminals.set(flowId, { term, fitAddon, resizeObs });
+  }
+
+  disposeLogTerminal(flowId) {
+    this._disposeTerminalEntry(this._logTerminals, flowId);
+  }
+
+  // === Past Run Log Viewer (modal) ===
+
+  _buildLogModalHeader(flow, run) {
+    const header = _el('div', 'flow-log-header');
+    header.appendChild(_el('span', 'flow-log-title', `${flow.name} — ${formatRunDateTime(run.date, run.timestamp)}`));
+    header.appendChild(_el('span', `flow-log-status flow-log-status-${run.status}`, STATUS_LABELS[run.status] || run.status));
+    header.appendChild(_el('button', 'flow-log-close', '✕'));
+    return header;
+  }
+
+  async showRunLog(flow, run) {
+    const log = await window.api.flow.getRunLog(flow.id, run.logTimestamp);
+
+    const overlay = _el('div', 'flow-modal-overlay');
+    const modal = _el('div', 'flow-log-modal');
+    const termContainer = _el('div', 'flow-log-terminal');
+    modal.append(this._buildLogModalHeader(flow, run), termContainer);
+    overlay.appendChild(modal);
+    document.body.appendChild(overlay);
+
+    const { term, resizeObs } = this._createReadonlyTerminal(termContainer, {
+      scrollback: LOG_SCROLLBACK,
+    });
+
+    term.write(log || NO_LOG_MODAL_MESSAGE);
+
+    const close = () => { resizeObs.disconnect(); term.dispose(); overlay.remove(); };
+    modal.querySelector('.flow-log-close').addEventListener('click', close);
+    overlay.addEventListener('click', (e) => { if (e.target === overlay) close(); });
+  }
+
+  // === Cleanup on render / refresh ===
+
+  cleanupStaleLiveTerminals(runningMap) {
+    for (const [flowId] of this._liveTerminals) {
+      if (!runningMap[flowId]) this.disposeLiveTerminal(flowId);
+    }
+  }
+
+  disposeAllLogTerminals() {
+    this._disposeAllFromMap(this._logTerminals);
+  }
+
+  disposeAll() {
+    this._disposeAllFromMap(this._liveTerminals);
+    this._disposeAllFromMap(this._logTerminals);
+  }
+}

--- a/src/components/flow-category-renderer.js
+++ b/src/components/flow-category-renderer.js
@@ -1,0 +1,163 @@
+/**
+ * Category group rendering for FlowView.
+ * Handles category headers, collapse state, and drag-drop zone setup.
+ * Extracted from flow-view.js to reduce component size.
+ */
+import { _el } from '../utils/dom.js';
+import { CATEGORY_ACTIONS, UNCATEGORIZED } from '../utils/flow-view-helpers.js';
+
+/**
+ * Create a category group DOM element with header and flow items.
+ * @param {Object} params
+ * @param {Object} params.cat - { id, name }
+ * @param {Array} params.flows - flow objects in this category
+ * @param {boolean} params.isUncategorized
+ * @param {Set} params.collapsedCategories
+ * @param {function} params.createCard - (flow, catId) => HTMLElement
+ * @param {function} params.onToggleCollapse - (catId) => void
+ * @param {function} params.onRenameCategory - (catId, nameEl) => void
+ * @param {function} params.onDeleteCategory - (catId) => void
+ * @param {function} params.onDropFlow - (flowId, catId, insertIndex) => void
+ * @param {Object} params.dragState - { getDragFlowId, clearDrag }
+ * @returns {HTMLElement}
+ */
+export function createCategoryGroup(params) {
+  const { cat, flows, isUncategorized, collapsedCategories, createCard,
+          onToggleCollapse, onRenameCategory, onDeleteCategory, onDropFlow, dragState } = params;
+
+  const isCollapsed = collapsedCategories.has(cat.id);
+  const group = _el('div', `flow-category-group${isCollapsed ? ' flow-category-collapsed' : ''}`);
+  group.dataset.catId = cat.id;
+
+  group.appendChild(_buildCategoryHeader(cat, flows, isUncategorized, collapsedCategories,
+    onToggleCollapse, onRenameCategory, onDeleteCategory));
+
+  const items = _el('div', 'flow-category-items');
+  items.dataset.catId = cat.id;
+  _setupCategoryDropZone(items, cat.id, onDropFlow, dragState);
+
+  if (!isCollapsed) {
+    for (const flow of flows) {
+      items.appendChild(createCard(flow, cat.id));
+    }
+    if (flows.length === 0) {
+      items.appendChild(_el('div', {
+        className: 'flow-empty',
+        style: { padding: '12px 0', fontSize: '12px' },
+        textContent: 'Glissez un flow ici',
+      }));
+    }
+  }
+
+  group.appendChild(items);
+  return group;
+}
+
+function _buildCategoryHeader(cat, flows, isUncategorized, collapsedCategories, onToggleCollapse, onRenameCategory, onDeleteCategory) {
+  const header = _el('div', 'flow-category-header');
+
+  const chevron = _el('span', 'flow-category-chevron', '▼');
+  const name = _el('span', 'flow-category-name', cat.name);
+  const count = _el('span', 'flow-category-count', `${flows.length}`);
+  header.append(chevron, name, count);
+
+  if (!isUncategorized) {
+    const actions = _el('div', 'flow-category-actions');
+    const catHandlers = {
+      rename: () => onRenameCategory(cat.id, name),
+      delete: () => onDeleteCategory(cat.id),
+    };
+    for (const { icon, title, cls, action } of CATEGORY_ACTIONS) {
+      const btn = _el('button', cls ? `flow-category-btn ${cls}` : 'flow-category-btn', icon);
+      btn.title = title;
+      btn.addEventListener('click', (e) => { e.stopPropagation(); catHandlers[action](); });
+      actions.appendChild(btn);
+    }
+    header.appendChild(actions);
+  }
+
+  header.addEventListener('click', () => onToggleCollapse(cat.id));
+
+  return header;
+}
+
+function _setupCategoryDropZone(items, catId, onDropFlow, dragState) {
+  items.addEventListener('dragover', (e) => {
+    e.preventDefault();
+    e.dataTransfer.dropEffect = 'move';
+    items.classList.add('flow-drop-zone-active');
+    _updateDropIndicator(items, e.clientY);
+  });
+
+  items.addEventListener('dragleave', (e) => {
+    if (!items.contains(e.relatedTarget)) {
+      items.classList.remove('flow-drop-zone-active');
+      _clearDropIndicators(items);
+    }
+  });
+
+  items.addEventListener('drop', (e) => {
+    e.preventDefault();
+    items.classList.remove('flow-drop-zone-active');
+    _clearDropIndicators(items);
+
+    const dragFlowId = dragState.getDragFlowId();
+    if (!dragFlowId) return;
+
+    const insertIndex = _getDropIndex(items, e.clientY);
+    dragState.clearDrag();
+    onDropFlow(dragFlowId, catId, insertIndex);
+  });
+}
+
+// --- Drop indicator helpers ---
+
+function _updateDropIndicator(container, clientY) {
+  _clearDropIndicators(container);
+
+  const cards = [...container.querySelectorAll(':scope > .flow-card')];
+  if (cards.length === 0) return;
+
+  let insertBefore = null;
+  for (const card of cards) {
+    const rect = card.getBoundingClientRect();
+    const midY = rect.top + rect.height / 2;
+    if (clientY < midY) {
+      insertBefore = card;
+      break;
+    }
+  }
+
+  const indicator = _el('div', 'flow-drop-indicator flow-drop-active');
+  if (insertBefore) {
+    container.insertBefore(indicator, insertBefore);
+  } else {
+    container.appendChild(indicator);
+  }
+}
+
+function _clearDropIndicators(container) {
+  for (const el of container.querySelectorAll('.flow-drop-indicator')) {
+    el.remove();
+  }
+}
+
+function _getDropIndex(container, clientY) {
+  const cards = [...container.querySelectorAll(':scope > .flow-card')];
+  for (let i = 0; i < cards.length; i++) {
+    const rect = cards[i].getBoundingClientRect();
+    const midY = rect.top + rect.height / 2;
+    if (clientY < midY) return i;
+  }
+  return -1; // append at end
+}
+
+/**
+ * Remove all drag state indicators from the document.
+ */
+export function cleanupAllDragState() {
+  for (const el of document.querySelectorAll('.flow-drop-indicator')) el.remove();
+  for (const el of document.querySelectorAll('.flow-drop-zone-active')) {
+    el.classList.remove('flow-drop-zone-active');
+  }
+}

--- a/src/components/flow-view.js
+++ b/src/components/flow-view.js
@@ -1,19 +1,18 @@
 import { openFlowModal } from './flow-modal.js';
-import { SCHEDULE_LABELS, DAY_NAMES, formatSchedule } from '../utils/flow-schedule-helpers.js';
-import { _el, _safeFit, showPromptDialog, setupInlineInput } from '../utils/dom.js';
-import { createReadonlyTerminal, disposeTerminal, disposeTerminalMap } from '../utils/terminal-factory.js';
+import { formatSchedule } from '../utils/flow-schedule-helpers.js';
+import { _el, showPromptDialog, setupInlineInput } from '../utils/dom.js';
 import { generateId } from '../utils/id.js';
 import { registerComponent } from '../utils/component-registry.js';
 import {
-  FIT_DELAY_MS, LOG_SCROLLBACK, LIVE_SCROLLBACK,
-  STATUS_LABELS, NO_LOG_MESSAGE, NO_LOG_MODAL_MESSAGE,
   EMPTY_LIST_MESSAGE, MAX_VISIBLE_RUNS, UNCATEGORIZED,
-  HEADER_BUTTONS, CATEGORY_ACTIONS,
-  formatRunDateTime, buildDotTooltip, buildCardActionEntries,
+  HEADER_BUTTONS,
+  buildDotTooltip, buildCardActionEntries,
   getFlowsForCategory, getUncategorizedFlows,
   removeFlowFromOrder, moveFlowInOrder, deleteCategoryData,
   getLastRun,
 } from '../utils/flow-view-helpers.js';
+import { FlowCardTerminalManager } from './flow-card-terminal.js';
+import { createCategoryGroup, cleanupAllDragState } from './flow-category-renderer.js';
 
 
 export class FlowView {
@@ -23,8 +22,7 @@ export class FlowView {
     this.flows = [];
     this.catData = { categories: [], order: {} };
     this.disposed = false;
-    this._liveTerminals = new Map();
-    this._logTerminals = new Map();
+    this._termManager = new FlowCardTerminalManager();
     this._expandedCards = new Set();
     this._collapsedCategories = new Set();
     this._runningMap = {};
@@ -40,7 +38,7 @@ export class FlowView {
     });
 
     this._unsubComplete = window.api.flow.onRunComplete(({ flowId }) => {
-      this._disposeLiveTerminal(flowId);
+      this._termManager.disposeLiveTerminal(flowId);
       delete this._runningMap[flowId];
       this.refresh();
     });
@@ -105,10 +103,8 @@ export class FlowView {
   _renderList() {
     if (!this.listEl) return;
 
-    for (const [flowId] of this._liveTerminals) {
-      if (!this._runningMap[flowId]) this._disposeLiveTerminal(flowId);
-    }
-    disposeTerminalMap(this._logTerminals);
+    this._termManager.cleanupStaleLiveTerminals(this._runningMap);
+    this._termManager.disposeAllLogTerminals();
 
     this.listEl.replaceChildren();
 
@@ -121,22 +117,38 @@ export class FlowView {
       return;
     }
 
+    const groupParams = (cat, flows, isUncat = false) => ({
+      cat,
+      flows,
+      isUncategorized: isUncat,
+      collapsedCategories: this._collapsedCategories,
+      createCard: (flow, catId) => this._createCard(flow, catId),
+      onToggleCollapse: (catId) => this._toggleCollapse(catId),
+      onRenameCategory: (catId, nameEl) => this._renameCategoryInline(catId, nameEl),
+      onDeleteCategory: (catId) => this._deleteCategory(catId),
+      onDropFlow: (flowId, catId, insertIndex) => {
+        this._moveFlowToCategory(flowId, catId, insertIndex);
+        this._renderList();
+      },
+      dragState: {
+        getDragFlowId: () => this._dragFlowId,
+        clearDrag: () => { this._dragFlowId = null; this._dragSourceCat = null; },
+      },
+    });
+
     // Render categorized groups
     for (const cat of this.catData.categories) {
       const flows = getFlowsForCategory(this.flows, this.catData.order, cat.id);
-      this.listEl.appendChild(this._createCategoryGroup(cat, flows));
+      this.listEl.appendChild(createCategoryGroup(groupParams(cat, flows)));
     }
 
     // Render uncategorized
     if (uncatFlows.length > 0 || hasCats) {
       if (hasCats) {
-        this.listEl.appendChild(this._createCategoryGroup(
-          { id: UNCATEGORIZED, name: 'Sans catégorie' },
-          uncatFlows,
-          true
+        this.listEl.appendChild(createCategoryGroup(
+          groupParams({ id: UNCATEGORIZED, name: 'Sans catégorie' }, uncatFlows, true)
         ));
       } else {
-        // No categories exist, just render flat list
         for (const flow of uncatFlows) {
           this.listEl.appendChild(this._createCard(flow, UNCATEGORIZED));
         }
@@ -144,146 +156,13 @@ export class FlowView {
     }
   }
 
-  _createCategoryGroup(cat, flows, isUncategorized = false) {
-    const isCollapsed = this._collapsedCategories.has(cat.id);
-    const group = _el('div', `flow-category-group${isCollapsed ? ' flow-category-collapsed' : ''}`);
-    group.dataset.catId = cat.id;
-
-    group.appendChild(this._buildCategoryHeader(cat, flows, isUncategorized));
-
-    const items = _el('div', 'flow-category-items');
-    items.dataset.catId = cat.id;
-    this._setupCategoryDropZone(items, cat.id);
-
-    if (!isCollapsed) {
-      for (const flow of flows) {
-        items.appendChild(this._createCard(flow, cat.id));
-      }
-      if (flows.length === 0) {
-        items.appendChild(_el('div', {
-          className: 'flow-empty',
-          style: { padding: '12px 0', fontSize: '12px' },
-          textContent: 'Glissez un flow ici',
-        }));
-      }
-    }
-
-    group.appendChild(items);
-    return group;
-  }
-
-  _buildCategoryHeader(cat, flows, isUncategorized) {
-    const header = _el('div', 'flow-category-header');
-
-    const chevron = _el('span', 'flow-category-chevron', '▼');
-    const name = _el('span', 'flow-category-name', cat.name);
-    const count = _el('span', 'flow-category-count', `${flows.length}`);
-    header.append(chevron, name, count);
-
-    if (!isUncategorized) {
-      const actions = _el('div', 'flow-category-actions');
-      const catHandlers = {
-        rename: () => this._renameCategoryInline(cat.id, name),
-        delete: () => this._deleteCategory(cat.id),
-      };
-      for (const { icon, title, cls, action } of CATEGORY_ACTIONS) {
-        const btn = _el('button', cls ? `flow-category-btn ${cls}` : 'flow-category-btn', icon);
-        btn.title = title;
-        btn.addEventListener('click', (e) => { e.stopPropagation(); catHandlers[action](); });
-        actions.appendChild(btn);
-      }
-      header.appendChild(actions);
-    }
-
-    header.addEventListener('click', () => {
-      if (this._collapsedCategories.has(cat.id)) {
-        this._collapsedCategories.delete(cat.id);
-      } else {
-        this._collapsedCategories.add(cat.id);
-      }
-      this._renderList();
-    });
-
-    return header;
-  }
-
-  _setupCategoryDropZone(items, catId) {
-    items.addEventListener('dragover', (e) => {
-      e.preventDefault();
-      e.dataTransfer.dropEffect = 'move';
-      items.classList.add('flow-drop-zone-active');
-      this._updateDropIndicator(items, e.clientY);
-    });
-
-    items.addEventListener('dragleave', (e) => {
-      if (!items.contains(e.relatedTarget)) {
-        items.classList.remove('flow-drop-zone-active');
-        this._clearDropIndicators(items);
-      }
-    });
-
-    items.addEventListener('drop', (e) => {
-      e.preventDefault();
-      items.classList.remove('flow-drop-zone-active');
-      this._clearDropIndicators(items);
-
-      if (!this._dragFlowId) return;
-
-      const insertIndex = this._getDropIndex(items, e.clientY);
-      this._moveFlowToCategory(this._dragFlowId, catId, insertIndex);
-      this._dragFlowId = null;
-      this._dragSourceCat = null;
-      this._renderList();
-    });
-  }
-
-  // --- Drag & Drop helpers ---
-
-  _updateDropIndicator(container, clientY) {
-    this._clearDropIndicators(container);
-
-    const cards = [...container.querySelectorAll(':scope > .flow-card')];
-    if (cards.length === 0) return;
-
-    let insertBefore = null;
-    for (const card of cards) {
-      const rect = card.getBoundingClientRect();
-      const midY = rect.top + rect.height / 2;
-      if (clientY < midY) {
-        insertBefore = card;
-        break;
-      }
-    }
-
-    const indicator = _el('div', 'flow-drop-indicator flow-drop-active');
-    if (insertBefore) {
-      container.insertBefore(indicator, insertBefore);
+  _toggleCollapse(catId) {
+    if (this._collapsedCategories.has(catId)) {
+      this._collapsedCategories.delete(catId);
     } else {
-      container.appendChild(indicator);
+      this._collapsedCategories.add(catId);
     }
-  }
-
-  _clearDropIndicators(container) {
-    for (const el of container.querySelectorAll('.flow-drop-indicator')) {
-      el.remove();
-    }
-  }
-
-  _getDropIndex(container, clientY) {
-    const cards = [...container.querySelectorAll(':scope > .flow-card')];
-    for (let i = 0; i < cards.length; i++) {
-      const rect = cards[i].getBoundingClientRect();
-      const midY = rect.top + rect.height / 2;
-      if (clientY < midY) return i;
-    }
-    return -1; // append at end
-  }
-
-  _cleanupAllDragState() {
-    for (const el of document.querySelectorAll('.flow-drop-indicator')) el.remove();
-    for (const el of document.querySelectorAll('.flow-drop-zone-active')) {
-      el.classList.remove('flow-drop-zone-active');
-    }
+    this._renderList();
   }
 
   // --- Card rendering ---
@@ -326,13 +205,13 @@ export class FlowView {
       card.classList.remove('flow-dragging');
       this._dragFlowId = null;
       this._dragSourceCat = null;
-      this._cleanupAllDragState();
+      cleanupAllDragState();
     });
   }
 
   _buildCardBody(flow, isRunning, isExpanded) {
     if (isRunning) {
-      const container = this._createLiveTerminal(flow.id, this._runningMap[flow.id]);
+      const container = this._termManager.createLiveTerminal(flow.id, this._runningMap[flow.id]);
       container.style.display = isExpanded ? '' : 'none';
       return container;
     }
@@ -340,7 +219,7 @@ export class FlowView {
       const lastRun = getLastRun(flow);
       if (lastRun) {
         const termArea = _el('div', 'flow-card-terminal');
-        this._loadLogIntoContainer(flow.id, lastRun, termArea);
+        this._termManager.loadLogIntoContainer(flow.id, lastRun, termArea);
         return termArea;
       }
     }
@@ -361,7 +240,7 @@ export class FlowView {
       }
       if (this._expandedCards.has(flow.id)) {
         this._expandedCards.delete(flow.id);
-        this._disposeLogTerminal(flow.id);
+        this._termManager.disposeLogTerminal(flow.id);
       } else {
         this._expandedCards.add(flow.id);
       }
@@ -408,7 +287,7 @@ export class FlowView {
       dot.title = buildDotTooltip(run);
       dot.addEventListener('click', (e) => {
         e.stopPropagation();
-        this._showRunLog(flow, run);
+        this._termManager.showRunLog(flow, run);
       });
       dots.appendChild(dot);
     }
@@ -430,7 +309,7 @@ export class FlowView {
   }
 
   async _deleteFlow(flowId) {
-    this._disposeLiveTerminal(flowId);
+    this._termManager.disposeLiveTerminal(flowId);
     removeFlowFromOrder(this.catData.order, flowId);
     await this._persistCategories();
     await window.api.flow.delete(flowId);
@@ -485,7 +364,7 @@ export class FlowView {
     this._renderList();
   }
 
-  // === Live Terminal (for running flows) ===
+  // === Action button helper ===
 
   _createActionButton(icon, title, onClick, extraClass = '') {
     const btn = _el('button', extraClass ? `flow-card-btn ${extraClass}` : 'flow-card-btn', icon);
@@ -494,116 +373,20 @@ export class FlowView {
     return btn;
   }
 
-  _createReadonlyTerminal(containerEl, termOpts = {}) {
-    return createReadonlyTerminal(containerEl, {
-      scrollback: LIVE_SCROLLBACK,
-      fitDelay: FIT_DELAY_MS,
-      ...termOpts,
-    });
-  }
-
-  _createLiveTerminal(flowId, ptyId) {
-    const existing = this._liveTerminals.get(flowId);
-    if (existing) {
-      setTimeout(() => _safeFit(existing.fitAddon), FIT_DELAY_MS);
-      return existing.containerEl;
-    }
-
-    const containerEl = _el('div', 'flow-card-terminal');
-
-    const { term, fitAddon, resizeObs } = this._createReadonlyTerminal(containerEl, {
-      scrollback: LIVE_SCROLLBACK,
-      cursorStyle: 'bar',
-    });
-
-    const unsubData = window.api.pty.onData(ptyId, (data) => {
-      term.write(data);
-    });
-
-    this._liveTerminals.set(flowId, { term, fitAddon, unsubData, resizeObs, containerEl, ptyId });
-
-    return containerEl;
-  }
-
-  _disposeTerminalEntry(map, flowId) {
-    const data = map.get(flowId);
-    if (!data) return;
-    disposeTerminal(data);
-    map.delete(flowId);
-  }
-
-  _disposeLiveTerminal(flowId) {
-    this._disposeTerminalEntry(this._liveTerminals, flowId);
-  }
-
-  // === Inline Log Terminal (expanded card) ===
-
-  async _loadLogIntoContainer(flowId, run, containerEl) {
-    const log = run.logTimestamp
-      ? await window.api.flow.getRunLog(flowId, run.logTimestamp)
-      : null;
-
-    const { term, fitAddon, resizeObs } = this._createReadonlyTerminal(containerEl, {
-      scrollback: LOG_SCROLLBACK,
-    });
-
-    term.write(log || NO_LOG_MESSAGE);
-    this._logTerminals.set(flowId, { term, fitAddon, resizeObs });
-  }
-
-  _disposeLogTerminal(flowId) {
-    this._disposeTerminalEntry(this._logTerminals, flowId);
-  }
-
-  // === Past Run Log Viewer (modal) ===
-
-  _buildLogModalHeader(flow, run) {
-    const header = _el('div', 'flow-log-header');
-    header.appendChild(_el('span', 'flow-log-title', `${flow.name} — ${formatRunDateTime(run.date, run.timestamp)}`));
-    header.appendChild(_el('span', `flow-log-status flow-log-status-${run.status}`, STATUS_LABELS[run.status] || run.status));
-    header.appendChild(_el('button', 'flow-log-close', '✕'));
-    return header;
-  }
-
-  async _showRunLog(flow, run) {
-    const log = await window.api.flow.getRunLog(flow.id, run.logTimestamp);
-
-    const overlay = _el('div', 'flow-modal-overlay');
-    const modal = _el('div', 'flow-log-modal');
-    const termContainer = _el('div', 'flow-log-terminal');
-    modal.append(this._buildLogModalHeader(flow, run), termContainer);
-    overlay.appendChild(modal);
-    document.body.appendChild(overlay);
-
-    const { term, resizeObs } = this._createReadonlyTerminal(termContainer, {
-      scrollback: LOG_SCROLLBACK,
-    });
-
-    term.write(log || NO_LOG_MODAL_MESSAGE);
-
-    const close = () => { resizeObs.disconnect(); term.dispose(); overlay.remove(); };
-    modal.querySelector('.flow-log-close').addEventListener('click', close);
-    overlay.addEventListener('click', (e) => { if (e.target === overlay) close(); });
-  }
-
   // ===== Creation / Edit Modal =====
 
   async _openModal(existing = null) {
     const flow = await openFlowModal(existing, this.catData.categories);
     if (flow) {
-      // Handle category assignment from modal
       const catId = flow._category;
       delete flow._category;
 
       await window.api.flow.save(flow);
 
-      // Update category ordering
       if (catId) {
         this._moveFlowToCategory(flow.id, catId);
       } else if (!existing) {
-        // New flow, add to uncategorized order
         if (!this.catData.order[UNCATEGORIZED]) this.catData.order[UNCATEGORIZED] = [];
-        // Only add if not already in any category
         const allOrdered = new Set(Object.values(this.catData.order).flat());
         if (!allOrdered.has(flow.id)) {
           this.catData.order[UNCATEGORIZED].push(flow.id);
@@ -619,8 +402,7 @@ export class FlowView {
     this.disposed = true;
     if (this._unsubStarted) this._unsubStarted();
     if (this._unsubComplete) this._unsubComplete();
-    disposeTerminalMap(this._liveTerminals);
-    disposeTerminalMap(this._logTerminals);
+    this._termManager.disposeAll();
   }
 }
 

--- a/src/components/settings-appearance.js
+++ b/src/components/settings-appearance.js
@@ -1,0 +1,105 @@
+/**
+ * Appearance section renderer for SettingsModal.
+ * Extracted from settings-modal.js to reduce component size.
+ */
+import { TERMINAL_THEMES, getTerminalThemeName, setTerminalTheme, getTerminalTheme, switchTerminalForMode } from '../utils/terminal-themes.js';
+import { getAppTheme, setAppTheme } from '../utils/app-theme.js';
+import { _el } from '../utils/dom.js';
+import { MODE_BUTTONS, THEME_PREVIEW_LINES, COLOR_DOT_KEYS } from '../utils/settings-helpers.js';
+
+/**
+ * Apply the current terminal theme to all terminal panels across tabs.
+ * @param {Object|null} tabManager
+ */
+export function applyThemeToTerminals(tabManager) {
+  if (!tabManager) return;
+  const theme = getTerminalTheme();
+  for (const [, tab] of tabManager.tabs) {
+    if (tab.terminalPanel) tab.terminalPanel.applyTheme(theme);
+  }
+}
+
+function _createThemePreviewLine(segments, theme) {
+  const line = _el('div', 'theme-preview-line');
+  for (const { text, colorKey } of segments) {
+    const span = _el('span', null, text);
+    span.style.color = theme[colorKey];
+    line.appendChild(span);
+  }
+  return line;
+}
+
+function _createThemeCard(name, theme, isActive, tabManager, renderAppearanceFn) {
+  const card = _el('div', 'theme-card');
+  if (isActive) card.classList.add('theme-active');
+
+  // Preview block
+  const preview = _el('div', 'theme-preview');
+  preview.style.background = theme.background;
+
+  for (const segments of THEME_PREVIEW_LINES) {
+    preview.appendChild(_createThemePreviewLine(segments, theme));
+  }
+
+  // Color dots
+  const dots = _el('div', 'theme-preview-dots');
+  for (const key of COLOR_DOT_KEYS) {
+    const dot = _el('span', 'theme-dot');
+    dot.style.background = theme[key];
+    dots.appendChild(dot);
+  }
+  preview.appendChild(dots);
+
+  card.appendChild(preview);
+  card.appendChild(_el('div', 'theme-card-label', name));
+
+  card.addEventListener('click', () => {
+    setTerminalTheme(name);
+    applyThemeToTerminals(tabManager);
+    renderAppearanceFn();
+  });
+
+  return card;
+}
+
+/**
+ * Render the Appearance section into the given content element.
+ * @param {HTMLElement} contentEl - the settings content container
+ * @param {function} createSectionHeading - (title, ...extras) => heading element
+ * @param {Object|null} tabManager
+ * @param {function} renderAppearanceFn - callback to re-render this section
+ */
+export function renderAppearance(contentEl, createSectionHeading, tabManager, renderAppearanceFn) {
+  createSectionHeading('Appearance');
+
+  // Day/Night mode toggle
+  const modeRow = _el('div', 'theme-mode-row');
+  modeRow.appendChild(_el('span', 'theme-mode-label', 'Mode'));
+
+  const modeToggle = _el('div', 'theme-mode-toggle');
+  const currentMode = getAppTheme();
+
+  for (const { mode, label } of MODE_BUTTONS) {
+    const btn = _el('button', 'theme-mode-btn', label);
+    if (currentMode === mode) btn.classList.add('active');
+    btn.addEventListener('click', () => {
+      setAppTheme(mode);
+      if (switchTerminalForMode(mode)) applyThemeToTerminals(tabManager);
+      renderAppearanceFn();
+    });
+    modeToggle.appendChild(btn);
+  }
+
+  modeRow.appendChild(modeToggle);
+  contentEl.appendChild(modeRow);
+
+  // Terminal theme grid
+  contentEl.appendChild(_el('h4', 'theme-sub-heading', 'Terminal Theme'));
+
+  const currentThemeName = getTerminalThemeName();
+  const grid = _el('div', 'theme-grid');
+  for (const [name, theme] of Object.entries(TERMINAL_THEMES)) {
+    grid.appendChild(_createThemeCard(name, theme, name === currentThemeName, tabManager, renderAppearanceFn));
+  }
+  contentEl.appendChild(grid);
+}

--- a/src/components/settings-configs.js
+++ b/src/components/settings-configs.js
@@ -1,0 +1,113 @@
+/**
+ * Workspace Configs section renderer for SettingsModal.
+ * Extracted from settings-modal.js to reduce component size.
+ */
+import { _el } from '../utils/dom.js';
+import { CONFIG_ACTIONS, BOTTOM_CONFIG_BUTTONS, formatConfigMeta, buildActionBtn } from '../utils/settings-helpers.js';
+
+function _createConfigActions(config, tabManager, renderConfigsFn) {
+  const handlers = {
+    setDefault: async (e) => { e.stopPropagation(); await window.api.config.setDefault(config.name); renderConfigsFn(); },
+    overwrite: async (e) => {
+      e.stopPropagation();
+      if (!tabManager) return;
+      await window.api.config.save(config.name, tabManager.serialize());
+      renderConfigsFn();
+    },
+    delete: async (e) => { e.stopPropagation(); await window.api.config.delete(config.name); renderConfigsFn(); },
+  };
+
+  const actions = _el('div', 'config-actions');
+  for (const desc of CONFIG_ACTIONS) {
+    if (desc.hideWhen && config[desc.hideWhen]) continue;
+    actions.appendChild(buildActionBtn({ ...desc, onClick: handlers[desc.action] }));
+  }
+  return actions;
+}
+
+function _buildConfigRowLeft(config) {
+  const left = _el('div', 'config-row-left');
+
+  const radio = _el('span', 'config-radio');
+  if (config.isDefault) radio.classList.add('config-radio-default');
+  left.appendChild(radio);
+
+  const info = _el('div', 'config-info');
+  const nameEl = _el('span', 'config-name', config.name);
+  if (config.isDefault) {
+    nameEl.appendChild(_el('span', 'config-default-tag', 'default'));
+  }
+  info.appendChild(nameEl);
+  info.appendChild(_el('span', 'config-meta', formatConfigMeta(config.tabCount || 0, config.updatedAt)));
+  left.appendChild(info);
+
+  return left;
+}
+
+function _createConfigRow(config, currentName, tabManager, renderConfigsFn) {
+  const row = _el('div', 'config-row');
+  if (config.name === currentName) row.classList.add('config-active');
+
+  row.addEventListener('click', async () => {
+    if (!tabManager) return;
+    await tabManager.configManager.switchConfig(config.name);
+    renderConfigsFn();
+  });
+
+  row.appendChild(_buildConfigRowLeft(config));
+  row.appendChild(_createConfigActions(config, tabManager, renderConfigsFn));
+  return row;
+}
+
+function _createBottomActions(currentName, tabManager, renderConfigsFn) {
+  const handlers = {
+    new: () => {
+      if (!tabManager) return;
+      tabManager.configManager.promptConfigName('', async (name) => {
+        await tabManager.configManager.newConfig(name);
+        renderConfigsFn();
+      });
+    },
+    duplicate: () => {
+      if (!tabManager) return;
+      tabManager.configManager.promptConfigName(`${currentName} (copy)`, async (name) => {
+        await tabManager.configManager.duplicateConfig(name);
+        renderConfigsFn();
+      });
+    },
+  };
+  const container = _el('div', 'config-bottom-actions');
+  for (const { label, action } of BOTTOM_CONFIG_BUTTONS) {
+    container.appendChild(buildActionBtn({ label, cls: 'config-bottom-btn', onClick: handlers[action] }));
+  }
+  return container;
+}
+
+/**
+ * Render the Workspace Configs section into the given content element.
+ * @param {HTMLElement} contentEl - the settings content container
+ * @param {function} createSectionHeading - (title, ...extras) => heading element
+ * @param {Object|null} tabManager
+ * @param {function} renderConfigsFn - callback to re-render this section
+ */
+export async function renderConfigs(contentEl, createSectionHeading, tabManager, renderConfigsFn) {
+  createSectionHeading('Workspace Configs');
+
+  const currentName = tabManager?.configManager?.currentConfigName || 'Default';
+
+  // Current loaded config indicator
+  const currentBar = _el('div', 'config-current-bar');
+  currentBar.appendChild(_el('span', 'config-current-label', 'Config chargée :'));
+  currentBar.appendChild(_el('span', 'config-current-value', currentName));
+  contentEl.appendChild(currentBar);
+
+  // Config list
+  const configs = await window.api.config.list();
+  const list = _el('div', 'config-list');
+  for (const config of configs) {
+    list.appendChild(_createConfigRow(config, currentName, tabManager, renderConfigsFn));
+  }
+  contentEl.appendChild(list);
+
+  contentEl.appendChild(_createBottomActions(currentName, tabManager, renderConfigsFn));
+}

--- a/src/components/settings-keybindings.js
+++ b/src/components/settings-keybindings.js
@@ -1,0 +1,85 @@
+/**
+ * Keybindings section renderer for SettingsModal.
+ * Extracted from settings-modal.js to reduce component size.
+ */
+import { formatCombo } from '../utils/shortcut-helpers.js';
+import { _el } from '../utils/dom.js';
+
+/**
+ * Create a key badge element for a binding at a given index.
+ * @param {Object} binding - { id, label, keys }
+ * @param {number} index
+ * @param {Object} shortcutManager
+ * @param {function} startRecordingFn - (actionId, index, badgeEl) => void
+ * @param {function} renderKeybindingsFn - callback to re-render
+ * @returns {HTMLElement}
+ */
+export function createKeyBadge(binding, index, shortcutManager, startRecordingFn, renderKeybindingsFn) {
+  const wrapper = _el('div', 'keybinding-badge-wrapper');
+
+  const badge = _el('span', 'keybinding-badge');
+  badge.textContent = binding.keys[index]
+    ? formatCombo(binding.keys[index])
+    : 'Not set';
+  if (!binding.keys[index]) badge.classList.add('unset');
+
+  badge.addEventListener('click', () => {
+    startRecordingFn(binding.id, index, badge);
+  });
+
+  const removeBtn = _el('span', 'keybinding-badge-remove', '×');
+  removeBtn.addEventListener('click', (e) => {
+    e.stopPropagation();
+    binding.keys.splice(index, 1);
+    shortcutManager.updateBinding(binding.id, binding.keys);
+    renderKeybindingsFn();
+  });
+
+  wrapper.appendChild(badge);
+  if (binding.keys.length > 1) wrapper.appendChild(removeBtn);
+
+  return wrapper;
+}
+
+/**
+ * Render the Keybindings section into the given content element.
+ * @param {HTMLElement} contentEl - the settings content container
+ * @param {function} createSectionHeading - (title, ...extras) => heading element
+ * @param {Object} shortcutManager
+ * @param {function} startRecordingFn
+ * @param {function} renderKeybindingsFn - callback to re-render
+ */
+export function renderKeybindings(contentEl, createSectionHeading, shortcutManager, startRecordingFn, renderKeybindingsFn) {
+  const resetBtn = _el('button', 'settings-reset-btn', 'Reset to defaults');
+  resetBtn.addEventListener('click', () => {
+    shortcutManager.resetToDefaults();
+    renderKeybindingsFn();
+  });
+  createSectionHeading('Keyboard Shortcuts', resetBtn);
+
+  const list = _el('div', 'keybinding-list');
+
+  for (const binding of shortcutManager.getBindingsList()) {
+    const row = _el('div', 'keybinding-row');
+    row.appendChild(_el('div', 'keybinding-label', binding.label));
+
+    const keysContainer = _el('div', 'keybinding-keys');
+    for (let i = 0; i < binding.keys.length; i++) {
+      keysContainer.appendChild(createKeyBadge(binding, i, shortcutManager, startRecordingFn, renderKeybindingsFn));
+    }
+
+    const addBtn = _el('button', 'keybinding-add-btn', '+');
+    addBtn.title = 'Add keybinding';
+    addBtn.addEventListener('click', () => {
+      binding.keys.push('');
+      shortcutManager.updateBinding(binding.id, binding.keys);
+      renderKeybindingsFn();
+    });
+    keysContainer.appendChild(addBtn);
+
+    row.appendChild(keysContainer);
+    list.appendChild(row);
+  }
+
+  contentEl.appendChild(list);
+}

--- a/src/components/settings-modal.js
+++ b/src/components/settings-modal.js
@@ -1,12 +1,9 @@
 import { formatCombo, eventToCombo } from '../utils/shortcut-helpers.js';
-import { TERMINAL_THEMES, getTerminalThemeName, setTerminalTheme, getTerminalTheme, switchTerminalForMode } from '../utils/terminal-themes.js';
-import { getAppTheme, setAppTheme } from '../utils/app-theme.js';
 import { _el, createModalOverlay } from '../utils/dom.js';
-import {
-  MODAL_CLOSE_TRANSITION_MS, MODIFIER_KEYS, NAV_SECTIONS,
-  MODE_BUTTONS, BOTTOM_CONFIG_BUTTONS, THEME_PREVIEW_LINES,
-  COLOR_DOT_KEYS, CONFIG_ACTIONS, formatConfigMeta, buildActionBtn,
-} from '../utils/settings-helpers.js';
+import { MODAL_CLOSE_TRANSITION_MS, MODIFIER_KEYS, NAV_SECTIONS } from '../utils/settings-helpers.js';
+import { renderAppearance } from './settings-appearance.js';
+import { renderKeybindings } from './settings-keybindings.js';
+import { renderConfigs } from './settings-configs.js';
 
 export class SettingsModal {
   constructor(shortcutManager) {
@@ -16,19 +13,11 @@ export class SettingsModal {
     this.recording = null; // { actionId, index, el }
     this.activeSection = 'keybindings';
     this.sectionRenderers = {
-      keybindings: () => this.renderKeybindings(),
-      appearance: () => this.renderAppearance(),
-      configs: () => this.renderConfigs(),
+      keybindings: () => this._renderKeybindings(),
+      appearance: () => this._renderAppearance(),
+      configs: () => this._renderConfigs(),
     };
     this.build();
-  }
-
-  _applyThemeToTerminals() {
-    if (!this.tabManager) return;
-    const theme = getTerminalTheme();
-    for (const [, tab] of this.tabManager.tabs) {
-      if (tab.terminalPanel) tab.terminalPanel.applyTheme(theme);
-    }
   }
 
   // ===== Build =====
@@ -111,153 +100,37 @@ export class SettingsModal {
     return heading;
   }
 
-  // ===== Appearance Section =====
+  // ===== Delegated section renderers =====
 
-  _createThemePreviewLine(segments, theme) {
-    const line = _el('div', 'theme-preview-line');
-    for (const { text, colorKey } of segments) {
-      const span = _el('span', null, text);
-      span.style.color = theme[colorKey];
-      line.appendChild(span);
-    }
-    return line;
+  _renderAppearance() {
+    renderAppearance(
+      this.content,
+      (title, ...extras) => this._createSectionHeading(title, ...extras),
+      this.tabManager,
+      () => this._renderAppearance(),
+    );
   }
 
-  _createThemeCard(name, theme, isActive) {
-    const card = _el('div', 'theme-card');
-    if (isActive) card.classList.add('theme-active');
-
-    // Preview block
-    const preview = _el('div', 'theme-preview');
-    preview.style.background = theme.background;
-
-    for (const segments of THEME_PREVIEW_LINES) {
-      preview.appendChild(this._createThemePreviewLine(segments, theme));
-    }
-
-    // Color dots
-    const dots = _el('div', 'theme-preview-dots');
-    for (const key of COLOR_DOT_KEYS) {
-      const dot = _el('span', 'theme-dot');
-      dot.style.background = theme[key];
-      dots.appendChild(dot);
-    }
-    preview.appendChild(dots);
-
-    card.appendChild(preview);
-    card.appendChild(_el('div', 'theme-card-label', name));
-
-    card.addEventListener('click', () => {
-      setTerminalTheme(name);
-      this._applyThemeToTerminals();
-      this.renderAppearance();
-    });
-
-    return card;
+  _renderKeybindings() {
+    renderKeybindings(
+      this.content,
+      (title, ...extras) => this._createSectionHeading(title, ...extras),
+      this.shortcutManager,
+      (actionId, index, badgeEl) => this.startRecording(actionId, index, badgeEl),
+      () => this._renderKeybindings(),
+    );
   }
 
-  renderAppearance() {
-    this._createSectionHeading('Appearance');
-
-    // Day/Night mode toggle
-    const modeRow = _el('div', 'theme-mode-row');
-    modeRow.appendChild(_el('span', 'theme-mode-label', 'Mode'));
-
-    const modeToggle = _el('div', 'theme-mode-toggle');
-    const currentMode = getAppTheme();
-
-    for (const { mode, label } of MODE_BUTTONS) {
-      const btn = _el('button', 'theme-mode-btn', label);
-      if (currentMode === mode) btn.classList.add('active');
-      btn.addEventListener('click', () => {
-        setAppTheme(mode);
-        this._switchTerminalForMode(mode);
-        this.renderAppearance();
-      });
-      modeToggle.appendChild(btn);
-    }
-
-    modeRow.appendChild(modeToggle);
-    this.content.appendChild(modeRow);
-
-    // Terminal theme grid
-    this.content.appendChild(_el('h4', 'theme-sub-heading', 'Terminal Theme'));
-
-    const currentThemeName = getTerminalThemeName();
-    const grid = _el('div', 'theme-grid');
-    for (const [name, theme] of Object.entries(TERMINAL_THEMES)) {
-      grid.appendChild(this._createThemeCard(name, theme, name === currentThemeName));
-    }
-    this.content.appendChild(grid);
+  _renderConfigs() {
+    renderConfigs(
+      this.content,
+      (title, ...extras) => this._createSectionHeading(title, ...extras),
+      this.tabManager,
+      () => this._renderConfigs(),
+    );
   }
 
-  _switchTerminalForMode(mode) {
-    if (switchTerminalForMode(mode)) this._applyThemeToTerminals();
-  }
-
-  // ===== Keybindings Section =====
-
-  renderKeybindings() {
-    const resetBtn = _el('button', 'settings-reset-btn', 'Reset to defaults');
-    resetBtn.addEventListener('click', () => {
-      this.shortcutManager.resetToDefaults();
-      this.renderKeybindings();
-    });
-    this._createSectionHeading('Keyboard Shortcuts', resetBtn);
-
-    const list = _el('div', 'keybinding-list');
-
-    for (const binding of this.shortcutManager.getBindingsList()) {
-      const row = _el('div', 'keybinding-row');
-      row.appendChild(_el('div', 'keybinding-label', binding.label));
-
-      const keysContainer = _el('div', 'keybinding-keys');
-      for (let i = 0; i < binding.keys.length; i++) {
-        keysContainer.appendChild(this.createKeyBadge(binding, i));
-      }
-
-      const addBtn = _el('button', 'keybinding-add-btn', '+');
-      addBtn.title = 'Add keybinding';
-      addBtn.addEventListener('click', () => {
-        binding.keys.push('');
-        this.shortcutManager.updateBinding(binding.id, binding.keys);
-        this.renderKeybindings();
-      });
-      keysContainer.appendChild(addBtn);
-
-      row.appendChild(keysContainer);
-      list.appendChild(row);
-    }
-
-    this.content.appendChild(list);
-  }
-
-  createKeyBadge(binding, index) {
-    const wrapper = _el('div', 'keybinding-badge-wrapper');
-
-    const badge = _el('span', 'keybinding-badge');
-    badge.textContent = binding.keys[index]
-      ? formatCombo(binding.keys[index])
-      : 'Not set';
-    if (!binding.keys[index]) badge.classList.add('unset');
-
-    badge.addEventListener('click', () => {
-      this.startRecording(binding.id, index, badge);
-    });
-
-    const removeBtn = _el('span', 'keybinding-badge-remove', '×');
-    removeBtn.addEventListener('click', (e) => {
-      e.stopPropagation();
-      binding.keys.splice(index, 1);
-      this.shortcutManager.updateBinding(binding.id, binding.keys);
-      this.renderKeybindings();
-    });
-
-    wrapper.appendChild(badge);
-    if (binding.keys.length > 1) wrapper.appendChild(removeBtn);
-
-    return wrapper;
-  }
+  // ===== Recording (keybinding capture) =====
 
   startRecording(actionId, index, badgeEl) {
     this.cancelRecording();
@@ -282,121 +155,14 @@ export class SettingsModal {
       this.shortcutManager.updateBinding(actionId, binding.keys);
     }
 
-    this.renderKeybindings();
+    this._renderKeybindings();
   }
 
   cancelRecording() {
     if (this.recording) {
       this.recording.el.classList.remove('recording');
       this.recording = null;
-      this.renderKeybindings();
+      this._renderKeybindings();
     }
   }
-
-  // ===== Workspace Configs Section =====
-
-  _createConfigActions(config) {
-    const handlers = {
-      setDefault: async (e) => { e.stopPropagation(); await window.api.config.setDefault(config.name); this.renderConfigs(); },
-      overwrite: async (e) => {
-        e.stopPropagation();
-        if (!this.tabManager) return;
-        await window.api.config.save(config.name, this.tabManager.serialize());
-        this.renderConfigs();
-      },
-      delete: async (e) => { e.stopPropagation(); await window.api.config.delete(config.name); this.renderConfigs(); },
-    };
-
-    const actions = _el('div', 'config-actions');
-    for (const desc of CONFIG_ACTIONS) {
-      if (desc.hideWhen && config[desc.hideWhen]) continue;
-      actions.appendChild(buildActionBtn({ ...desc, onClick: handlers[desc.action] }));
-    }
-    return actions;
-  }
-
-  _buildConfigRowLeft(config) {
-    const left = _el('div', 'config-row-left');
-
-    const radio = _el('span', 'config-radio');
-    if (config.isDefault) radio.classList.add('config-radio-default');
-    left.appendChild(radio);
-
-    const info = _el('div', 'config-info');
-    const nameEl = _el('span', 'config-name', config.name);
-    if (config.isDefault) {
-      nameEl.appendChild(_el('span', 'config-default-tag', 'default'));
-    }
-    info.appendChild(nameEl);
-    info.appendChild(_el('span', 'config-meta', formatConfigMeta(config.tabCount || 0, config.updatedAt)));
-    left.appendChild(info);
-
-    return left;
-  }
-
-  _createConfigRow(config, currentName) {
-    const row = _el('div', 'config-row');
-    if (config.name === currentName) row.classList.add('config-active');
-
-    row.addEventListener('click', async () => {
-      if (!this.tabManager) return;
-      await this.tabManager.configManager.switchConfig(config.name);
-      this.renderConfigs();
-    });
-
-    row.appendChild(this._buildConfigRowLeft(config));
-    row.appendChild(this._createConfigActions(config));
-    return row;
-  }
-
-  _createBottomActions(currentName) {
-    const handlers = {
-      new: () => this._newConfig(),
-      duplicate: () => this._duplicateConfig(currentName),
-    };
-    const container = _el('div', 'config-bottom-actions');
-    for (const { label, action } of BOTTOM_CONFIG_BUTTONS) {
-      container.appendChild(buildActionBtn({ label, cls: 'config-bottom-btn', onClick: handlers[action] }));
-    }
-    return container;
-  }
-
-  async renderConfigs() {
-    this._createSectionHeading('Workspace Configs');
-
-    const currentName = this.tabManager?.configManager?.currentConfigName || 'Default';
-
-    // Current loaded config indicator
-    const currentBar = _el('div', 'config-current-bar');
-    currentBar.appendChild(_el('span', 'config-current-label', 'Config chargée :'));
-    currentBar.appendChild(_el('span', 'config-current-value', currentName));
-    this.content.appendChild(currentBar);
-
-    // Config list
-    const configs = await window.api.config.list();
-    const list = _el('div', 'config-list');
-    for (const config of configs) {
-      list.appendChild(this._createConfigRow(config, currentName));
-    }
-    this.content.appendChild(list);
-
-    this.content.appendChild(this._createBottomActions(currentName));
-  }
-
-  _newConfig() {
-    if (!this.tabManager) return;
-    this.tabManager.configManager.promptConfigName('', async (name) => {
-      await this.tabManager.configManager.newConfig(name);
-      this.renderConfigs();
-    });
-  }
-
-  _duplicateConfig(currentName) {
-    if (!this.tabManager) return;
-    this.tabManager.configManager.promptConfigName(`${currentName} (copy)`, async (name) => {
-      await this.tabManager.configManager.duplicateConfig(name);
-      this.renderConfigs();
-    });
-  }
-
 }

--- a/src/components/terminal-panel.js
+++ b/src/components/terminal-panel.js
@@ -12,6 +12,14 @@ import {
   isInsertBefore,
 } from '../utils/split-helpers.js';
 import { registerComponent } from '../utils/component-registry.js';
+import { serializeLayout, serializeElement } from '../utils/terminal-serializer.js';
+import {
+  getPanels,
+  detachElement,
+  moveToCenter,
+  insertIntoSplit,
+  wrapInNewSplit,
+} from '../utils/split-layout-ops.js';
 
 export class TerminalPanel {
   constructor(container, cwd) {
@@ -32,33 +40,22 @@ export class TerminalPanel {
 
   // ===== DOM Helpers =====
 
-  /** Return non-handle child panels of a split container. */
-  _getPanels(splitEl) {
-    return Array.from(splitEl.children).filter(
-      (c) => !c.classList.contains('split-handle'),
-    );
-  }
-
-  /** Create a split-handle element wired for resizing. */
   _createSplitHandle(direction, splitEl) {
     const handle = _el('div', `split-handle split-handle-${direction}`);
     this.setupResizeHandle(handle, splitEl, direction);
     return handle;
   }
 
-  /** Create a split-container div with direction and flex. */
   _createSplitContainer(direction, flex = '1') {
     const el = _el('div', `split-container split-${direction}`);
     el.style.flex = String(flex);
     return el;
   }
 
-  /** Check if an element is a split container with the given direction. */
   _isSameDirectionSplit(el, direction) {
     return el?.classList.contains('split-container') && el.classList.contains(`split-${direction}`);
   }
 
-  /** Find the cwd of the terminal whose element matches el. */
   _findTerminalCwd(el) {
     for (const [, node] of this.terminals) {
       if (node.element === el) return node.terminal.cwd;
@@ -66,13 +63,11 @@ export class TerminalPanel {
     return this.cwd;
   }
 
-  /** Reset container to blank terminal-panel state. */
   _resetContainer() {
     this.container.replaceChildren();
     this.container.className = 'terminal-panel';
   }
 
-  /** Build the top bar (drag handle + close button) for a terminal node. */
   _buildTopBar(node) {
     const topBar = _el('div', 'terminal-top-bar');
 
@@ -95,8 +90,6 @@ export class TerminalPanel {
     return topBar;
   }
 
-
-  /** Return the two panels adjacent to a split-handle: [before, after]. */
   _adjacentPanels(handle, splitEl) {
     const children = Array.from(splitEl.children);
     const idx = children.indexOf(handle);
@@ -270,95 +263,29 @@ export class TerminalPanel {
     const sourceEl = sourceNode.element;
     const targetEl = targetNode.element;
 
-    this._detachElement(sourceEl);
+    detachElement(sourceEl);
 
     if (side === 'center') {
-      this._moveToCenter(sourceEl, targetEl);
+      moveToCenter(sourceEl, targetEl);
     } else {
       const direction = directionFromSide(side);
       const before = isInsertBefore(side);
       const parentEl = targetEl.parentElement;
 
       if (this._isSameDirectionSplit(parentEl, direction)) {
-        this._insertIntoSplit(sourceEl, targetEl, direction, before, parentEl);
+        insertIntoSplit(sourceEl, targetEl, direction, before, parentEl,
+          (d, s) => this._createSplitHandle(d, s),
+          (s) => this.equalizeChildren(s));
       } else {
-        this._wrapInNewSplit(sourceEl, targetEl, direction, before, parentEl);
+        wrapInNewSplit(sourceEl, targetEl, direction, before, parentEl,
+          (d, f) => this._createSplitContainer(d, f),
+          (d, s) => this._createSplitHandle(d, s));
       }
     }
 
     this.fitAll();
     this.setActive(sourceNode);
     bus.emit('layout:changed');
-  }
-
-  _moveToCenter(sourceEl, targetEl) {
-    targetEl.parentElement.insertBefore(sourceEl, targetEl);
-    sourceEl.style.flex = targetEl.style.flex;
-  }
-
-  _insertIntoSplit(sourceEl, targetEl, direction, before, parentEl) {
-    const handle = this._createSplitHandle(direction, parentEl);
-    if (before) {
-      targetEl.insertAdjacentElement('beforebegin', sourceEl);
-      sourceEl.insertAdjacentElement('afterend', handle);
-    } else {
-      targetEl.insertAdjacentElement('afterend', handle);
-      handle.insertAdjacentElement('afterend', sourceEl);
-    }
-    this.equalizeChildren(parentEl);
-  }
-
-  _wrapInNewSplit(sourceEl, targetEl, direction, before, parentEl) {
-    const splitEl = this._createSplitContainer(direction, targetEl.style.flex || '1');
-    parentEl.replaceChild(splitEl, targetEl);
-    targetEl.style.flex = '1';
-    sourceEl.style.flex = '1';
-
-    const [first, second] = before ? [sourceEl, targetEl] : [targetEl, sourceEl];
-    splitEl.appendChild(first);
-    splitEl.appendChild(this._createSplitHandle(direction, splitEl));
-    splitEl.appendChild(second);
-  }
-
-  _detachElement(el) {
-    const parentEl = el.parentElement;
-    if (!parentEl) return;
-
-    el.remove();
-
-    if (parentEl.classList.contains('split-container')) {
-      const handles = Array.from(parentEl.querySelectorAll(':scope > .split-handle'));
-      if (handles.length > 0) {
-        handles[handles.length - 1].remove();
-      }
-
-      const remainingPanels = this._getPanels(parentEl);
-
-      if (remainingPanels.length === 1) {
-        const survivor = remainingPanels[0];
-        const grandParent = parentEl.parentElement;
-        if (grandParent) {
-          survivor.style.flex = parentEl.style.flex || '1';
-          grandParent.replaceChild(survivor, parentEl);
-          this._unwrapIfSingle(grandParent);
-        }
-      } else if (remainingPanels.length === 0) {
-        parentEl.remove();
-      }
-    }
-  }
-
-  _unwrapIfSingle(el) {
-    if (!el || !el.classList.contains('split-container')) return;
-    const panels = this._getPanels(el);
-    if (panels.length === 1) {
-      const survivor = panels[0];
-      const parent = el.parentElement;
-      if (parent) {
-        survivor.style.flex = el.style.flex || '1';
-        parent.replaceChild(survivor, el);
-      }
-    }
   }
 
   setActive(node) {
@@ -436,7 +363,7 @@ export class TerminalPanel {
   }
 
   equalizeChildren(splitEl) {
-    const panels = this._getPanels(splitEl);
+    const panels = getPanels(splitEl);
     for (const panel of panels) {
       panel.style.flex = '1';
     }
@@ -493,7 +420,7 @@ export class TerminalPanel {
       return;
     }
 
-    this._detachElement(node.element);
+    detachElement(node.element);
 
     const first = this.terminals.values().next().value;
     if (first) this.setActive(first);
@@ -506,38 +433,11 @@ export class TerminalPanel {
   }
 
   serialize() {
-    const rootEl = this.container.firstElementChild;
-    if (!rootEl) return { type: 'terminal', cwd: this.cwd, flex: 1 };
-    return this.serializeElement(rootEl);
+    return serializeLayout(this.container, (el) => this._findTerminalCwd(el), this.cwd);
   }
 
   serializeElement(el) {
-    if (el.classList.contains('split-container')) {
-      const direction = el.classList.contains('split-horizontal') ? 'horizontal' : 'vertical';
-      const children = [];
-
-      for (const child of el.children) {
-        if (child.classList.contains('split-handle')) continue;
-        children.push(this.serializeElement(child));
-      }
-
-      return {
-        type: 'split',
-        direction,
-        flex: parseFloat(el.style.flex) || 1,
-        children,
-      };
-    }
-
-    if (el.classList.contains('terminal-wrapper')) {
-      return {
-        type: 'terminal',
-        cwd: this._findTerminalCwd(el),
-        flex: parseFloat(el.style.flex) || 1,
-      };
-    }
-
-    return { type: 'terminal', cwd: this.cwd, flex: 1 };
+    return serializeElement(el, (e) => this._findTerminalCwd(e), this.cwd);
   }
 
   applyTheme(theme) {

--- a/src/utils/file-tree-context-menu.js
+++ b/src/utils/file-tree-context-menu.js
@@ -1,0 +1,60 @@
+/**
+ * Context menu builders for the file tree.
+ * Extracted from FileTree to reduce component size.
+ */
+import { bus } from './events.js';
+import { contextMenu } from '../components/context-menu.js';
+import { getRelativePath } from './file-tree-helpers.js';
+
+/**
+ * Build the common context menu items shared between files and directories.
+ * @param {string} entryPath
+ * @param {HTMLElement} nameEl - the name span for inline rename
+ * @param {string} rootCwd - workspace root for relative path
+ * @param {function} promptRenameFn - (entryPath, nameEl) => void
+ * @param {string} [deleteLabel] - custom delete confirmation text
+ * @returns {Array} menu items
+ */
+export function buildCommonContextItems(entryPath, nameEl, rootCwd, promptRenameFn, deleteLabel) {
+  const displayName = entryPath.split('/').pop();
+  return [
+    { label: 'Rename', action: () => promptRenameFn(entryPath, nameEl) },
+    { separator: true },
+    { label: 'Copy Path', action: () => window.api.clipboard.write(entryPath) },
+    { label: 'Copy Relative Path', action: () => window.api.clipboard.write(getRelativePath(entryPath, rootCwd)) },
+    { separator: true },
+    { label: 'Duplicate', action: () => window.api.fs.copy(entryPath) },
+    { label: 'Reveal in Finder', action: () => window.api.shell.showInFolder(entryPath) },
+    { separator: true },
+    {
+      label: 'Delete',
+      action: () => {
+        if (confirm(deleteLabel || `Delete "${displayName}"?`)) {
+          window.api.fs.trash(entryPath);
+        }
+      },
+    },
+  ];
+}
+
+/**
+ * Show a file context menu.
+ */
+export function showFileContextMenu(x, y, entryPath, nameEl, rootCwd, promptRenameFn) {
+  contextMenu.show(x, y, buildCommonContextItems(entryPath, nameEl, rootCwd, promptRenameFn));
+}
+
+/**
+ * Show a directory context menu with additional directory-specific items.
+ */
+export function showDirContextMenu(x, y, dirPath, rootCwd, contentEl, depth, expandedDirs, nameEl, promptRenameFn, promptNewEntryFn) {
+  const dirName = dirPath.split('/').pop();
+  contextMenu.show(x, y, [
+    { label: 'New File', action: () => promptNewEntryFn(dirPath, contentEl, depth, expandedDirs, 'file') },
+    { label: 'New Folder', action: () => promptNewEntryFn(dirPath, contentEl, depth, expandedDirs, 'folder') },
+    { separator: true },
+    { label: 'Open as Workspace', action: () => bus.emit('workspace:openFromFolder', { cwd: dirPath }) },
+    { separator: true },
+    ...buildCommonContextItems(dirPath, nameEl, rootCwd, promptRenameFn, `Delete folder "${dirName}" and all its contents?`),
+  ]);
+}

--- a/src/utils/split-layout-ops.js
+++ b/src/utils/split-layout-ops.js
@@ -1,0 +1,121 @@
+/**
+ * Split layout DOM operations for terminal panel.
+ * Handles element detachment, unwrapping single-child splits, and
+ * move operations (center/insert/wrap).
+ * Extracted from TerminalPanel to reduce component size.
+ */
+
+/**
+ * Get non-handle child panels of a split container.
+ * @param {HTMLElement} splitEl
+ * @returns {HTMLElement[]}
+ */
+export function getPanels(splitEl) {
+  return Array.from(splitEl.children).filter(
+    (c) => !c.classList.contains('split-handle'),
+  );
+}
+
+/**
+ * Unwrap a split container if it has only one child panel.
+ * @param {HTMLElement} el
+ */
+export function unwrapIfSingle(el) {
+  if (!el || !el.classList.contains('split-container')) return;
+  const panels = getPanels(el);
+  if (panels.length === 1) {
+    const survivor = panels[0];
+    const parent = el.parentElement;
+    if (parent) {
+      survivor.style.flex = el.style.flex || '1';
+      parent.replaceChild(survivor, el);
+    }
+  }
+}
+
+/**
+ * Detach an element from its parent split container, cleaning up
+ * handles and unwrapping if the parent becomes a single-child split.
+ * @param {HTMLElement} el
+ */
+export function detachElement(el) {
+  const parentEl = el.parentElement;
+  if (!parentEl) return;
+
+  el.remove();
+
+  if (parentEl.classList.contains('split-container')) {
+    const handles = Array.from(parentEl.querySelectorAll(':scope > .split-handle'));
+    if (handles.length > 0) {
+      handles[handles.length - 1].remove();
+    }
+
+    const remainingPanels = getPanels(parentEl);
+
+    if (remainingPanels.length === 1) {
+      const survivor = remainingPanels[0];
+      const grandParent = parentEl.parentElement;
+      if (grandParent) {
+        survivor.style.flex = parentEl.style.flex || '1';
+        grandParent.replaceChild(survivor, parentEl);
+        unwrapIfSingle(grandParent);
+      }
+    } else if (remainingPanels.length === 0) {
+      parentEl.remove();
+    }
+  }
+}
+
+/**
+ * Move source element to replace / swap with target (center drop).
+ * @param {HTMLElement} sourceEl
+ * @param {HTMLElement} targetEl
+ */
+export function moveToCenter(sourceEl, targetEl) {
+  targetEl.parentElement.insertBefore(sourceEl, targetEl);
+  sourceEl.style.flex = targetEl.style.flex;
+}
+
+/**
+ * Insert source into an existing same-direction split container.
+ * @param {HTMLElement} sourceEl
+ * @param {HTMLElement} targetEl
+ * @param {string} direction
+ * @param {boolean} before - insert before target?
+ * @param {HTMLElement} parentEl - the split container
+ * @param {function} createHandle - (direction, splitEl) => handle element
+ * @param {function} equalize - (splitEl) => void
+ */
+export function insertIntoSplit(sourceEl, targetEl, direction, before, parentEl, createHandle, equalize) {
+  const handle = createHandle(direction, parentEl);
+  if (before) {
+    targetEl.insertAdjacentElement('beforebegin', sourceEl);
+    sourceEl.insertAdjacentElement('afterend', handle);
+  } else {
+    targetEl.insertAdjacentElement('afterend', handle);
+    handle.insertAdjacentElement('afterend', sourceEl);
+  }
+  equalize(parentEl);
+}
+
+/**
+ * Wrap source and target in a new split container.
+ * @param {HTMLElement} sourceEl
+ * @param {HTMLElement} targetEl
+ * @param {string} direction
+ * @param {boolean} before - insert source before target?
+ * @param {HTMLElement} parentEl - current parent of targetEl
+ * @param {function} createSplitContainer - (direction, flex) => split element
+ * @param {function} createHandle - (direction, splitEl) => handle element
+ */
+export function wrapInNewSplit(sourceEl, targetEl, direction, before, parentEl, createSplitContainer, createHandle) {
+  const splitEl = createSplitContainer(direction, targetEl.style.flex || '1');
+  parentEl.replaceChild(splitEl, targetEl);
+  targetEl.style.flex = '1';
+  sourceEl.style.flex = '1';
+
+  const [first, second] = before ? [sourceEl, targetEl] : [targetEl, sourceEl];
+  splitEl.appendChild(first);
+  splitEl.appendChild(createHandle(direction, splitEl));
+  splitEl.appendChild(second);
+}

--- a/src/utils/terminal-serializer.js
+++ b/src/utils/terminal-serializer.js
@@ -1,0 +1,54 @@
+/**
+ * Serialization / deserialization helpers for terminal split layout.
+ * Extracted from TerminalPanel to reduce component size.
+ * No business logic changes — pure structural refactoring.
+ */
+
+/**
+ * Serialize a single DOM element into a layout tree descriptor.
+ * @param {HTMLElement} el - either a split-container or terminal-wrapper
+ * @param {function} findTerminalCwd - (el) => cwd string
+ * @param {string} fallbackCwd - default cwd if terminal not found
+ * @returns {Object} tree descriptor
+ */
+export function serializeElement(el, findTerminalCwd, fallbackCwd) {
+  if (el.classList.contains('split-container')) {
+    const direction = el.classList.contains('split-horizontal') ? 'horizontal' : 'vertical';
+    const children = [];
+
+    for (const child of el.children) {
+      if (child.classList.contains('split-handle')) continue;
+      children.push(serializeElement(child, findTerminalCwd, fallbackCwd));
+    }
+
+    return {
+      type: 'split',
+      direction,
+      flex: parseFloat(el.style.flex) || 1,
+      children,
+    };
+  }
+
+  if (el.classList.contains('terminal-wrapper')) {
+    return {
+      type: 'terminal',
+      cwd: findTerminalCwd(el),
+      flex: parseFloat(el.style.flex) || 1,
+    };
+  }
+
+  return { type: 'terminal', cwd: fallbackCwd, flex: 1 };
+}
+
+/**
+ * Serialize the entire terminal panel layout.
+ * @param {HTMLElement} container - the terminal-panel container
+ * @param {function} findTerminalCwd - (el) => cwd string
+ * @param {string} fallbackCwd - default cwd
+ * @returns {Object} tree descriptor
+ */
+export function serializeLayout(container, findTerminalCwd, fallbackCwd) {
+  const rootEl = container.firstElementChild;
+  if (!rootEl) return { type: 'terminal', cwd: fallbackCwd, flex: 1 };
+  return serializeElement(rootEl, findTerminalCwd, fallbackCwd);
+}


### PR DESCRIPTION
## Refactoring

Décomposition des 5 composants les plus volumineux en modules spécialisés :

| Fichier | Avant | Après | Réduction |
|---------|-------|-------|-----------|
| flow-view.js | 635 | 406 | -36% |
| terminal-panel.js | 554 | 454 | -18% |
| file-viewer.js | 470 | 399 | -15% |
| file-tree.js | 412 | 378 | -8% |
| settings-modal.js | 405 | 171 | -58% |

### 9 modules extraits

**Composants** : `flow-card-terminal.js`, `flow-category-renderer.js`, `file-viewer-webview.js`, `settings-appearance.js`, `settings-keybindings.js`, `settings-configs.js`

**Utilitaires** : `terminal-serializer.js`, `split-layout-ops.js`, `file-tree-context-menu.js`

Closes #3

## Vérifications

- [x] Build OK
- [x] Tests OK (204 passed)

---

📂 Path local : `/Users/rekta/projet/coding/refactor-pikagent`
🤖 PR créée automatiquement par l'Agent Refactor