### PR TITLE
refactor: extract PollingTimer and deduplicate flow-view helpers

### DIFF
--- a/main/flow-manager.js
+++ b/main/flow-manager.js
@@ -10,12 +10,13 @@ const {
   shouldRun, buildFlowCommand, createOutputProcessor,
 } = require('./flow-helpers');
 const { safeSend } = require('./ipc-helpers');
+const { PollingTimer } = require('./polling-timer');
 
 const ensureDir = ensureDirOnce(LOGS_DIR);
 
 class FlowManager {
   constructor() {
-    this._timer = null;
+    this._poller = new PollingTimer(SCHEDULER_INTERVAL_MS, () => this._tick());
     this._getWindow = null;
     this._ptyManager = null;
     this._runningFlows = new Map();
@@ -24,15 +25,11 @@ class FlowManager {
   start(getWindow, ptyManager) {
     this._getWindow = getWindow;
     this._ptyManager = ptyManager;
-    this._timer = setInterval(() => this._tick(), SCHEDULER_INTERVAL_MS);
-    this._tick();
+    this._poller.start();
   }
 
   stop() {
-    if (this._timer) {
-      clearInterval(this._timer);
-      this._timer = null;
-    }
+    this._poller.stop();
   }
 
   // --- Window IPC helper ---

--- a/main/polling-timer.js
+++ b/main/polling-timer.js
@@ -1,0 +1,30 @@
+/**
+ * Reusable polling timer with start/stop lifecycle.
+ * Shared by FlowManager and SessionManager.
+ */
+class PollingTimer {
+  constructor(intervalMs, callback) {
+    this._intervalMs = intervalMs;
+    this._callback = callback;
+    this._timer = null;
+  }
+
+  start() {
+    if (this._timer) return;
+    this._timer = setInterval(() => this._callback(), this._intervalMs);
+    this._callback();
+  }
+
+  stop() {
+    if (this._timer) {
+      clearInterval(this._timer);
+      this._timer = null;
+    }
+  }
+
+  get running() {
+    return this._timer !== null;
+  }
+}
+
+module.exports = { PollingTimer };

--- a/main/session-manager.js
+++ b/main/session-manager.js
@@ -2,6 +2,7 @@ const os = require('os');
 const { BASE_DIR, SESSIONS_FILE } = require('./paths');
 const { readJson, writeJson, ensureDirOnce } = require('./fs-utils');
 const { generateSessionId, durationSec, isFlowTerminal, buildEndedRecord, buildActiveRecord, trimSessions } = require('./session-helpers');
+const { PollingTimer } = require('./polling-timer');
 
 const POLL_INTERVAL_MS = 5000;
 
@@ -9,7 +10,7 @@ const ensureDir = ensureDirOnce(BASE_DIR);
 
 class SessionManager {
   constructor() {
-    this._timer = null;
+    this._poller = new PollingTimer(POLL_INTERVAL_MS, () => this._poll());
     this._ptyManager = null;
     this._previousAgents = {};
     this._activeSessions = {};
@@ -20,15 +21,11 @@ class SessionManager {
   async start(ptyManager) {
     this._ptyManager = ptyManager;
     await this._loadAll();
-    this._timer = setInterval(() => this._poll(), POLL_INTERVAL_MS);
-    this._poll();
+    this._poller.start();
   }
 
   stop() {
-    if (this._timer) {
-      clearInterval(this._timer);
-      this._timer = null;
-    }
+    this._poller.stop();
     for (const termId of Object.keys(this._activeSessions)) {
       this._endSession(termId, 'interrupted');
     }

--- a/src/utils/flow-view-helpers.js
+++ b/src/utils/flow-view-helpers.js
@@ -59,6 +59,25 @@ export function buildDotTooltip(run) {
 }
 
 /**
+ * Build a Map keyed by flow.id for fast lookup.
+ * @param {Array} flows
+ * @returns {Map<string, Object>}
+ */
+function buildFlowMap(flows) {
+  return new Map(flows.map(f => [f.id, f]));
+}
+
+/**
+ * Resolve an array of flow IDs to flow objects using a flow map.
+ * @param {string[]} ids
+ * @param {Map<string, Object>} flowMap
+ * @returns {Array}
+ */
+function resolveIds(ids, flowMap) {
+  return ids.map(id => flowMap.get(id)).filter(Boolean);
+}
+
+/**
  * Return flows belonging to a given category, ordered by catData.order.
  * @param {Array} flows - all flow objects
  * @param {Object} order - catData.order mapping catId → [flowId, …]
@@ -66,9 +85,7 @@ export function buildDotTooltip(run) {
  * @returns {Array} ordered flows for this category
  */
 export function getFlowsForCategory(flows, order, catId) {
-  const orderedIds = order[catId] || [];
-  const flowMap = new Map(flows.map(f => [f.id, f]));
-  return orderedIds.map(id => flowMap.get(id)).filter(Boolean);
+  return resolveIds(order[catId] || [], buildFlowMap(flows));
 }
 
 /**
@@ -83,13 +100,14 @@ export function getUncategorizedFlows(flows, order) {
   for (const ids of Object.values(order)) {
     for (const id of ids) assigned.add(id);
   }
-  const unordered = flows.filter(f => !assigned.has(f.id));
+
+  const flowMap = buildFlowMap(flows);
   const orderedIds = order[UNCATEGORIZED] || [];
-  const flowMap = new Map(flows.map(f => [f.id, f]));
-  const ordered = orderedIds.map(id => flowMap.get(id)).filter(Boolean);
+  const ordered = resolveIds(orderedIds, flowMap);
   const inOrder = new Set(orderedIds);
-  for (const f of unordered) {
-    if (!inOrder.has(f.id)) ordered.push(f);
+
+  for (const f of flows) {
+    if (!assigned.has(f.id) && !inOrder.has(f.id)) ordered.push(f);
   }
   return ordered;
 }


### PR DESCRIPTION
## Refactoring

- **PollingTimer** : extracted reusable `PollingTimer` class in `main/polling-timer.js` replacing the duplicated `setInterval`/`clearInterval` start/stop pattern in both `FlowManager` and `SessionManager`.
- **Flow map helpers** : extracted `buildFlowMap()` and `resolveIds()` in `src/utils/flow-view-helpers.js` to eliminate the duplicate `new Map(flows.map(f => [f.id, f]))` pattern in `getFlowsForCategory` and `getUncategorizedFlows`.
- Settings section and CRUD patterns were already well-factored (shared `createSectionHeading` callback and `fs-utils.js`), no further changes needed.

Closes #22

## Fichier(s) modifié(s)

- `main/polling-timer.js` (new)
- `main/flow-manager.js`
- `main/session-manager.js`
- `src/utils/flow-view-helpers.js`

## Vérifications

- [x] Build OK
- [x] Tests OK (204 passed)

---

📂 Path local : `/Users/rekta/projet/coding/refactor-pikagent`
🤖 PR créée automatiquement par l'Agent Refactor