### PR TITLE
refactor: dynamic cleanup registry in ipc-handlers

### DIFF
--- a/main/flow-manager.js
+++ b/main/flow-manager.js
@@ -226,6 +226,10 @@ class FlowManager {
     await this.save(flow);
   }
 
+  cleanup() {
+    this.stop();
+  }
+
   registerHandlers(ipcMain, { getWindow, ptyManager }) {
     const { registerForward, registerSpread } = require('./ipc-helpers');
 

--- a/main/fs-manager.js
+++ b/main/fs-manager.js
@@ -135,4 +135,8 @@ function registerHandlers(ipcMain, { getWindow }) {
   });
 }
 
-module.exports = { readDirectory, readFile, writeFile, makeDir, copyEntry, copyFileTo, renameEntry, getHomedir, watchDir, unwatchDir, unwatchAll, registerHandlers };
+function cleanup() {
+  unwatchAll();
+}
+
+module.exports = { readDirectory, readFile, writeFile, makeDir, copyEntry, copyFileTo, renameEntry, getHomedir, watchDir, unwatchDir, unwatchAll, cleanup, registerHandlers };

--- a/main/ipc-handlers.js
+++ b/main/ipc-handlers.js
@@ -34,14 +34,9 @@ function register(getWindow) {
 }
 
 function cleanup() {
-  const sessionManager = require('./session-manager');
-  const flowManager = require('./flow-manager');
-  const fsManager = require('./fs-manager');
-
-  sessionManager.stop();
-  flowManager.stop();
-  ptyManager.killAll();
-  fsManager.unwatchAll();
+  for (const mod of HANDLER_MODULES) {
+    if (typeof mod.cleanup === 'function') mod.cleanup();
+  }
 }
 
 module.exports = { register, cleanup };

--- a/main/pty-manager.js
+++ b/main/pty-manager.js
@@ -112,6 +112,10 @@ class PtyManager {
     this.processes.clear();
   }
 
+  cleanup() {
+    this.killAll();
+  }
+
   registerHandlers(ipcMain, { getWindow, sessionManager }) {
     const { safeSend, registerForward, registerSpread } = require('./ipc-helpers');
 

--- a/main/session-manager.js
+++ b/main/session-manager.js
@@ -115,6 +115,10 @@ class SessionManager {
     return Object.values(this._activeSessions).map(buildActiveRecord);
   }
 
+  cleanup() {
+    this.stop();
+  }
+
   registerHandlers(_ipcMain, { ptyManager }) {
     this.start(ptyManager);
   }

--- a/main/usage-manager.js
+++ b/main/usage-manager.js
@@ -149,4 +149,4 @@ function registerHandlers(ipcMain, { sessionManager }) {
   ]);
 }
 
-module.exports = { init, getMetrics, registerHandlers };
+module.exports = { getMetrics, registerHandlers };


### PR DESCRIPTION
## Refactoring

- **Dynamic cleanup** : replaced hardcoded `cleanup()` in `ipc-handlers.js` (which re-required 3 specific managers) with a dynamic loop over `HANDLER_MODULES`, calling `cleanup()` on each module that defines it.
- **Added `cleanup()` methods** to `session-manager`, `flow-manager`, `pty-manager`, and `fs-manager`.
- **Removed `init` export** from `usage-manager.js` — it was only called internally via `registerHandlers`, no external consumers.

The `register()` function already used the registry pattern (from PR #18). Now `cleanup()` is also decoupled — no new manager requires a manual wire-up in `ipc-handlers.js`.

Closes #14

## Fichier(s) modifié(s)

- `main/ipc-handlers.js`
- `main/session-manager.js`
- `main/flow-manager.js`
- `main/pty-manager.js`
- `main/fs-manager.js`
- `main/usage-manager.js`

## Vérifications

- [x] Build OK
- [x] Tests OK (204 passed)

---

📂 Path local : `/Users/rekta/projet/coding/refactor-pikagent`
🤖 PR créée automatiquement par l'Agent Refactor