### PR TITLE
refactor: extract card renderer and drop indicator from large components

### DIFF
--- a/src/components/flow-view.js
+++ b/src/components/flow-view.js
@@ -1,16 +1,14 @@
 import { openFlowModal } from './flow-modal.js';
-import { formatSchedule } from '../utils/flow-schedule-helpers.js';
 import { _el, showPromptDialog, setupInlineInput } from '../utils/dom.js';
 import { generateId } from '../utils/id.js';
 import { registerComponent } from '../utils/component-registry.js';
 import {
-  EMPTY_LIST_MESSAGE, MAX_VISIBLE_RUNS, UNCATEGORIZED,
-  HEADER_BUTTONS,
-  buildDotTooltip, buildCardActionEntries,
+  EMPTY_LIST_MESSAGE, UNCATEGORIZED, HEADER_BUTTONS,
   getFlowsForCategory, getUncategorizedFlows,
   removeFlowFromOrder, moveFlowInOrder, deleteCategoryData,
   getLastRun,
 } from '../utils/flow-view-helpers.js';
+import { createCardHeader } from '../utils/flow-card-renderer.js';
 import { FlowCardTerminalManager } from './flow-card-terminal.js';
 import { createCategoryGroup, cleanupAllDragState } from './flow-category-renderer.js';
 
@@ -181,7 +179,20 @@ export class FlowView {
 
     this._setupCardDrag(card, flow.id, catId);
 
-    const headerRow = this._createCardHeader(flow, isRunning, isExpanded);
+    const headerRow = createCardHeader(flow, isRunning, isExpanded, {
+      onToggleOutput: (flowId) => {
+        if (this._expandedCards.has(flowId)) this._expandedCards.delete(flowId);
+        else this._expandedCards.add(flowId);
+        this._renderList();
+      },
+      onShowLog: (f, run) => this._termManager.showRunLog(f, run),
+      actionHandlers: {
+        run:    () => window.api.flow.runNow(flow.id),
+        toggle: async () => { await window.api.flow.toggle(flow.id); this.refresh(); },
+        edit:   () => this._openModal(flow),
+        delete: () => this._deleteFlow(flow.id),
+      },
+    });
     card.appendChild(headerRow);
 
     const body = this._buildCardBody(flow, isRunning, isExpanded);
@@ -248,65 +259,6 @@ export class FlowView {
     });
   }
 
-  _createCardHeader(flow, isRunning, isExpanded) {
-    const headerRow = _el('div', 'flow-card-header');
-
-    const info = _el('div', 'flow-card-info');
-    const nameRow = _el('div', 'flow-card-name-row');
-    nameRow.appendChild(_el('span', 'flow-card-name', flow.name));
-    if (isRunning) nameRow.appendChild(_el('span', 'flow-running-badge', 'En cours...'));
-    if (isRunning) {
-      nameRow.appendChild(_el('button', {
-        className: 'flow-output-toggle',
-        textContent: isExpanded ? '▾ Sortie' : '▸ Sortie',
-        title: isExpanded ? 'Masquer la sortie' : 'Afficher la sortie',
-        onClick: (e) => {
-          e.stopPropagation();
-          if (this._expandedCards.has(flow.id)) this._expandedCards.delete(flow.id);
-          else this._expandedCards.add(flow.id);
-          this._renderList();
-        },
-      }));
-    }
-    info.appendChild(nameRow);
-    info.appendChild(_el('div', 'flow-card-schedule', formatSchedule(flow.schedule)));
-    headerRow.appendChild(info);
-
-    const right = _el('div', 'flow-card-right');
-    right.appendChild(this._createRunDots(flow));
-    right.appendChild(this._createCardActions(flow, isRunning));
-    headerRow.appendChild(right);
-
-    return headerRow;
-  }
-
-  _createRunDots(flow) {
-    const dots = _el('div', 'flow-card-dots');
-    for (const run of (flow.runs || []).slice(-MAX_VISIBLE_RUNS)) {
-      const dot = _el('button', `flow-dot flow-dot-${run.status}`);
-      dot.title = buildDotTooltip(run);
-      dot.addEventListener('click', (e) => {
-        e.stopPropagation();
-        this._termManager.showRunLog(flow, run);
-      });
-      dots.appendChild(dot);
-    }
-    return dots;
-  }
-
-  _createCardActions(flow, isRunning) {
-    const actions = _el('div', 'flow-card-actions');
-    const handlers = {
-      run:    () => window.api.flow.runNow(flow.id),
-      toggle: async () => { await window.api.flow.toggle(flow.id); this.refresh(); },
-      edit:   () => this._openModal(flow),
-      delete: () => this._deleteFlow(flow.id),
-    };
-    for (const { icon, title, action, cls } of buildCardActionEntries(flow, isRunning)) {
-      actions.appendChild(this._createActionButton(icon, title, handlers[action], cls));
-    }
-    return actions;
-  }
 
   async _deleteFlow(flowId) {
     this._termManager.disposeLiveTerminal(flowId);
@@ -362,15 +314,6 @@ export class FlowView {
     if (!deleteCategoryData(this.catData, catId)) return;
     await this._persistCategories();
     this._renderList();
-  }
-
-  // === Action button helper ===
-
-  _createActionButton(icon, title, onClick, extraClass = '') {
-    const btn = _el('button', extraClass ? `flow-card-btn ${extraClass}` : 'flow-card-btn', icon);
-    btn.title = title;
-    btn.addEventListener('click', (e) => { e.stopPropagation(); onClick(); });
-    return btn;
   }
 
   // ===== Creation / Edit Modal =====

--- a/src/components/terminal-panel.js
+++ b/src/components/terminal-panel.js
@@ -2,19 +2,19 @@ import { bus } from '../utils/events.js';
 import { _el } from '../utils/dom.js';
 import { trackMouse } from '../utils/drag-helpers.js';
 import { TerminalInstance } from '../utils/terminal-instance.js';
-import { DRAG_GRIP, SplitNode, RESIZE_CURSOR, DIRECTION_PROPS } from '../utils/terminal-panel-helpers.js';
 import {
-  detectDropSide,
-  computeIndicatorRect,
-  computeResizeRatio,
+  DRAG_GRIP, SplitNode, RESIZE_CURSOR,
+  isSameDirectionSplit, createSplitContainer, adjacentPanels, equalizeChildren, doResize,
+} from '../utils/terminal-panel-helpers.js';
+import {
   findClosestInDirection,
   directionFromSide,
   isInsertBefore,
 } from '../utils/split-helpers.js';
+import { DropIndicatorManager } from '../utils/terminal-drop-indicator.js';
 import { registerComponent } from '../utils/component-registry.js';
 import { serializeLayout, serializeElement } from '../utils/terminal-serializer.js';
 import {
-  getPanels,
   detachElement,
   moveToCenter,
   insertIntoSplit,
@@ -31,9 +31,7 @@ export class TerminalPanel {
 
     // Drag and drop state
     this._dragSourceId = null;
-    this._dropIndicator = null;
-    this._dropTarget = null;
-    this._dropSide = null;
+    this._drop = new DropIndicatorManager(container);
 
     this.init();
   }
@@ -44,16 +42,6 @@ export class TerminalPanel {
     const handle = _el('div', `split-handle split-handle-${direction}`);
     this.setupResizeHandle(handle, splitEl, direction);
     return handle;
-  }
-
-  _createSplitContainer(direction, flex = '1') {
-    const el = _el('div', `split-container split-${direction}`);
-    el.style.flex = String(flex);
-    return el;
-  }
-
-  _isSameDirectionSplit(el, direction) {
-    return el?.classList.contains('split-container') && el.classList.contains(`split-${direction}`);
   }
 
   _findTerminalCwd(el) {
@@ -90,19 +78,6 @@ export class TerminalPanel {
     return topBar;
   }
 
-  _adjacentPanels(handle, splitEl) {
-    const children = Array.from(splitEl.children);
-    const idx = children.indexOf(handle);
-    let before = null, after = null;
-    for (let i = idx - 1; i >= 0; i--) {
-      if (!children[i].classList.contains('split-handle')) { before = children[i]; break; }
-    }
-    for (let i = idx + 1; i < children.length; i++) {
-      if (!children[i].classList.contains('split-handle')) { after = children[i]; break; }
-    }
-    return [before, after];
-  }
-
   init() {
     this._resetContainer();
 
@@ -136,7 +111,7 @@ export class TerminalPanel {
       return node;
     }
 
-    const splitEl = this._createSplitContainer(tree.direction, tree.flex || 1);
+    const splitEl = createSplitContainer(tree.direction, tree.flex || 1);
 
     const splitNode = new SplitNode('split');
     splitNode.direction = tree.direction;
@@ -186,72 +161,21 @@ export class TerminalPanel {
 
       this._dragSourceId = sourceNode.terminal.id;
       sourceNode.element.classList.add('dragging');
-      this._createDropIndicator();
+      this._drop.create();
 
       trackMouse('grabbing',
-        (ev) => this._updateDropTarget(ev.clientX, ev.clientY),
+        (ev) => this._drop.update(ev.clientX, ev.clientY, this.terminals, this._dragSourceId),
         () => {
           sourceNode.element.classList.remove('dragging');
-          this._removeDropIndicator();
-          if (this._dropTarget && this._dropSide && this._dropTarget !== this._dragSourceId) {
-            this.moveTerminal(this._dragSourceId, this._dropTarget, this._dropSide);
+          const { targetId, side } = this._drop;
+          this._drop.remove();
+          if (targetId && side && targetId !== this._dragSourceId) {
+            this.moveTerminal(this._dragSourceId, targetId, side);
           }
           this._dragSourceId = null;
-          this._dropTarget = null;
-          this._dropSide = null;
         },
       );
     });
-  }
-
-  _createDropIndicator() {
-    this._dropIndicator = _el('div', 'drop-indicator');
-    this.container.appendChild(this._dropIndicator);
-  }
-
-  _removeDropIndicator() {
-    if (this._dropIndicator) {
-      this._dropIndicator.remove();
-      this._dropIndicator = null;
-    }
-    this.container.querySelectorAll('.drop-hover').forEach((el) => el.classList.remove('drop-hover'));
-  }
-
-  _updateDropTarget(mx, my) {
-    this._dropTarget = null;
-    this._dropSide = null;
-    if (this._dropIndicator) this._dropIndicator.style.display = 'none';
-
-    this.container.querySelectorAll('.drop-hover').forEach((el) => el.classList.remove('drop-hover'));
-
-    for (const [termId, node] of this.terminals) {
-      if (termId === this._dragSourceId) continue;
-
-      const rect = node.element.getBoundingClientRect();
-      if (mx < rect.left || mx > rect.right || my < rect.top || my > rect.bottom) continue;
-
-      const relX = (mx - rect.left) / rect.width;
-      const relY = (my - rect.top) / rect.height;
-      const side = detectDropSide(relX, relY);
-
-      this._dropTarget = termId;
-      this._dropSide = side;
-      node.element.classList.add('drop-hover');
-
-      this._positionIndicator(rect, side);
-      return;
-    }
-  }
-
-  _positionIndicator(rect, side) {
-    if (!this._dropIndicator) return;
-    const s = this._dropIndicator.style;
-    const r = computeIndicatorRect(rect, side);
-    s.display = 'block';
-    s.left = `${r.left}px`;
-    s.top = `${r.top}px`;
-    s.width = `${r.width}px`;
-    s.height = `${r.height}px`;
   }
 
   moveTerminal(sourceId, targetId, side) {
@@ -272,13 +196,13 @@ export class TerminalPanel {
       const before = isInsertBefore(side);
       const parentEl = targetEl.parentElement;
 
-      if (this._isSameDirectionSplit(parentEl, direction)) {
+      if (isSameDirectionSplit(parentEl, direction)) {
         insertIntoSplit(sourceEl, targetEl, direction, before, parentEl,
           (d, s) => this._createSplitHandle(d, s),
-          (s) => this.equalizeChildren(s));
+          (s) => equalizeChildren(s));
       } else {
         wrapInNewSplit(sourceEl, targetEl, direction, before, parentEl,
-          (d, f) => this._createSplitContainer(d, f),
+          (d, f) => createSplitContainer(d, f),
           (d, s) => this._createSplitHandle(d, s));
       }
     }
@@ -336,19 +260,19 @@ export class TerminalPanel {
     const sourceCwd = targetNode.terminal ? targetNode.terminal.cwd : this.cwd;
     const newTermNode = this.createTerminalNode(sourceCwd);
 
-    if (this._isSameDirectionSplit(parentEl, direction)) {
+    if (isSameDirectionSplit(parentEl, direction)) {
       const handle = this._createSplitHandle(direction, parentEl);
       targetNode.element.insertAdjacentElement('afterend', handle);
       handle.insertAdjacentElement('afterend', newTermNode.element);
-      this.equalizeChildren(parentEl);
+      equalizeChildren(parentEl);
     } else {
-      const splitEl = this._createSplitContainer(direction, targetNode.element.style.flex || '1');
+      const splitEl = createSplitContainer(direction, targetNode.element.style.flex || '1');
       parentEl.replaceChild(splitEl, targetNode.element);
 
       splitEl.appendChild(targetNode.element);
       splitEl.appendChild(this._createSplitHandle(direction, splitEl));
       splitEl.appendChild(newTermNode.element);
-      this.equalizeChildren(splitEl);
+      equalizeChildren(splitEl);
 
       if (this.root === targetNode) {
         const newSplitNode = new SplitNode('split');
@@ -362,39 +286,14 @@ export class TerminalPanel {
     this.setActive(newTermNode);
   }
 
-  equalizeChildren(splitEl) {
-    const panels = getPanels(splitEl);
-    for (const panel of panels) {
-      panel.style.flex = '1';
-    }
-  }
-
   setupResizeHandle(handle, splitEl, direction) {
     handle.addEventListener('mousedown', (e) => {
       e.preventDefault();
       trackMouse(RESIZE_CURSOR[direction],
-        (ev) => this._doResize(ev, handle, splitEl, direction),
+        (ev) => doResize(ev, handle, splitEl, direction, () => this.fitAll()),
         () => bus.emit('layout:changed'),
       );
     });
-  }
-
-  _doResize(e, handle, splitEl, direction) {
-    const [panelBefore, panelAfter] = this._adjacentPanels(handle, splitEl);
-    if (!panelBefore || !panelAfter) return;
-
-    const { size, start, mouse } = DIRECTION_PROPS[direction];
-    const rectBefore = panelBefore.getBoundingClientRect();
-    const rectAfter = panelAfter.getBoundingClientRect();
-
-    const totalSize = rectBefore[size] + rectAfter[size];
-    const ratio = computeResizeRatio(e[mouse], rectBefore[start], totalSize);
-
-    const totalFlex = (parseFloat(panelBefore.style.flex) || 1) + (parseFloat(panelAfter.style.flex) || 1);
-    panelBefore.style.flex = `${totalFlex * ratio}`;
-    panelAfter.style.flex = `${totalFlex * (1 - ratio)}`;
-
-    this.fitAll();
   }
 
   fitAll() {

--- a/src/utils/flow-card-renderer.js
+++ b/src/utils/flow-card-renderer.js
@@ -1,0 +1,87 @@
+/**
+ * Pure rendering helpers for flow cards.
+ * Extracted from flow-view.js to reduce component size.
+ */
+import { _el } from './dom.js';
+import { formatSchedule } from './flow-schedule-helpers.js';
+import { MAX_VISIBLE_RUNS, buildDotTooltip, buildCardActionEntries } from './flow-view-helpers.js';
+
+/**
+ * Create a single action button for a flow card.
+ */
+export function createFlowActionButton(icon, title, onClick, extraClass = '') {
+  const btn = _el('button', extraClass ? `flow-card-btn ${extraClass}` : 'flow-card-btn', icon);
+  btn.title = title;
+  btn.addEventListener('click', (e) => { e.stopPropagation(); onClick(); });
+  return btn;
+}
+
+/**
+ * Create the run-status dots row for a flow card.
+ * @param {Object} flow
+ * @param {function} onShowLog - (flow, run) => void
+ */
+export function createRunDots(flow, onShowLog) {
+  const dots = _el('div', 'flow-card-dots');
+  for (const run of (flow.runs || []).slice(-MAX_VISIBLE_RUNS)) {
+    const dot = _el('button', `flow-dot flow-dot-${run.status}`);
+    dot.title = buildDotTooltip(run);
+    dot.addEventListener('click', (e) => {
+      e.stopPropagation();
+      onShowLog(flow, run);
+    });
+    dots.appendChild(dot);
+  }
+  return dots;
+}
+
+/**
+ * Create the action buttons row for a flow card.
+ * @param {Object} flow
+ * @param {boolean} isRunning
+ * @param {Object} handlers - { run, toggle, edit, delete }
+ */
+export function createCardActions(flow, isRunning, handlers) {
+  const actions = _el('div', 'flow-card-actions');
+  for (const { icon, title, action, cls } of buildCardActionEntries(flow, isRunning)) {
+    actions.appendChild(createFlowActionButton(icon, title, handlers[action], cls));
+  }
+  return actions;
+}
+
+/**
+ * Create the full header row for a flow card.
+ * @param {Object} flow
+ * @param {boolean} isRunning
+ * @param {boolean} isExpanded
+ * @param {Object} opts - { onToggleOutput, onShowLog, actionHandlers }
+ */
+export function createCardHeader(flow, isRunning, isExpanded, opts) {
+  const headerRow = _el('div', 'flow-card-header');
+
+  const info = _el('div', 'flow-card-info');
+  const nameRow = _el('div', 'flow-card-name-row');
+  nameRow.appendChild(_el('span', 'flow-card-name', flow.name));
+  if (isRunning) nameRow.appendChild(_el('span', 'flow-running-badge', 'En cours...'));
+  if (isRunning) {
+    nameRow.appendChild(_el('button', {
+      className: 'flow-output-toggle',
+      textContent: isExpanded ? '▾ Sortie' : '▸ Sortie',
+      title: isExpanded ? 'Masquer la sortie' : 'Afficher la sortie',
+      onClick: (e) => {
+        e.stopPropagation();
+        opts.onToggleOutput(flow.id);
+      },
+    }));
+  }
+  info.appendChild(nameRow);
+  info.appendChild(_el('div', 'flow-card-schedule', formatSchedule(flow.schedule)));
+  headerRow.appendChild(info);
+
+  const right = _el('div', 'flow-card-right');
+  right.appendChild(createRunDots(flow, opts.onShowLog));
+  right.appendChild(createCardActions(flow, isRunning, opts.actionHandlers));
+  headerRow.appendChild(right);
+
+  return headerRow;
+}

--- a/src/utils/terminal-drop-indicator.js
+++ b/src/utils/terminal-drop-indicator.js
@@ -1,0 +1,66 @@
+/**
+ * Drop indicator management for terminal panel drag-and-drop.
+ * Extracted from terminal-panel.js to reduce component size.
+ */
+import { _el } from './dom.js';
+import { detectDropSide, computeIndicatorRect } from './split-helpers.js';
+
+export class DropIndicatorManager {
+  constructor(container) {
+    this.container = container;
+    this.indicator = null;
+    this.targetId = null;
+    this.side = null;
+  }
+
+  create() {
+    this.indicator = _el('div', 'drop-indicator');
+    this.container.appendChild(this.indicator);
+  }
+
+  remove() {
+    if (this.indicator) {
+      this.indicator.remove();
+      this.indicator = null;
+    }
+    this.container.querySelectorAll('.drop-hover').forEach((el) => el.classList.remove('drop-hover'));
+    this.targetId = null;
+    this.side = null;
+  }
+
+  update(mx, my, terminals, dragSourceId) {
+    this.targetId = null;
+    this.side = null;
+    if (this.indicator) this.indicator.style.display = 'none';
+
+    this.container.querySelectorAll('.drop-hover').forEach((el) => el.classList.remove('drop-hover'));
+
+    for (const [termId, node] of terminals) {
+      if (termId === dragSourceId) continue;
+
+      const rect = node.element.getBoundingClientRect();
+      if (mx < rect.left || mx > rect.right || my < rect.top || my > rect.bottom) continue;
+
+      const relX = (mx - rect.left) / rect.width;
+      const relY = (my - rect.top) / rect.height;
+
+      this.targetId = termId;
+      this.side = detectDropSide(relX, relY);
+      node.element.classList.add('drop-hover');
+
+      this._positionIndicator(rect, this.side);
+      return;
+    }
+  }
+
+  _positionIndicator(rect, side) {
+    if (!this.indicator) return;
+    const s = this.indicator.style;
+    const r = computeIndicatorRect(rect, side);
+    s.display = 'block';
+    s.left = `${r.left}px`;
+    s.top = `${r.top}px`;
+    s.width = `${r.width}px`;
+    s.height = `${r.height}px`;
+  }
+}

--- a/src/utils/terminal-panel-helpers.js
+++ b/src/utils/terminal-panel-helpers.js
@@ -1,5 +1,7 @@
-/* Pure helpers and constants for terminal-panel.
- * No DOM access — only data logic. */
+/* Pure helpers and constants for terminal-panel. */
+import { _el } from './dom.js';
+import { computeResizeRatio } from './split-helpers.js';
+import { getPanels } from './split-layout-ops.js';
 
 /** Polling interval (ms) for detecting terminal cwd changes. */
 export const CWD_POLL_MS = 1500;
@@ -32,10 +34,6 @@ export class SplitNode {
 }
 
 // ===== Pure DOM helpers =====
-
-import { _el } from './dom.js';
-import { computeResizeRatio } from './split-helpers.js';
-import { getPanels } from './split-layout-ops.js';
 
 /** Check if an element is a split container with the given direction. */
 export function isSameDirectionSplit(el, direction) {

--- a/src/utils/terminal-panel-helpers.js
+++ b/src/utils/terminal-panel-helpers.js
@@ -30,3 +30,61 @@ export class SplitNode {
     this.element = null;
   }
 }
+
+// ===== Pure DOM helpers =====
+
+import { _el } from './dom.js';
+import { computeResizeRatio } from './split-helpers.js';
+import { getPanels } from './split-layout-ops.js';
+
+/** Check if an element is a split container with the given direction. */
+export function isSameDirectionSplit(el, direction) {
+  return el?.classList.contains('split-container') && el.classList.contains(`split-${direction}`);
+}
+
+/** Create a new split container element. */
+export function createSplitContainer(direction, flex = '1') {
+  const el = _el('div', `split-container split-${direction}`);
+  el.style.flex = String(flex);
+  return el;
+}
+
+/** Find the adjacent non-handle panels around a split handle. */
+export function adjacentPanels(handle, splitEl) {
+  const children = Array.from(splitEl.children);
+  const idx = children.indexOf(handle);
+  let before = null, after = null;
+  for (let i = idx - 1; i >= 0; i--) {
+    if (!children[i].classList.contains('split-handle')) { before = children[i]; break; }
+  }
+  for (let i = idx + 1; i < children.length; i++) {
+    if (!children[i].classList.contains('split-handle')) { after = children[i]; break; }
+  }
+  return [before, after];
+}
+
+/** Equalize flex values for all direct panel children of a split container. */
+export function equalizeChildren(splitEl) {
+  for (const panel of getPanels(splitEl)) {
+    panel.style.flex = '1';
+  }
+}
+
+/** Perform resize calculation on two adjacent panels. */
+export function doResize(e, handle, splitEl, direction, fitAllFn) {
+  const [panelBefore, panelAfter] = adjacentPanels(handle, splitEl);
+  if (!panelBefore || !panelAfter) return;
+
+  const { size, start, mouse } = DIRECTION_PROPS[direction];
+  const rectBefore = panelBefore.getBoundingClientRect();
+  const rectAfter = panelAfter.getBoundingClientRect();
+
+  const totalSize = rectBefore[size] + rectAfter[size];
+  const ratio = computeResizeRatio(e[mouse], rectBefore[start], totalSize);
+
+  const totalFlex = (parseFloat(panelBefore.style.flex) || 1) + (parseFloat(panelAfter.style.flex) || 1);
+  panelBefore.style.flex = `${totalFlex * ratio}`;
+  panelAfter.style.flex = `${totalFlex * (1 - ratio)}`;
+
+  fitAllFn();
+}


### PR DESCRIPTION
## Refactoring

Further reduction of the 5 large components identified in the issue.

### Extractions
- **`src/utils/flow-card-renderer.js`** (new): extracted `createCardHeader`, `createRunDots`, `createCardActions`, `createFlowActionButton` from flow-view.js
- **`src/utils/terminal-drop-indicator.js`** (new): extracted `DropIndicatorManager` class from terminal-panel.js
- **`src/utils/terminal-panel-helpers.js`** (augmented): moved `isSameDirectionSplit`, `createSplitContainer`, `adjacentPanels`, `equalizeChildren`, `doResize` from terminal-panel.js

### Line count reduction
| File | Before | After | Reduction |
|------|--------|-------|-----------|
| flow-view.js | 409 | 352 | -57 |
| terminal-panel.js | 457 | 356 | -101 |
| settings-modal.js | 168 | 168 | already OK |

Closes #3

## Fichier(s) modifié(s)

- `src/components/flow-view.js`
- `src/components/terminal-panel.js`
- `src/utils/flow-card-renderer.js` (new)
- `src/utils/terminal-drop-indicator.js` (new)
- `src/utils/terminal-panel-helpers.js`

## Vérifications

- [x] Build OK
- [x] Tests OK (204 passed)

---

📂 Path local : `/Users/rekta/projet/coding/refactor-pikagent`
🤖 PR créée automatiquement par l'Agent Refactor