### PR TITLE
refactor: split long functions in preload.js and flow-modal.js

### DIFF
--- a/preload.js
+++ b/preload.js
@@ -6,74 +6,100 @@ const { _onIpc, _fwd, _pack, _createTargetedChannel } = require('./preload-helpe
 const _onPtyData = _createTargetedChannel('pty:data', ({ id, data }) => ({ id, value: data }));
 const _onPtyExit = _createTargetedChannel('pty:exit', ({ id, exitCode }) => ({ id, value: { id, exitCode } }));
 
+// --- API builder functions ---
+
+function buildTerminalApi() {
+  return {
+    pty: {
+      create:      _fwd('pty:create'),
+      write:       _fwd('pty:write'),
+      resize:      _fwd('pty:resize'),
+      kill:        _fwd('pty:kill'),
+      getCwd:      _fwd('pty:getcwd'),
+      checkAgents: _fwd('pty:checkAgents'),
+      onData:      _onPtyData,
+      onExit:      _onPtyExit,
+    },
+  };
+}
+
+function buildFileApi() {
+  return {
+    fs: {
+      readdir:   _fwd('fs:readdir'),
+      readfile:  _fwd('fs:readfile'),
+      mkdir:     _fwd('fs:mkdir'),
+      homedir:   _fwd('fs:homedir'),
+      copy:      _fwd('fs:copy'),
+      trash:     _fwd('fs:trash'),
+      writefile: _pack('fs:writefile', ['filePath', 'content']),
+      rename:    _pack('fs:rename', ['oldPath', 'newName']),
+      copyTo:    _pack('fs:copyTo', ['srcPath', 'destDir']),
+      watch:     _pack('fs:watch', ['id', 'dirPath']),
+      unwatch:   _pack('fs:unwatch', ['id']),
+      onChanged: _onIpc('fs:changed'),
+    },
+    shell: {
+      showInFolder: _fwd('shell:showInFolder'),
+      openExternal: _fwd('shell:openExternal'),
+      openPath:     _fwd('shell:openPath'),
+    },
+    clipboard: { write: _fwd('clipboard:write') },
+    dialog:    { openFolder: _fwd('dialog:openFolder') },
+  };
+}
+
+function buildGitApi() {
+  return {
+    git: {
+      branch:       _fwd('git:branch'),
+      remote:       _fwd('git:remote'),
+      localChanges: _fwd('git:localChanges'),
+      fileDiff:     _pack('git:fileDiff', ['cwd', 'filePath', 'isStaged']),
+    },
+  };
+}
+
+function buildFlowApi() {
+  return {
+    flow: {
+      save:          _fwd('flow:save'),
+      get:           _fwd('flow:get'),
+      list:          _fwd('flow:list'),
+      delete:        _fwd('flow:delete'),
+      toggle:        _fwd('flow:toggle'),
+      runNow:        _fwd('flow:runNow'),
+      getRunning:    _fwd('flow:getRunning'),
+      getRunLog:     _pack('flow:getRunLog', ['flowId', 'logTimestamp']),
+      getCategories: _fwd('flow:getCategories'),
+      saveCategories: _fwd('flow:saveCategories'),
+      onRunStarted:  _onIpc('flow:runStarted'),
+      onRunComplete: _onIpc('flow:runComplete'),
+    },
+  };
+}
+
+function buildConfigApi() {
+  return {
+    usage: { getMetrics: _fwd('usage:getMetrics') },
+    config: {
+      save:        _pack('config:save', ['name', 'data']),
+      load:        _fwd('config:load'),
+      list:        _fwd('config:list'),
+      delete:      _fwd('config:delete'),
+      setDefault:  _fwd('config:setDefault'),
+      getDefault:  _fwd('config:getDefault'),
+      loadDefault: _fwd('config:loadDefault'),
+    },
+  };
+}
+
 // --- Exposed API ---
 
 contextBridge.exposeInMainWorld('api', {
-  pty: {
-    create:      _fwd('pty:create'),
-    write:       _fwd('pty:write'),
-    resize:      _fwd('pty:resize'),
-    kill:        _fwd('pty:kill'),
-    getCwd:      _fwd('pty:getcwd'),
-    checkAgents: _fwd('pty:checkAgents'),
-    onData:      _onPtyData,
-    onExit:      _onPtyExit,
-  },
-
-  fs: {
-    readdir:   _fwd('fs:readdir'),
-    readfile:  _fwd('fs:readfile'),
-    mkdir:     _fwd('fs:mkdir'),
-    homedir:   _fwd('fs:homedir'),
-    copy:      _fwd('fs:copy'),
-    trash:     _fwd('fs:trash'),
-    writefile: _pack('fs:writefile', ['filePath', 'content']),
-    rename:    _pack('fs:rename', ['oldPath', 'newName']),
-    copyTo:    _pack('fs:copyTo', ['srcPath', 'destDir']),
-    watch:     _pack('fs:watch', ['id', 'dirPath']),
-    unwatch:   _pack('fs:unwatch', ['id']),
-    onChanged: _onIpc('fs:changed'),
-  },
-
-  shell: {
-    showInFolder: _fwd('shell:showInFolder'),
-    openExternal: _fwd('shell:openExternal'),
-    openPath:     _fwd('shell:openPath'),
-  },
-  clipboard: { write: _fwd('clipboard:write') },
-  dialog:    { openFolder: _fwd('dialog:openFolder') },
-
-  git: {
-    branch:       _fwd('git:branch'),
-    remote:       _fwd('git:remote'),
-    localChanges: _fwd('git:localChanges'),
-    fileDiff:     _pack('git:fileDiff', ['cwd', 'filePath', 'isStaged']),
-  },
-
-  flow: {
-    save:          _fwd('flow:save'),
-    get:           _fwd('flow:get'),
-    list:          _fwd('flow:list'),
-    delete:        _fwd('flow:delete'),
-    toggle:        _fwd('flow:toggle'),
-    runNow:        _fwd('flow:runNow'),
-    getRunning:    _fwd('flow:getRunning'),
-    getRunLog:     _pack('flow:getRunLog', ['flowId', 'logTimestamp']),
-    getCategories: _fwd('flow:getCategories'),
-    saveCategories: _fwd('flow:saveCategories'),
-    onRunStarted:  _onIpc('flow:runStarted'),
-    onRunComplete: _onIpc('flow:runComplete'),
-  },
-
-  usage: { getMetrics: _fwd('usage:getMetrics') },
-
-  config: {
-    save:        _pack('config:save', ['name', 'data']),
-    load:        _fwd('config:load'),
-    list:        _fwd('config:list'),
-    delete:      _fwd('config:delete'),
-    setDefault:  _fwd('config:setDefault'),
-    getDefault:  _fwd('config:getDefault'),
-    loadDefault: _fwd('config:loadDefault'),
-  },
+  ...buildTerminalApi(),
+  ...buildFileApi(),
+  ...buildGitApi(),
+  ...buildFlowApi(),
+  ...buildConfigApi(),
 });

--- a/src/components/flow-modal.js
+++ b/src/components/flow-modal.js
@@ -179,59 +179,74 @@ function _buildCategoryPicker(categories, selectedCatId) {
 
 // --- Main entry ---
 
+function _buildModalDom(existing, categories, state) {
+  const fields = _buildFormFields(existing);
+  state.nameInput = fields.nameInput;
+  state.promptArea = fields.promptArea;
+
+  const header = _buildHeader(existing, state);
+  const bottom = _buildBottomBar(existing, state);
+  const catPicker = categories.length > 0
+    ? _buildCategoryPicker(categories, existing?._category || '')
+    : null;
+
+  const modalChildren = [header, fields.nameGroup, fields.promptGroup];
+  if (catPicker) modalChildren.push(_el('div', { className: 'flow-modal-group', style: { paddingBottom: '8px' } }, catPicker.chip));
+  modalChildren.push(bottom.bar);
+
+  return { fields, bottom, catPicker, modalChildren };
+}
+
+function _buildActionBar(existing, fields, bottom, catPicker, state, overlayRef, resolve) {
+  const close = () => { overlayRef.overlay.remove(); resolve(null); };
+
+  const actionBar = _el('div', { className: 'flow-modal-actions' },
+    _el('button', {
+      className: 'flow-modal-btn flow-modal-btn-cancel',
+      textContent: 'Annuler',
+      onClick: close,
+    }),
+    _el('button', {
+      className: 'flow-modal-btn flow-modal-btn-create',
+      textContent: existing ? 'Enregistrer' : 'Créer',
+      onClick: () => {
+        const name = fields.nameInput.value.trim();
+        const prompt = fields.promptArea.value.trim();
+        if (!name || !prompt) return;
+
+        overlayRef.overlay.remove();
+        const result = {
+          id: existing?.id || generateId(),
+          name,
+          prompt,
+          agent: bottom.agentSelect.value,
+          cwd: state.selectedCwd || undefined,
+          schedule: buildScheduleData(bottom.schedSelect.value, bottom.timeInput.value, bottom.intervalInput.value, bottom.selectedDays),
+          dangerouslySkipPermissions: !!SKIP_PERM_CONFIG[bottom.agentSelect.value] && bottom.skipPermCheckbox.checked,
+          enabled: existing?.enabled ?? true,
+          runs: existing?.runs || [],
+        };
+        if (catPicker) result._category = catPicker.select.value || '';
+        resolve(result);
+      },
+    }),
+  );
+
+  return { actionBar, close };
+}
+
 export function openFlowModal(existing = null, categories = []) {
   return new Promise((resolve) => {
     const state = { selectedCwd: existing?.cwd || '' };
+    const overlayRef = {};
 
-    const fields = _buildFormFields(existing);
-    state.nameInput = fields.nameInput;
-    state.promptArea = fields.promptArea;
+    const { fields, bottom, catPicker, modalChildren } = _buildModalDom(existing, categories, state);
+    const { actionBar, close } = _buildActionBar(existing, fields, bottom, catPicker, state, overlayRef, resolve);
 
-    const header = _buildHeader(existing, state);
-    const bottom = _buildBottomBar(existing, state);
-    const catPicker = categories.length > 0
-      ? _buildCategoryPicker(categories, existing?._category || '')
-      : null;
-
-    const close = () => { overlay.remove(); resolve(null); };
-
-    const actionBar = _el('div', { className: 'flow-modal-actions' },
-      _el('button', {
-        className: 'flow-modal-btn flow-modal-btn-cancel',
-        textContent: 'Annuler',
-        onClick: close,
-      }),
-      _el('button', {
-        className: 'flow-modal-btn flow-modal-btn-create',
-        textContent: existing ? 'Enregistrer' : 'Créer',
-        onClick: () => {
-          const name = fields.nameInput.value.trim();
-          const prompt = fields.promptArea.value.trim();
-          if (!name || !prompt) return;
-
-          overlay.remove();
-          const result = {
-            id: existing?.id || generateId(),
-            name,
-            prompt,
-            agent: bottom.agentSelect.value,
-            cwd: state.selectedCwd || undefined,
-            schedule: buildScheduleData(bottom.schedSelect.value, bottom.timeInput.value, bottom.intervalInput.value, bottom.selectedDays),
-            dangerouslySkipPermissions: !!SKIP_PERM_CONFIG[bottom.agentSelect.value] && bottom.skipPermCheckbox.checked,
-            enabled: existing?.enabled ?? true,
-            runs: existing?.runs || [],
-          };
-          if (catPicker) result._category = catPicker.select.value || '';
-          resolve(result);
-        },
-      }),
-    );
-
-    const modalChildren = [header, fields.nameGroup, fields.promptGroup];
-    if (catPicker) modalChildren.push(_el('div', { className: 'flow-modal-group', style: { paddingBottom: '8px' } }, catPicker.chip));
-    modalChildren.push(bottom.bar, actionBar);
+    modalChildren.push(actionBar);
 
     const { overlay, modal } = createModalOverlay('flow-modal-overlay', 'flow-modal', close);
+    overlayRef.overlay = overlay;
     modal.append(...modalChildren);
 
     document.body.appendChild(overlay);


### PR DESCRIPTION
## Refactoring

Découpage des fonctions longues (>50 lignes) en sous-fonctions thématiques :

- **preload.js** : `exposeInMainWorld` (69L) → découpé en builders thématiques (terminal, file, config, flow, etc.)
- **flow-modal.js** : `openFlowModal` (59L) → extraction du DOM building et des event listeners

Aucun changement de logique ou de contrat API.

Closes #29

## Fichier(s) modifié(s)

- `preload.js`
- `src/components/flow-modal.js`

## Vérifications

- [x] Build OK
- [x] Tests OK

---

📂 Path local : `/Users/rekta/projet/coding/refactor-pikagent`
🤖 PR créée automatiquement par l'Agent Refactor