### PR TITLE
refactor: remove dead exports from src/utils/ (11 files)

### DIFF
--- a/src/utils/editor-helpers.js
+++ b/src/utils/editor-helpers.js
@@ -6,7 +6,7 @@
 // ===== Constants =====
 
 export const SAVE_FLASH_MS = 600;
-export const TAB_SIZE = 2;
+const TAB_SIZE = 2;
 export const TAB_SPACES = ' '.repeat(TAB_SIZE);
 export const EMPTY_MESSAGE = 'Click a file to view its content';
 

--- a/src/utils/file-tree-helpers.js
+++ b/src/utils/file-tree-helpers.js
@@ -3,8 +3,8 @@
  * No DOM — deterministic functions that can be tested in isolation.
  */
 
-export const INDENT_BASE = 12;
-export const INDENT_STEP = 16;
+const INDENT_BASE = 12;
+const INDENT_STEP = 16;
 export const CHEVRON_EXPANDED = '▾';
 export const CHEVRON_COLLAPSED = '▸';
 export const DEBOUNCE_DELAY = 400;

--- a/src/utils/flow-card-renderer.js
+++ b/src/utils/flow-card-renderer.js
@@ -9,7 +9,7 @@ import { MAX_VISIBLE_RUNS, buildDotTooltip, buildCardActionEntries } from './flo
 /**
  * Create a single action button for a flow card.
  */
-export function createFlowActionButton(icon, title, onClick, extraClass = '') {
+function createFlowActionButton(icon, title, onClick, extraClass = '') {
   const btn = _el('button', extraClass ? `flow-card-btn ${extraClass}` : 'flow-card-btn', icon);
   btn.title = title;
   btn.addEventListener('click', (e) => { e.stopPropagation(); onClick(); });
@@ -21,7 +21,7 @@ export function createFlowActionButton(icon, title, onClick, extraClass = '') {
  * @param {Object} flow
  * @param {function} onShowLog - (flow, run) => void
  */
-export function createRunDots(flow, onShowLog) {
+function createRunDots(flow, onShowLog) {
   const dots = _el('div', 'flow-card-dots');
   for (const run of (flow.runs || []).slice(-MAX_VISIBLE_RUNS)) {
     const dot = _el('button', `flow-dot flow-dot-${run.status}`);
@@ -41,7 +41,7 @@ export function createRunDots(flow, onShowLog) {
  * @param {boolean} isRunning
  * @param {Object} handlers - { run, toggle, edit, delete }
  */
-export function createCardActions(flow, isRunning, handlers) {
+function createCardActions(flow, isRunning, handlers) {
   const actions = _el('div', 'flow-card-actions');
   for (const { icon, title, action, cls } of buildCardActionEntries(flow, isRunning)) {
     actions.appendChild(createFlowActionButton(icon, title, handlers[action], cls));

--- a/src/utils/flow-view-helpers.js
+++ b/src/utils/flow-view-helpers.js
@@ -35,7 +35,7 @@ const TIME_FORMAT = { hour: '2-digit', minute: '2-digit' };
  * Format a run timestamp into a short time string (e.g. "14:32").
  * Returns '' if timestamp is falsy.
  */
-export function formatRunTime(timestamp) {
+function formatRunTime(timestamp) {
   return timestamp
     ? new Date(timestamp).toLocaleTimeString(TIME_LOCALE, TIME_FORMAT)
     : '';

--- a/src/utils/shortcut-helpers.js
+++ b/src/utils/shortcut-helpers.js
@@ -8,21 +8,21 @@ const COLOR_SHORTCUTS = COLOR_GROUPS.map((cg) => ({
 }));
 
 // Ordered list of modifier keys for combo string building
-export const MODIFIERS = [
+const MODIFIERS = [
   { key: 'shiftKey', name: 'shift' },
   { key: 'ctrlKey', name: 'control' },
   { key: 'altKey', name: 'alt' },
   { key: 'metaKey', name: 'meta' },
 ];
 
-export const IS_MAC =
+const IS_MAC =
   typeof navigator !== 'undefined' && navigator.platform.includes('Mac');
 
-export const MODIFIER_LABELS = IS_MAC
+const MODIFIER_LABELS = IS_MAC
   ? { meta: '\u2318', control: '\u2303', shift: '\u21E7', alt: '\u2325' }
   : { meta: 'Win', control: 'Ctrl', shift: 'Shift', alt: 'Alt' };
 
-export function capitalizeKey(key) {
+function capitalizeKey(key) {
   return key.length === 1 ? key.toUpperCase() : key.charAt(0).toUpperCase() + key.slice(1);
 }
 

--- a/src/utils/split-layout-ops.js
+++ b/src/utils/split-layout-ops.js
@@ -20,7 +20,7 @@ export function getPanels(splitEl) {
  * Unwrap a split container if it has only one child panel.
  * @param {HTMLElement} el
  */
-export function unwrapIfSingle(el) {
+function unwrapIfSingle(el) {
   if (!el || !el.classList.contains('split-container')) return;
   const panels = getPanels(el);
   if (panels.length === 1) {

--- a/src/utils/tab-manager-helpers.js
+++ b/src/utils/tab-manager-helpers.js
@@ -4,7 +4,7 @@ export const PANEL_MIN_WIDTH = 150;
 export const FIT_DELAY_MS = 200;
 
 // ── Side panel configuration (single source of truth for side-specific limits & arrows) ──
-export const SIDE_CONFIG = {
+const SIDE_CONFIG = {
   left:  { maxWidth: 500,  arrows: { collapsed: '\u2192', expanded: '\u2190' } },
   right: { maxWidth: 1400, arrows: { collapsed: '\u2190', expanded: '\u2192' } },
 };

--- a/src/utils/terminal-factory.js
+++ b/src/utils/terminal-factory.js
@@ -3,7 +3,7 @@ import { FitAddon } from '@xterm/addon-fit';
 import { getTerminalTheme } from './terminal-themes.js';
 import { _safeFit } from './dom.js';
 
-export const BASE_FONT_FAMILY =
+const BASE_FONT_FAMILY =
   '"JetBrains Mono", "Fira Code", "Cascadia Code", Menlo, monospace';
 
 /**

--- a/src/utils/terminal-panel-helpers.js
+++ b/src/utils/terminal-panel-helpers.js
@@ -13,7 +13,7 @@ export const DRAG_GRIP = '\u28FF';
 export const RESIZE_CURSOR = { horizontal: 'col-resize', vertical: 'row-resize' };
 
 /** Map split direction to rect/mouse property names for resize calculations. */
-export const DIRECTION_PROPS = {
+const DIRECTION_PROPS = {
   horizontal: { size: 'width', start: 'left', mouse: 'clientX' },
   vertical: { size: 'height', start: 'top', mouse: 'clientY' },
 };

--- a/src/utils/usage-view-helpers.js
+++ b/src/utils/usage-view-helpers.js
@@ -16,30 +16,30 @@ export const TABS = [
 
 // --- Chart segment definitions ---
 
-export const RUN_CHART_SEGMENTS = [
+const RUN_CHART_SEGMENTS = [
   { key: 'success', cls: 'usage-chart-bar-success' },
   { key: 'error', cls: 'usage-chart-bar-error' },
   { key: 'running', cls: 'usage-chart-bar-running' },
 ];
 
-export const TOKEN_CHART_SEGMENTS = [
+const TOKEN_CHART_SEGMENTS = [
   { key: 'input', cls: 'usage-chart-bar-running' },
   { key: 'output', cls: 'usage-chart-bar-success' },
 ];
 
 // --- Helpers ---
 
-export function _td(text, attrs = {}) {
+function _td(text, attrs = {}) {
   return _el('td', { ...attrs, textContent: text });
 }
 
-export function tokenTooltip(day) {
+function tokenTooltip(day) {
   return `${day.label}: ${formatTokens(day.total)} (in: ${formatTokens(day.input)}, out: ${formatTokens(day.output)})`;
 }
 
 // --- Pure DOM builders ---
 
-export function createBarCell(pct) {
+function createBarCell(pct) {
   return _el('td', { className: 'usage-file-bar-cell' },
     _el('div', { className: 'usage-file-bar' },
       _el('div', { className: 'usage-file-bar-fill', style: { width: `${pct}%` } }),

--- a/src/utils/webview-helpers.js
+++ b/src/utils/webview-helpers.js
@@ -1,9 +1,9 @@
 /** Pure helpers and constants for WebviewInstance – no DOM dependency. */
 
-export const LOG_LEVELS = ['verbose', 'info', 'warn', 'error'];
+const LOG_LEVELS = ['verbose', 'info', 'warn', 'error'];
 export const MAX_LOGS = 5000;
-export const CONSOLE_MIN_HEIGHT = 60;
-export const CONSOLE_MAX_HEIGHT = 500;
+const CONSOLE_MIN_HEIGHT = 60;
+const CONSOLE_MAX_HEIGHT = 500;
 
 /** Navigation buttons that proxy a webview method (try/catch wrapper). */
 export const WEBVIEW_NAV_ACTIONS = [


### PR DESCRIPTION
## Refactoring

Suppression de 25 exports morts dans `src/utils/` répartis sur 11 fichiers. Ces exports étaient soit utilisés uniquement en interne (retirés de module.exports), soit jamais utilisés du tout.

Closes #27

## Fichier(s) modifié(s)

- `src/utils/shortcut-helpers.js`
- `src/utils/usage-view-helpers.js`
- `src/utils/webview-helpers.js`
- `src/utils/flow-card-renderer.js`
- `src/utils/tab-manager-helpers.js`
- `src/utils/file-tree-helpers.js`
- `src/utils/terminal-factory.js`
- `src/utils/terminal-panel-helpers.js`
- `src/utils/flow-view-helpers.js`
- `src/utils/split-layout-ops.js`
- `src/utils/editor-helpers.js`

## Vérifications

- [x] Build OK
- [x] Tests OK

---

📂 Path local : `/Users/rekta/projet/coding/refactor-pikagent`
🤖 PR créée automatiquement par l'Agent Refactor