### PR TITLE
refactor: factor duplicated patterns in settings and managers (#22)

### DIFF
--- a/src/components/settings-appearance.js
+++ b/src/components/settings-appearance.js
@@ -6,6 +6,7 @@ import { TERMINAL_THEMES, getTerminalThemeName, setTerminalTheme, getTerminalThe
 import { getAppTheme, setAppTheme } from '../utils/app-theme.js';
 import { _el } from '../utils/dom.js';
 import { MODE_BUTTONS, THEME_PREVIEW_LINES, COLOR_DOT_KEYS } from '../utils/settings-helpers.js';
+import { createSettingsSection } from '../utils/settings-section-builder.js';
 
 /**
  * Apply the current terminal theme to all terminal panels across tabs.
@@ -65,13 +66,10 @@ function _createThemeCard(name, theme, isActive, tabManager, renderAppearanceFn)
 /**
  * Render the Appearance section into the given content element.
  * @param {HTMLElement} contentEl - the settings content container
- * @param {function} createSectionHeading - (title, ...extras) => heading element
  * @param {Object|null} tabManager
  * @param {function} renderAppearanceFn - callback to re-render this section
  */
-export function renderAppearance(contentEl, createSectionHeading, tabManager, renderAppearanceFn) {
-  createSectionHeading('Appearance');
-
+export function renderAppearance(contentEl, tabManager, renderAppearanceFn) {
   // Day/Night mode toggle
   const modeRow = _el('div', 'theme-mode-row');
   modeRow.appendChild(_el('span', 'theme-mode-label', 'Mode'));
@@ -91,15 +89,18 @@ export function renderAppearance(contentEl, createSectionHeading, tabManager, re
   }
 
   modeRow.appendChild(modeToggle);
-  contentEl.appendChild(modeRow);
 
   // Terminal theme grid
-  contentEl.appendChild(_el('h4', 'theme-sub-heading', 'Terminal Theme'));
+  const subHeading = _el('h4', 'theme-sub-heading', 'Terminal Theme');
 
   const currentThemeName = getTerminalThemeName();
   const grid = _el('div', 'theme-grid');
   for (const [name, theme] of Object.entries(TERMINAL_THEMES)) {
     grid.appendChild(_createThemeCard(name, theme, name === currentThemeName, tabManager, renderAppearanceFn));
   }
-  contentEl.appendChild(grid);
+
+  createSettingsSection(contentEl, {
+    heading: 'Appearance',
+    content: [modeRow, subHeading, grid],
+  });
 }

--- a/src/components/settings-configs.js
+++ b/src/components/settings-configs.js
@@ -4,6 +4,7 @@
  */
 import { _el } from '../utils/dom.js';
 import { CONFIG_ACTIONS, BOTTOM_CONFIG_BUTTONS, formatConfigMeta, buildActionBtn } from '../utils/settings-helpers.js';
+import { createSettingsSection } from '../utils/settings-section-builder.js';
 
 function _createConfigActions(config, tabManager, renderConfigsFn) {
   const handlers = {
@@ -86,20 +87,16 @@ function _createBottomActions(currentName, tabManager, renderConfigsFn) {
 /**
  * Render the Workspace Configs section into the given content element.
  * @param {HTMLElement} contentEl - the settings content container
- * @param {function} createSectionHeading - (title, ...extras) => heading element
  * @param {Object|null} tabManager
  * @param {function} renderConfigsFn - callback to re-render this section
  */
-export async function renderConfigs(contentEl, createSectionHeading, tabManager, renderConfigsFn) {
-  createSectionHeading('Workspace Configs');
-
+export async function renderConfigs(contentEl, tabManager, renderConfigsFn) {
   const currentName = tabManager?.configManager?.currentConfigName || 'Default';
 
   // Current loaded config indicator
   const currentBar = _el('div', 'config-current-bar');
   currentBar.appendChild(_el('span', 'config-current-label', 'Config chargée :'));
   currentBar.appendChild(_el('span', 'config-current-value', currentName));
-  contentEl.appendChild(currentBar);
 
   // Config list
   const configs = await window.api.config.list();
@@ -107,7 +104,9 @@ export async function renderConfigs(contentEl, createSectionHeading, tabManager,
   for (const config of configs) {
     list.appendChild(_createConfigRow(config, currentName, tabManager, renderConfigsFn));
   }
-  contentEl.appendChild(list);
 
-  contentEl.appendChild(_createBottomActions(currentName, tabManager, renderConfigsFn));
+  createSettingsSection(contentEl, {
+    heading: 'Workspace Configs',
+    content: [currentBar, list, _createBottomActions(currentName, tabManager, renderConfigsFn)],
+  });
 }

--- a/src/components/settings-keybindings.js
+++ b/src/components/settings-keybindings.js
@@ -4,6 +4,7 @@
  */
 import { formatCombo } from '../utils/shortcut-helpers.js';
 import { _el } from '../utils/dom.js';
+import { createSettingsSection } from '../utils/settings-section-builder.js';
 
 /**
  * Create a key badge element for a binding at a given index.
@@ -44,18 +45,16 @@ export function createKeyBadge(binding, index, shortcutManager, startRecordingFn
 /**
  * Render the Keybindings section into the given content element.
  * @param {HTMLElement} contentEl - the settings content container
- * @param {function} createSectionHeading - (title, ...extras) => heading element
  * @param {Object} shortcutManager
  * @param {function} startRecordingFn
  * @param {function} renderKeybindingsFn - callback to re-render
  */
-export function renderKeybindings(contentEl, createSectionHeading, shortcutManager, startRecordingFn, renderKeybindingsFn) {
+export function renderKeybindings(contentEl, shortcutManager, startRecordingFn, renderKeybindingsFn) {
   const resetBtn = _el('button', 'settings-reset-btn', 'Reset to defaults');
   resetBtn.addEventListener('click', () => {
     shortcutManager.resetToDefaults();
     renderKeybindingsFn();
   });
-  createSectionHeading('Keyboard Shortcuts', resetBtn);
 
   const list = _el('div', 'keybinding-list');
 
@@ -81,5 +80,9 @@ export function renderKeybindings(contentEl, createSectionHeading, shortcutManag
     list.appendChild(row);
   }
 
-  contentEl.appendChild(list);
+  createSettingsSection(contentEl, {
+    heading: 'Keyboard Shortcuts',
+    actions: [resetBtn],
+    content: [list],
+  });
 }

--- a/src/components/settings-modal.js
+++ b/src/components/settings-modal.js
@@ -91,21 +91,11 @@ export class SettingsModal {
     }, MODAL_CLOSE_TRANSITION_MS);
   }
 
-  _createSectionHeading(title, ...extras) {
-    this.content.replaceChildren();
-    const heading = _el('div', 'settings-section-header');
-    heading.appendChild(_el('h3', null, title));
-    for (const el of extras) heading.appendChild(el);
-    this.content.appendChild(heading);
-    return heading;
-  }
-
   // ===== Delegated section renderers =====
 
   _renderAppearance() {
     renderAppearance(
       this.content,
-      (title, ...extras) => this._createSectionHeading(title, ...extras),
       this.tabManager,
       () => this._renderAppearance(),
     );
@@ -114,7 +104,6 @@ export class SettingsModal {
   _renderKeybindings() {
     renderKeybindings(
       this.content,
-      (title, ...extras) => this._createSectionHeading(title, ...extras),
       this.shortcutManager,
       (actionId, index, badgeEl) => this.startRecording(actionId, index, badgeEl),
       () => this._renderKeybindings(),
@@ -124,7 +113,6 @@ export class SettingsModal {
   _renderConfigs() {
     renderConfigs(
       this.content,
-      (title, ...extras) => this._createSectionHeading(title, ...extras),
       this.tabManager,
       () => this._renderConfigs(),
     );

--- a/src/utils/settings-section-builder.js
+++ b/src/utils/settings-section-builder.js
@@ -1,0 +1,29 @@
+/**
+ * Generic settings section DOM builder.
+ * Abstracts the heading + content + action buttons pattern
+ * shared across settings-appearance, settings-configs, and settings-keybindings.
+ */
+import { _el } from './dom.js';
+
+/**
+ * Build a settings section and populate the given container.
+ *
+ * @param {HTMLElement} contentEl - the settings content container (will be cleared)
+ * @param {Object} config
+ * @param {string}        config.heading  - section title text
+ * @param {HTMLElement[]} [config.actions]  - extra elements appended to the heading row (e.g. reset button)
+ * @param {HTMLElement[]} [config.content]  - main content elements appended after the heading
+ * @returns {HTMLElement} the heading element that was created
+ */
+export function createSettingsSection(contentEl, { heading, actions = [], content = [] }) {
+  contentEl.replaceChildren();
+
+  const headingEl = _el('div', 'settings-section-header');
+  headingEl.appendChild(_el('h3', null, heading));
+  for (const el of actions) headingEl.appendChild(el);
+  contentEl.appendChild(headingEl);
+
+  for (const el of content) contentEl.appendChild(el);
+
+  return headingEl;
+}


### PR DESCRIPTION
## Summary

- Create `src/utils/settings-section-builder.js` with a generic `createSettingsSection(contentEl, { heading, actions, content })` builder that abstracts the heading+content+actions DOM pattern
- Refactor `settings-appearance.js`, `settings-configs.js`, `settings-keybindings.js` to use the builder directly instead of a passed-in `createSectionHeading` callback
- Remove the now-redundant `_createSectionHeading` method from `SettingsModal` and simplify all 3 render call sites

> Note: Patterns 2 (CRUD fs-utils), 3 (flow-view-helpers ordering helpers), and 4 (PollingTimer) were already factored in prior commits on `dev`.

Closes #22

## Files modified

- `src/utils/settings-section-builder.js` *(new)*
- `src/components/settings-appearance.js`
- `src/components/settings-configs.js`
- `src/components/settings-keybindings.js`
- `src/components/settings-modal.js`

## Build & test status

- `npm run build` — ✅ passed
- `npm test` — ✅ 204/204 tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)