### PR TITLE
refactor: factor duplicated patterns in UI components

### DIFF
--- a/src/components/context-menu.js
+++ b/src/components/context-menu.js
@@ -1,7 +1,4 @@
-import { _el } from '../utils/dom.js';
-
-/** Viewport edge padding (px) when clamping menu position. */
-const VIEWPORT_PADDING = 8;
+import { _el, positionInViewport } from '../utils/dom.js';
 
 export class ContextMenu {
   constructor() {
@@ -58,8 +55,9 @@ export class ContextMenu {
 
     this.el.style.display = 'block';
     const { width, height } = this.el.getBoundingClientRect();
-    this.el.style.left = `${Math.min(x, window.innerWidth - width - VIEWPORT_PADDING)}px`;
-    this.el.style.top = `${Math.min(y, window.innerHeight - height - VIEWPORT_PADDING)}px`;
+    const { left, top } = positionInViewport(x, y, width, height);
+    this.el.style.left = `${left}px`;
+    this.el.style.top = `${top}px`;
 
     // Register dismiss listeners only while visible (idempotent remove-then-add)
     document.removeEventListener('mousedown', this._onMouseDown);

--- a/src/components/file-tree.js
+++ b/src/components/file-tree.js
@@ -1,5 +1,5 @@
 import { bus } from '../utils/events.js';
-import { _el, setupInlineInput } from '../utils/dom.js';
+import { _el, setupInlineInput, setupDropZone } from '../utils/dom.js';
 import {
   CHEVRON_EXPANDED, CHEVRON_COLLAPSED,
   DEBOUNCE_DELAY, INPUT_BLUR_DELAY, WATCH_PREFIX,
@@ -244,26 +244,12 @@ export class FileTree {
   // --- Drag & Drop ---
 
   _setupDropZone(el, getTargetDir) {
-    el.addEventListener('dragover', (e) => {
-      if (!e.dataTransfer.types.includes('Files')) return;
-      e.preventDefault();
-      e.stopPropagation();
-      e.dataTransfer.dropEffect = 'copy';
-      el.classList.add('drop-target');
-    });
-
-    el.addEventListener('dragleave', (e) => {
-      e.stopPropagation();
-      el.classList.remove('drop-target');
-    });
-
-    el.addEventListener('drop', async (e) => {
-      e.preventDefault();
-      e.stopPropagation();
-      el.classList.remove('drop-target');
-      const targetDir = typeof getTargetDir === 'function' ? getTargetDir() : getTargetDir;
-      if (!targetDir) return;
-      await this._handleFileDrop(e.dataTransfer.files, targetDir);
+    setupDropZone(el, {
+      onDrop: async (files) => {
+        const targetDir = typeof getTargetDir === 'function' ? getTargetDir() : getTargetDir;
+        if (!targetDir) return;
+        await this._handleFileDrop(files, targetDir);
+      },
     });
   }
 

--- a/src/utils/dom.js
+++ b/src/utils/dom.js
@@ -111,6 +111,52 @@ export function showPromptDialog({ title, placeholder = '', defaultValue = '', c
 }
 
 /**
+ * Attach file-drop drag-and-drop listeners to an element.
+ * Adds/removes `className` on dragover/dragleave, then calls `onDrop` with the
+ * dropped FileList on drop.
+ *
+ * @param {HTMLElement} el - target element
+ * @param {{ onDrop: (files: FileList) => void, className?: string }} opts
+ */
+export function setupDropZone(el, { onDrop, className = 'drop-target' }) {
+  el.addEventListener('dragover', (e) => {
+    if (!e.dataTransfer.types.includes('Files')) return;
+    e.preventDefault();
+    e.stopPropagation();
+    e.dataTransfer.dropEffect = 'copy';
+    el.classList.add(className);
+  });
+
+  el.addEventListener('dragleave', (e) => {
+    e.stopPropagation();
+    el.classList.remove(className);
+  });
+
+  el.addEventListener('drop', (e) => {
+    e.preventDefault();
+    e.stopPropagation();
+    el.classList.remove(className);
+    onDrop(e.dataTransfer.files);
+  });
+}
+
+/**
+ * Clamp (x, y) so a box of (width, height) stays within the viewport.
+ * @param {number} x
+ * @param {number} y
+ * @param {number} width
+ * @param {number} height
+ * @param {number} [padding=8]
+ * @returns {{ left: number, top: number }}
+ */
+export function positionInViewport(x, y, width, height, padding = 8) {
+  return {
+    left: Math.min(x, window.innerWidth  - width  - padding),
+    top:  Math.min(y, window.innerHeight - height - padding),
+  };
+}
+
+/**
  * Show a confirm dialog.
  * @param {Node|string} message - text string or DOM node
  * @returns {Promise<boolean>}


### PR DESCRIPTION
## Summary

- Extract `setupDropZone(el, { onDrop, className })` into `src/utils/dom.js`; `file-tree.js` now delegates to it (Pattern 1)
- Extract `positionInViewport(x, y, w, h, padding)` into `src/utils/dom.js`; `context-menu.js` now uses it (Pattern 8)
- Audit confirms Patterns 2–7 are already resolved by prior PRs (#21–#26):
  - **Pattern 2** (Modal overlay): `createModalOverlay` in `dom.js`, used by both `flow-modal.js` and `settings-modal.js`
  - **Pattern 3** (Readonly terminal): `createReadonlyTerminal` + `BOARD_TERMINAL_OPTS` already in `terminal-factory.js` / `board-helpers.js`
  - **Pattern 4** (Bus listener cleanup): `subscribeBus` / `unsubscribeBus` in `events.js`, used by `tab-manager.js`, `file-viewer.js`, `board-view.js`
  - **Pattern 5** (Map disposal): `disposeTerminalMap` in `terminal-factory.js`
  - **Pattern 6** (Terminal disposal wrappers): consolidated in `FlowCardTerminalManager._disposeTerminalEntry`
  - **Pattern 7** (Inline input setup): `setupInlineInput` in `dom.js`

## Test plan

- [x] `npm run build` passes
- [x] `npm test` passes (204 tests, 16 test files)
- [x] File-tree drag-and-drop behavior preserved (delegates to shared `setupDropZone`)
- [x] Context menu positioning behavior preserved (delegates to shared `positionInViewport`)

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)