### PR TITLE
refactor: factor 4 duplication patterns in main/

### DIFF
--- a/main/collection-helpers.js
+++ b/main/collection-helpers.js
@@ -1,0 +1,35 @@
+/**
+ * Generic collection utilities shared across helper modules.
+ */
+
+/**
+ * Groups an array of items by a key function.
+ * @param {Array} items
+ * @param {Function} keyFn - Returns the grouping key for each item
+ * @returns {Object} map of key -> array of items
+ */
+function groupBy(items, keyFn) {
+  const groups = {};
+  for (const item of items) {
+    const key = keyFn(item);
+    (groups[key] ||= []).push(item);
+  }
+  return groups;
+}
+
+/**
+ * Counts occurrences of each key produced by keyFn.
+ * @param {Array} items
+ * @param {Function} keyFn - Returns the key for each item
+ * @returns {Object} map of key -> count
+ */
+function countBy(items, keyFn) {
+  const counts = {};
+  for (const item of items) {
+    const key = keyFn(item);
+    counts[key] = (counts[key] || 0) + 1;
+  }
+  return counts;
+}
+
+module.exports = { groupBy, countBy };

--- a/main/config-helpers.js
+++ b/main/config-helpers.js
@@ -3,19 +3,16 @@
  * No I/O — deterministic functions that can be tested in isolation.
  */
 
+const { buildRecord } = require('./record-helpers');
+
 const DEFAULT_META = { defaultConfig: null };
 
 function sanitizeName(name) {
   return name.replace(/[^a-zA-Z0-9_\- ]/g, '_').substring(0, 64);
 }
 
-function buildConfigRecord(name, data, existing, now) {
-  return {
-    ...data,
-    name,
-    createdAt: existing?.createdAt || now,
-    updatedAt: now,
-  };
+function buildConfigRecord(name, data, existing, now = new Date().toISOString()) {
+  return buildRecord({ ...data, name }, { createdAt: existing?.createdAt || now, updatedAt: now });
 }
 
 function formatConfigList(configs, defaultConfigName) {

--- a/main/config-manager.js
+++ b/main/config-manager.js
@@ -26,7 +26,7 @@ async function writeMeta(meta) {
 async function save(name, data) {
   await ensureDir();
   const existing = await readJson(configPath(name));
-  const config = buildConfigRecord(name, data, existing, new Date().toISOString());
+  const config = buildConfigRecord(name, data, existing);
   await writeJson(configPath(name), config);
   return config;
 }

--- a/main/flow-manager.js
+++ b/main/flow-manager.js
@@ -11,6 +11,7 @@ const {
 } = require('./flow-helpers');
 const { safeSend } = require('./ipc-helpers');
 const { PollingTimer } = require('./polling-timer');
+const { buildRecord } = require('./record-helpers');
 
 const ensureDir = ensureDirOnce(LOGS_DIR);
 
@@ -43,11 +44,8 @@ class FlowManager {
   async save(flow) {
     await ensureDir();
     const existing = await this.get(flow.id);
-    const data = {
-      ...flow,
-      createdAt: existing?.createdAt || new Date().toISOString(),
-      updatedAt: new Date().toISOString(),
-    };
+    const now = new Date().toISOString();
+    const data = buildRecord(flow, { createdAt: existing?.createdAt || now, updatedAt: now });
     if (!data.runs) data.runs = [];
     if (data.enabled === undefined) data.enabled = true;
     await writeJson(flowPath(flow.id), data);

--- a/main/fs-manager-helpers.js
+++ b/main/fs-manager-helpers.js
@@ -13,6 +13,17 @@ async function safeAsync(fn) {
   }
 }
 
+/**
+ * Factory that wraps an async function with safeAsync error handling.
+ * @param {Function} fn - async function to wrap
+ * @returns {Function} wrapped function with same signature
+ */
+function createSafeHandler(fn) {
+  return function (...args) {
+    return safeAsync(() => fn(...args));
+  };
+}
+
 async function pathExists(filePath) {
   try {
     await fsp.access(filePath);
@@ -58,4 +69,4 @@ function dirFirstCompare(a, b) {
   return a.name.localeCompare(b.name);
 }
 
-module.exports = { MAX_FILE_SIZE, safeAsync, doCopy, dirFirstCompare };
+module.exports = { MAX_FILE_SIZE, safeAsync, createSafeHandler, doCopy, dirFirstCompare };

--- a/main/fs-manager.js
+++ b/main/fs-manager.js
@@ -2,7 +2,7 @@ const fs = require('fs');
 const fsp = fs.promises;
 const path = require('path');
 const os = require('os');
-const { MAX_FILE_SIZE, safeAsync, doCopy, dirFirstCompare } = require('./fs-manager-helpers');
+const { MAX_FILE_SIZE, createSafeHandler, doCopy, dirFirstCompare } = require('./fs-manager-helpers');
 
 // ---------------------------------------------------------------------------
 // File Watcher
@@ -51,50 +51,38 @@ async function readDirectory(dirPath) {
   }
 }
 
-async function readFile(filePath) {
-  return safeAsync(async () => {
-    const stat = await fsp.stat(filePath);
-    if (stat.size > MAX_FILE_SIZE) return { error: 'File too large (>2MB)' };
-    const content = await fsp.readFile(filePath, 'utf-8');
-    return { content, size: stat.size };
-  });
-}
+const readFile = createSafeHandler(async (filePath) => {
+  const stat = await fsp.stat(filePath);
+  if (stat.size > MAX_FILE_SIZE) return { error: 'File too large (>2MB)' };
+  const content = await fsp.readFile(filePath, 'utf-8');
+  return { content, size: stat.size };
+});
 
-async function writeFile(filePath, content) {
-  return safeAsync(async () => {
-    await fsp.writeFile(filePath, content, 'utf-8');
-    return { success: true };
-  });
-}
+const writeFile = createSafeHandler(async (filePath, content) => {
+  await fsp.writeFile(filePath, content, 'utf-8');
+  return { success: true };
+});
 
-async function makeDir(dirPath) {
-  return safeAsync(async () => {
-    await fsp.mkdir(dirPath, { recursive: true });
-    return { success: true };
-  });
-}
+const makeDir = createSafeHandler(async (dirPath) => {
+  await fsp.mkdir(dirPath, { recursive: true });
+  return { success: true };
+});
 
-async function copyEntry(srcPath) {
-  return safeAsync(async () => {
-    const destPath = await doCopy(srcPath, path.dirname(srcPath), true);
-    return { success: true, destPath };
-  });
-}
+const copyEntry = createSafeHandler(async (srcPath) => {
+  const destPath = await doCopy(srcPath, path.dirname(srcPath), true);
+  return { success: true, destPath };
+});
 
-async function copyFileTo(srcPath, destDir) {
-  return safeAsync(async () => {
-    const destPath = await doCopy(srcPath, destDir, false);
-    return { success: true, destPath };
-  });
-}
+const copyFileTo = createSafeHandler(async (srcPath, destDir) => {
+  const destPath = await doCopy(srcPath, destDir, false);
+  return { success: true, destPath };
+});
 
-async function renameEntry(oldPath, newName) {
-  return safeAsync(async () => {
-    const newPath = path.join(path.dirname(oldPath), newName);
-    await fsp.rename(oldPath, newPath);
-    return { success: true, newPath };
-  });
-}
+const renameEntry = createSafeHandler(async (oldPath, newName) => {
+  const newPath = path.join(path.dirname(oldPath), newName);
+  await fsp.rename(oldPath, newPath);
+  return { success: true, newPath };
+});
 
 function getHomedir() {
   return os.homedir();

--- a/main/record-helpers.js
+++ b/main/record-helpers.js
@@ -1,0 +1,16 @@
+/**
+ * Utility for building immutable record objects with automatic timestamp.
+ */
+
+/**
+ * Merges base and overrides into a new record, automatically setting updatedAt
+ * to the current ISO timestamp.
+ * @param {Object} base - The base object to spread
+ * @param {Object} overrides - Additional fields to apply on top (may include createdAt, etc.)
+ * @returns {Object} merged record with updatedAt set to now
+ */
+function buildRecord(base, overrides) {
+  return { ...base, updatedAt: new Date().toISOString(), ...overrides };
+}
+
+module.exports = { buildRecord };

--- a/main/usage-helpers.js
+++ b/main/usage-helpers.js
@@ -1,6 +1,7 @@
 const os = require('os');
 const path = require('path');
 const { computeRate, computeDuration, perDay, dateStr, DEFAULT_DAYS } = require('./stats-helpers');
+const { groupBy, countBy } = require('./collection-helpers');
 
 // ===== Declarative configs =====
 
@@ -25,25 +26,6 @@ const TOP_PROJECTS_LIMIT = 10;
 const CACHE_TTL = 30000;
 const TOP_FILES_LIMIT = 15;
 const GIT_TIMEOUT_MS = 5000;
-
-// ===== Collection helpers =====
-
-function _groupBy(items, keyFn) {
-  const groups = {};
-  for (const item of items) {
-    const key = keyFn(item);
-    (groups[key] ||= []).push(item);
-  }
-  return groups;
-}
-
-function _countBy(items, keyFn) {
-  const counts = {};
-  for (const item of items) {
-    counts[keyFn(item)] = (counts[keyFn(item)] || 0) + 1;
-  }
-  return counts;
-}
 
 // ===== Token helpers =====
 
@@ -189,7 +171,7 @@ function buildFlowMetrics(flows, flowRuns) {
 // ===== Agent helpers =====
 
 function getByAgent(sessions) {
-  return Object.entries(_groupBy(sessions, s => s.agent || 'Unknown'))
+  return Object.entries(groupBy(sessions, s => s.agent || 'Unknown'))
     .map(([agent, items]) => ({
       agent,
       totalSessions: items.length,
@@ -223,7 +205,7 @@ function buildFileKey(cwd, filePath) {
 
 function rankModifiedFiles(results, limit = TOP_FILES_LIMIT) {
   const allFiles = results.flatMap(({ cwd, files }) => files.map(f => buildFileKey(cwd, f)));
-  return Object.entries(_countBy(allFiles, k => k))
+  return Object.entries(countBy(allFiles, k => k))
     .map(([file, count]) => ({ file, count }))
     .sort((a, b) => b.count - a.count)
     .slice(0, limit);


### PR DESCRIPTION
## Summary

- **SafeAsync factory**: Added `createSafeHandler(fn)` to `main/fs-manager-helpers.js`; refactored 6 functions (`readFile`, `writeFile`, `makeDir`, `copyEntry`, `copyFileTo`, `renameEntry`) in `main/fs-manager.js` to use it instead of inline `safeAsync` wrapping
- **Collection utilities**: Extracted `groupBy`/`countBy` into new `main/collection-helpers.js`; removed private `_groupBy`/`_countBy` from `main/usage-helpers.js` and replaced with the shared versions
- **Record building**: Added `buildRecord(base, overrides)` in new `main/record-helpers.js` that auto-sets `updatedAt`; used in `buildConfigRecord` (`main/config-helpers.js`) and `FlowManager.save` (`main/flow-manager.js`)

## Files modified

- `main/fs-manager-helpers.js` — added `createSafeHandler` factory
- `main/fs-manager.js` — use `createSafeHandler` for 6 handler functions
- `main/collection-helpers.js` _(new)_ — shared `groupBy`/`countBy`
- `main/usage-helpers.js` — use shared `groupBy`/`countBy` from collection-helpers
- `main/record-helpers.js` _(new)_ — shared `buildRecord` utility
- `main/config-helpers.js` — use `buildRecord` in `buildConfigRecord`
- `main/config-manager.js` — drop now-redundant explicit `now` arg to `buildConfigRecord`
- `main/flow-manager.js` — use `buildRecord` in `save()`

## Test plan

- [x] `npm test` — 204 tests, all pass
- [x] `npm run build` — build completes cleanly
- No behavior changes; purely structural refactoring

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)