### PR TITLE
refactor: split tab-manager into smaller modules

### DIFF
--- a/src/components/tab-manager.js
+++ b/src/components/tab-manager.js
@@ -1,10 +1,8 @@
-import { generateId } from '../utils/id.js';
 import { bus, subscribeBus, unsubscribeBus } from '../utils/events.js';
 import { ConfigManager } from './config-manager.js';
-import { _el, showConfirmDialog } from '../utils/dom.js';
 import { extractFolderName } from '../utils/file-tree-helpers.js';
 import {
-  COLOR_GROUPS, WorkspaceTab,
+  COLOR_GROUPS,
   reorderEntries, findCycleTarget, findColorGroupTarget,
 } from '../utils/tab-manager-helpers.js';
 import { isTabVisible, buildColorFilters } from '../utils/tab-color-filter.js';
@@ -16,10 +14,16 @@ import {
   disposeSideView, disposeAllSideViews,
 } from '../utils/sidebar-manager.js';
 import {
-  renderWorkspace as doRenderWorkspace, reattachLayout, syncFileTree,
+  renderWorkspace as doRenderWorkspace, reattachLayout,
   serialize as doSerialize, restoreConfig as doRestoreConfig,
-  capturePanelWidths, disposeTab, disposeAllTabs,
+  capturePanelWidths, disposeAllTabs,
 } from '../utils/workspace-layout.js';
+import {
+  createTab as doCreateTab, closeTab as doCloseTab,
+  switchTo as doSwitchTo, findTabForTerminal,
+  onTerminalCwdChanged,
+} from '../utils/tab-lifecycle.js';
+import { _el } from '../utils/dom.js';
 
 export { COLOR_GROUPS };
 
@@ -94,12 +98,7 @@ export class TabManager {
   }
 
   // Find which tab owns a terminal
-  _findTabForTerminal(termId) {
-    for (const [, tab] of this.tabs) {
-      if (tab.terminalPanel?.terminals?.has(termId)) return tab;
-    }
-    return null;
-  }
+  _findTabForTerminal(termId) { return findTabForTerminal(this, termId); }
 
   _activeTab() {
     return this.tabs.get(this.activeTabId);
@@ -136,91 +135,11 @@ export class TabManager {
 
   autoSave() { return this.configManager.autoSave(); }
 
-  createTab(name = null, cwd = null) {
-    const id = generateId('tab');
-    const tabName = name || `Workspace ${this.tabs.size + 1}`;
-    const tab = new WorkspaceTab(id, tabName, cwd || this.defaultCwd || '/');
-    if (this.activeColorFilter) tab.colorGroup = this.activeColorFilter;
-    this.tabs.set(id, tab);
-    this.renderTabBar();
-    this.switchTo(id);
-    this.configManager.scheduleAutoSave();
-    return tab;
-  }
+  createTab(name = null, cwd = null) { return doCreateTab(this, name, cwd); }
 
-  async closeTab(id) {
-    const tab = this.tabs.get(id);
-    if (!tab) return;
+  closeTab(id) { return doCloseTab(this, id); }
 
-    const ok = await showConfirmDialog(
-      _el('p', null, 'Close workspace ', _el('strong', null, tab.name), '?'),
-      { confirmLabel: 'Close' },
-    );
-    if (!ok) return;
-
-    disposeTab(tab);
-    this.tabs.delete(id);
-
-    if (this.tabs.size === 0) {
-      this.createTab();
-      return;
-    }
-
-    if (this.activeTabId === id) {
-      const remaining = Array.from(this.tabs.values());
-      this.switchTo(remaining[0].id);
-    }
-
-    this.renderTabBar();
-    this.configManager.scheduleAutoSave();
-  }
-
-  switchTo(id) {
-    const tab = this.tabs.get(id);
-    if (!tab) return;
-
-    // If in a non-work mode, switch back to work mode
-    if (this.sidebarMode !== 'work') {
-      detachSidebarView(this, this.sidebarMode);
-      this.sidebarMode = 'work';
-      this.renderActivityBar();
-
-      // If this tab is already active, just re-show its layout
-      if (id === this.activeTabId) {
-        if (tab.layoutElement) {
-          reattachLayout(this, tab);
-          syncFileTree(tab);
-          bus.emit('workspace:activated');
-        }
-        this.renderTabBar();
-        return;
-      }
-    }
-
-    if (id === this.activeTabId) return;
-
-    // Detach outgoing tab (keep terminals alive!)
-    if (this.activeTabId) {
-      const prev = this.tabs.get(this.activeTabId);
-      if (prev && prev.layoutElement) {
-        // Capture panel widths before detaching (needs attached DOM)
-        capturePanelWidths(prev);
-        prev.layoutElement.remove();
-      }
-    }
-
-    this.activeTabId = id;
-    this.renderTabBar();
-
-    if (tab.layoutElement) {
-      reattachLayout(this, tab);
-      syncFileTree(tab);
-      bus.emit('workspace:activated');
-    } else {
-      // First time rendering this tab
-      this.renderWorkspace(tab);
-    }
-  }
+  switchTo(id) { return doSwitchTo(this, id); }
 
   setColorFilter(colorGroupId) {
     this.excludedColors.clear();
@@ -288,32 +207,7 @@ export class TabManager {
     );
   }
 
-  _onTerminalCwdChanged(termId, cwd) {
-    // Find the tab that owns this terminal
-    const tab = this._findTabForTerminal(termId);
-    if (!tab) return;
-
-    // Update file tree (works even for inactive tabs)
-    if (tab.fileTree) {
-      tab.fileTree.setTerminalRoot(termId, cwd);
-    }
-
-    // Update header path/branch only for the active tab's active terminal
-    if (
-      tab.id === this.activeTabId &&
-      tab.terminalPanel?.activeTerminal?.terminal?.id === termId
-    ) {
-      tab.cwd = cwd;
-      if (tab.pathTextEl) tab.pathTextEl.textContent = cwd;
-      if (tab.branchBadgeEl) {
-        window.api.git.branch(cwd).then((branch) => {
-          if (tab.branchBadgeEl) {
-            tab.branchBadgeEl.textContent = branch ? ` ${branch}` : '';
-          }
-        });
-      }
-    }
-  }
+  _onTerminalCwdChanged(termId, cwd) { onTerminalCwdChanged(this, termId, cwd); }
 
   _disposeSideView(mode) { disposeSideView(this, mode); }
 

--- a/src/utils/tab-lifecycle.js
+++ b/src/utils/tab-lifecycle.js
@@ -1,0 +1,171 @@
+/**
+ * Tab Lifecycle — extracted from tab-manager.js.
+ *
+ * Handles tab creation, removal, and activation (switchTo) logic.
+ * All functions receive a `ctx` (TabManager instance) as their first argument.
+ */
+
+import { generateId } from './id.js';
+import { showConfirmDialog, _el } from './dom.js';
+import { bus } from './events.js';
+import { WorkspaceTab } from './tab-manager-helpers.js';
+import {
+  reattachLayout, syncFileTree, capturePanelWidths, disposeTab,
+} from './workspace-layout.js';
+import { detachSidebarView } from './sidebar-manager.js';
+
+// ── Tab creation ──
+
+/**
+ * Create a new tab and switch to it.
+ * @param {object} ctx    - TabManager instance
+ * @param {string|null} name - Optional tab name
+ * @param {string|null} cwd  - Optional working directory
+ * @returns {WorkspaceTab}
+ */
+export function createTab(ctx, name = null, cwd = null) {
+  const id = generateId('tab');
+  const tabName = name || `Workspace ${ctx.tabs.size + 1}`;
+  const tab = new WorkspaceTab(id, tabName, cwd || ctx.defaultCwd || '/');
+  if (ctx.activeColorFilter) tab.colorGroup = ctx.activeColorFilter;
+  ctx.tabs.set(id, tab);
+  ctx.renderTabBar();
+  switchTo(ctx, id);
+  ctx.configManager.scheduleAutoSave();
+  return tab;
+}
+
+// ── Tab removal ──
+
+/**
+ * Close a tab by id, prompting the user for confirmation.
+ * @param {object} ctx - TabManager instance
+ * @param {string} id  - Tab id to close
+ */
+export async function closeTab(ctx, id) {
+  const tab = ctx.tabs.get(id);
+  if (!tab) return;
+
+  const ok = await showConfirmDialog(
+    _el('p', null, 'Close workspace ', _el('strong', null, tab.name), '?'),
+    { confirmLabel: 'Close' },
+  );
+  if (!ok) return;
+
+  disposeTab(tab);
+  ctx.tabs.delete(id);
+
+  if (ctx.tabs.size === 0) {
+    createTab(ctx);
+    return;
+  }
+
+  if (ctx.activeTabId === id) {
+    const remaining = Array.from(ctx.tabs.values());
+    switchTo(ctx, remaining[0].id);
+  }
+
+  ctx.renderTabBar();
+  ctx.configManager.scheduleAutoSave();
+}
+
+// ── Tab activation ──
+
+/**
+ * Activate a tab by id, handling sidebar mode transitions and DOM attachment.
+ * @param {object} ctx - TabManager instance
+ * @param {string} id  - Tab id to activate
+ */
+export function switchTo(ctx, id) {
+  const tab = ctx.tabs.get(id);
+  if (!tab) return;
+
+  // If in a non-work mode, switch back to work mode
+  if (ctx.sidebarMode !== 'work') {
+    detachSidebarView(ctx, ctx.sidebarMode);
+    ctx.sidebarMode = 'work';
+    ctx.renderActivityBar();
+
+    // If this tab is already active, just re-show its layout
+    if (id === ctx.activeTabId) {
+      if (tab.layoutElement) {
+        reattachLayout(ctx, tab);
+        syncFileTree(tab);
+        bus.emit('workspace:activated');
+      }
+      ctx.renderTabBar();
+      return;
+    }
+  }
+
+  if (id === ctx.activeTabId) return;
+
+  // Detach outgoing tab (keep terminals alive!)
+  if (ctx.activeTabId) {
+    const prev = ctx.tabs.get(ctx.activeTabId);
+    if (prev && prev.layoutElement) {
+      // Capture panel widths before detaching (needs attached DOM)
+      capturePanelWidths(prev);
+      prev.layoutElement.remove();
+    }
+  }
+
+  ctx.activeTabId = id;
+  ctx.renderTabBar();
+
+  if (tab.layoutElement) {
+    reattachLayout(ctx, tab);
+    syncFileTree(tab);
+    bus.emit('workspace:activated');
+  } else {
+    // First time rendering this tab
+    ctx.renderWorkspace(tab);
+  }
+}
+
+// ── Terminal CWD tracking ──
+
+/**
+ * Find which tab owns a given terminal id.
+ * @param {object} ctx     - TabManager instance
+ * @param {string} termId  - Terminal id to look up
+ * @returns {WorkspaceTab|null}
+ */
+export function findTabForTerminal(ctx, termId) {
+  for (const [, tab] of ctx.tabs) {
+    if (tab.terminalPanel?.terminals?.has(termId)) return tab;
+  }
+  return null;
+}
+
+/**
+ * Handle terminal cwd changes — update file tree and active-tab header.
+ * @param {object} ctx     - TabManager instance
+ * @param {string} termId  - Terminal id that changed
+ * @param {string} cwd     - New working directory
+ */
+export function onTerminalCwdChanged(ctx, termId, cwd) {
+  const tab = findTabForTerminal(ctx, termId);
+  if (!tab) return;
+
+  // Update file tree (works even for inactive tabs)
+  if (tab.fileTree) {
+    tab.fileTree.setTerminalRoot(termId, cwd);
+  }
+
+  // Update header path/branch only for the active tab's active terminal
+  if (
+    tab.id === ctx.activeTabId &&
+    tab.terminalPanel?.activeTerminal?.terminal?.id === termId
+  ) {
+    tab.cwd = cwd;
+    if (tab.pathTextEl) tab.pathTextEl.textContent = cwd;
+    if (tab.branchBadgeEl) {
+      window.api.git.branch(cwd).then((branch) => {
+        if (tab.branchBadgeEl) {
+          tab.branchBadgeEl.textContent = branch ? ` ${branch}` : '';
+        }
+      });
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Extracted tab lifecycle logic (createTab, closeTab, switchTo, onTerminalCwdChanged, findTabForTerminal) into `src/utils/tab-lifecycle.js`
- tab-manager.js reduced from 381 → 275 lines, with each method now a one-liner delegate following the existing ctx-based pattern
- Aligns with already-extracted modules: sidebar-manager, workspace-layout, tab-renderer, tab-color-filter, tab-drag, component-registry

## What was extracted

`src/utils/tab-lifecycle.js` (171 lines):
- `createTab(ctx, name, cwd)` — tab creation and activation
- `closeTab(ctx, id)` — confirmation dialog and tab removal
- `switchTo(ctx, id)` — sidebar mode transition and DOM attachment
- `findTabForTerminal(ctx, termId)` — terminal-to-tab lookup
- `onTerminalCwdChanged(ctx, termId, cwd)` — file tree and header path update

## Test plan
- [x] `npm run build` passes
- [x] `npm test` passes — 204/204 tests green across 16 test files
- [x] Tab-manager public API unchanged (all methods retained as delegates)

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)