### PR TITLE
refactor: split large components into smaller modules

### DIFF
--- a/src/components/file-tree.js
+++ b/src/components/file-tree.js
@@ -1,13 +1,18 @@
-import { bus } from '../utils/events.js';
-import { _el, setupInlineInput, setupDropZone } from '../utils/dom.js';
+import { _el } from '../utils/dom.js';
 import {
   CHEVRON_EXPANDED, CHEVRON_COLLAPSED,
-  DEBOUNCE_DELAY, INPUT_BLUR_DELAY, WATCH_PREFIX,
+  DEBOUNCE_DELAY, WATCH_PREFIX,
   SVG_ICONS, HEADER_ACTIONS,
-  computeIndent, extractFolderName, resolveWatchCwd,
+  extractFolderName, resolveWatchCwd,
 } from '../utils/file-tree-helpers.js';
 import { registerComponent } from '../utils/component-registry.js';
-import { showFileContextMenu, showDirContextMenu } from '../utils/file-tree-context-menu.js';
+import { showDirContextMenu } from '../utils/file-tree-context-menu.js';
+import { renderDirEntry, renderFileEntry } from '../utils/file-tree-renderer.js';
+import {
+  setupDropZone, handleFileDrop,
+  promptRename as doPromptRename,
+  promptNewEntry as doPromptNewEntry,
+} from '../utils/file-tree-drop.js';
 
 function _parseSvg(svgStr) {
   const doc = new DOMParser().parseFromString(svgStr, 'image/svg+xml');
@@ -188,77 +193,19 @@ export class FileTree {
   // --- Rename inline input ---
 
   promptRename(entryPath, nameEl) {
-    const oldName = entryPath.split('/').pop();
-    const input = _el('input', { className: 'file-tree-rename-input', type: 'text', value: oldName });
-
-    nameEl.style.display = 'none';
-    nameEl.parentElement.appendChild(input);
-    input.focus();
-    const dotIndex = oldName.lastIndexOf('.');
-    input.setSelectionRange(0, dotIndex > 0 ? dotIndex : oldName.length);
-
-    setupInlineInput(input, {
-      blurDelay: INPUT_BLUR_DELAY,
-      onCommit: async (newName) => {
-        input.remove();
-        nameEl.style.display = '';
-        if (!newName || newName === oldName) return;
-        await window.api.fs.rename(entryPath, newName);
-      },
-      onCancel: () => {
-        input.remove();
-        nameEl.style.display = '';
-      },
-    });
+    doPromptRename(entryPath, nameEl);
   }
 
   // --- New File / Folder inline input ---
 
   promptNewEntry(dirPath, parentContentEl, depth, expandedDirs, type) {
-    const input = _el('input', {
-      className: 'file-tree-new-input',
-      type: 'text',
-      placeholder: type === 'folder' ? 'folder name' : 'filename',
-      style: { marginLeft: `${computeIndent(depth + 1)}px` },
-    });
-
-    parentContentEl.prepend(input);
-    input.focus();
-
-    setupInlineInput(input, {
-      blurDelay: INPUT_BLUR_DELAY,
-      onCommit: async (name) => {
-        input.remove();
-        if (!name) return;
-        const newPath = dirPath + '/' + name;
-        if (type === 'folder') {
-          await window.api.fs.mkdir(newPath);
-        } else {
-          await window.api.fs.writefile(newPath, '');
-          bus.emit('file:open', { path: newPath, name });
-        }
-      },
-    });
+    doPromptNewEntry(dirPath, parentContentEl, depth, expandedDirs, type);
   }
 
   // --- Drag & Drop ---
 
   _setupDropZone(el, getTargetDir) {
-    setupDropZone(el, {
-      onDrop: async (files) => {
-        const targetDir = typeof getTargetDir === 'function' ? getTargetDir() : getTargetDir;
-        if (!targetDir) return;
-        await this._handleFileDrop(files, targetDir);
-      },
-    });
-  }
-
-  async _handleFileDrop(files, destDir) {
-    for (const file of files) {
-      if (file.path) {
-        await window.api.fs.copyTo(file.path, destDir);
-      }
-    }
+    setupDropZone(el, getTargetDir, handleFileDrop);
   }
 
   // --- Directory expand/collapse ---
@@ -279,67 +226,36 @@ export class FileTree {
 
   // --- Render directory entries ---
 
-  _buildRow(entry, depth) {
-    const chevron = _el('span', { className: 'file-tree-chevron' });
-    const name = _el('span', { className: 'file-tree-name', textContent: entry.name });
-    const row = _el('div', {
-      className: 'file-tree-item',
-      style: { paddingLeft: `${computeIndent(depth)}px` },
-    }, chevron, name);
-    return { row, chevron, name };
+  _getDirEntryCallbacks(expandedDirs) {
+    return {
+      setupDropZone: (el, targetDir) => this._setupDropZone(el, targetDir),
+      expandDir: (dirPath, childContainer, chevron, depth, eDirs) =>
+        this._expandDir(dirPath, childContainer, chevron, depth, eDirs),
+      collapseDir: (dirPath, childContainer, chevron, eDirs) =>
+        this._collapseDir(dirPath, childContainer, chevron, eDirs),
+      renderDir: (dirPath, parentEl, depth, eDirs) =>
+        this.renderDir(dirPath, parentEl, depth, eDirs),
+      findRootCwd: (entryPath) => this.findRootCwd(entryPath),
+      promptRename: (path, nameEl) => this.promptRename(path, nameEl),
+      promptNewEntry: (dirPath, cEl, depth, eDirs, type) =>
+        this.promptNewEntry(dirPath, cEl, depth, eDirs, type),
+    };
   }
 
   async _renderDirEntry(entry, parentEl, depth, expandedDirs) {
-    const { row, chevron, name } = this._buildRow(entry, depth);
-    const isExpanded = expandedDirs.has(entry.path);
-    chevron.textContent = isExpanded ? CHEVRON_EXPANDED : CHEVRON_COLLAPSED;
-    chevron.classList.toggle('expanded', isExpanded);
-
-    const childContainer = _el('div', { className: 'file-tree-children' });
-    parentEl.append(row, childContainer);
-
-    if (isExpanded) {
-      await this.renderDir(entry.path, childContainer, depth + 1, expandedDirs);
-    }
-
-    this._setupDropZone(row, entry.path);
-
-    row.addEventListener('click', async () => {
-      if (expandedDirs.has(entry.path)) {
-        this._collapseDir(entry.path, childContainer, chevron, expandedDirs);
-      } else {
-        await this._expandDir(entry.path, childContainer, chevron, depth, expandedDirs);
-      }
-    });
-
-    row.addEventListener('contextmenu', async (e) => {
-      e.preventDefault();
-      e.stopPropagation();
-      if (!expandedDirs.has(entry.path)) {
-        await this._expandDir(entry.path, childContainer, chevron, depth, expandedDirs);
-      }
-      showDirContextMenu(e.clientX, e.clientY, entry.path, this.findRootCwd(entry.path), childContainer, depth + 1, expandedDirs, name,
-        (path, nameEl) => this.promptRename(path, nameEl),
-        (dirPath, cEl, d, eDirs, type) => this.promptNewEntry(dirPath, cEl, d, eDirs, type));
-    });
+    await renderDirEntry(entry, parentEl, depth, expandedDirs, this._getDirEntryCallbacks(expandedDirs));
   }
 
   _renderFileEntry(entry, parentEl, depth) {
-    const { row, name } = this._buildRow(entry, depth);
-    parentEl.appendChild(row);
-
-    row.addEventListener('click', () => {
-      if (this._activeRow) this._activeRow.classList.remove('active');
-      row.classList.add('active');
-      this._activeRow = row;
-      bus.emit('file:open', { path: entry.path, name: entry.name });
-    });
-
-    row.addEventListener('contextmenu', (e) => {
-      e.preventDefault();
-      e.stopPropagation();
-      showFileContextMenu(e.clientX, e.clientY, entry.path, name, this.findRootCwd(entry.path),
-        (path, nameEl) => this.promptRename(path, nameEl));
+    const self = this;
+    const activeRowRef = {
+      get current() { return self._activeRow; },
+      set current(v) { self._activeRow = v; },
+    };
+    renderFileEntry(entry, parentEl, depth, {
+      activeRowRef,
+      findRootCwd: (entryPath) => this.findRootCwd(entryPath),
+      promptRename: (path, nameEl) => this.promptRename(path, nameEl),
     });
   }
 

--- a/src/components/file-viewer.js
+++ b/src/components/file-viewer.js
@@ -1,9 +1,10 @@
 import { detectLanguage } from '../utils/file-icons.js';
 import { bus, subscribeBus, unsubscribeBus } from '../utils/events.js';
 import { GitChangesView } from './git-changes-view.js';
-import { contextMenu } from './context-menu.js';
 import { _el } from '../utils/dom.js';
-import { getCursorPosition, insertTab, SAVE_FLASH_MS, TAB_SPACES, EMPTY_MESSAGE, STATIC_MODES, MODE_CONFIG, ALL_STATIC_ELEMENTS, MODE_ACTIVATE, pinnedFiles } from '../utils/editor-helpers.js';
+import { EMPTY_MESSAGE, STATIC_MODES, MODE_CONFIG, ALL_STATIC_ELEMENTS, MODE_ACTIVATE, pinnedFiles } from '../utils/editor-helpers.js';
+import { createEditorDOM, bindEditorEvents, updateLineNumbers, updateHighlight, updateStatusBar, saveFile } from '../utils/file-editor-renderer.js';
+import { renderTabs as renderTabsHelper } from '../utils/file-viewer-tabs.js';
 import { registerComponent } from '../utils/component-registry.js';
 import { WebviewManager } from './file-viewer-webview.js';
 
@@ -147,86 +148,16 @@ export class FileViewer {
     return file.content !== file.savedContent;
   }
 
-  _createTabEl(filePath, file) {
-    const tab = _el('div', 'file-tab');
-    if (filePath === this.activeFile) tab.classList.add('active');
-
-    const pinned = this.isPinned(filePath);
-    const modified = this.isModified(filePath);
-
-    if (pinned) tab.appendChild(_el('span', 'file-tab-pin', '\u{1F4CC}'));
-    tab.appendChild(_el('span', 'file-tab-modified', modified ? '\u25CF' : ''));
-    tab.appendChild(_el('span', null, file.name));
-
-    const close = _el('span', 'file-tab-close', '\u00D7');
-    close.addEventListener('click', (e) => { e.stopPropagation(); this.closeFile(filePath); });
-    tab.appendChild(close);
-
-    tab.addEventListener('click', () => this.setActiveTab(filePath));
-    tab.addEventListener('contextmenu', (e) => {
-      e.preventDefault();
-      contextMenu.show(e.clientX, e.clientY, [
-        { label: pinned ? 'Unpin from all workspaces' : 'Pin across workspaces', action: () => this.togglePin(filePath) },
-        { separator: true },
-        { label: 'Close', action: () => this.closeFile(filePath) },
-      ]);
-    });
-
-    return tab;
-  }
-
   renderTabs() {
-    this.tabsBar.replaceChildren();
-    for (const [filePath, file] of this.openFiles) {
-      this.tabsBar.appendChild(this._createTabEl(filePath, file));
-    }
-  }
-
-  _createEditorDOM(file) {
-    this.lineNumbers = _el('div', 'editor-line-numbers');
-    this.highlightLayer = _el('pre', 'editor-highlight-layer');
-
-    this.editorEl = _el('textarea', 'editor-textarea');
-    this.editorEl.value = file.content;
-    this.editorEl.spellcheck = false;
-    this.editorEl.setAttribute('autocorrect', 'off');
-    this.editorEl.setAttribute('autocapitalize', 'off');
-
-    const editArea = _el('div', 'editor-edit-area');
-    editArea.append(this.highlightLayer, this.editorEl);
-    this.editorWrapper.append(this.lineNumbers, editArea);
-  }
-
-  _bindEditorEvents(file) {
-    this.editorEl.addEventListener('input', () => {
-      file.content = this.editorEl.value;
-      this.updateLineNumbers();
-      this.updateHighlight();
-      this.renderTabs();
-      this.updateStatusBar();
-    });
-
-    this.editorEl.addEventListener('scroll', () => {
-      this.lineNumbers.scrollTop = this.editorEl.scrollTop;
-      this.highlightLayer.scrollTop = this.editorEl.scrollTop;
-      this.highlightLayer.scrollLeft = this.editorEl.scrollLeft;
-    });
-
-    this.editorEl.addEventListener('keydown', (e) => {
-      if ((e.metaKey || e.ctrlKey) && e.key === 's') {
-        e.preventDefault();
-        e.stopPropagation();
-        this.saveActive();
-        return;
-      }
-      if (e.key === 'Tab') {
-        e.preventDefault();
-        const result = insertTab(this.editorEl.value, this.editorEl.selectionStart, this.editorEl.selectionEnd, TAB_SPACES);
-        this.editorEl.value = result.text;
-        this.editorEl.selectionStart = this.editorEl.selectionEnd = result.cursorPos;
-        this.editorEl.dispatchEvent(new Event('input'));
-      }
-    });
+    renderTabsHelper(this.tabsBar, this.openFiles, this.activeFile,
+      (p) => this.isPinned(p),
+      (p) => this.isModified(p),
+      {
+        onClose: (p) => this.closeFile(p),
+        onActivate: (p) => this.setActiveTab(p),
+        onTogglePin: (p) => this.togglePin(p),
+      },
+    );
   }
 
   renderEditor() {
@@ -243,8 +174,15 @@ export class FileViewer {
       return;
     }
 
-    this._createEditorDOM(file);
-    this._bindEditorEvents(file);
+    const { lineNumbers, highlightLayer, editorEl } = createEditorDOM(this.editorWrapper, file);
+    this.lineNumbers = lineNumbers;
+    this.highlightLayer = highlightLayer;
+    this.editorEl = editorEl;
+
+    bindEditorEvents(this.editorEl, this.lineNumbers, this.highlightLayer, file, {
+      onUpdate: () => { this.updateLineNumbers(); this.updateHighlight(); this.renderTabs(); this.updateStatusBar(); },
+      onSave: () => this.saveActive(),
+    });
     this.updateLineNumbers();
     this.updateHighlight();
     this.updateStatusBar();
@@ -252,71 +190,30 @@ export class FileViewer {
   }
 
   updateLineNumbers() {
-    if (!this.lineNumbers || !this.editorEl) return;
-    const count = this.editorEl.value.split('\n').length;
-    const frag = document.createDocumentFragment();
-    for (let i = 1; i <= count; i++) {
-      if (i > 1) frag.appendChild(document.createTextNode('\n'));
-      frag.appendChild(_el('span', null, String(i)));
-    }
-    this.lineNumbers.replaceChildren(frag);
+    updateLineNumbers(this.lineNumbers, this.editorEl);
   }
 
   updateHighlight() {
-    if (!this.highlightLayer || !this.editorEl) return;
     const file = this.openFiles.get(this.activeFile);
     if (!file) return;
-
-    const code = document.createElement('code');
-    code.className = `language-${file.lang}`;
-    // Need trailing newline so the pre sizing matches the textarea
-    code.textContent = this.editorEl.value + '\n';
-
-    this.highlightLayer.replaceChildren(code);
-
-    if (window.hljs) {
-      window.hljs.highlightElement(code);
-    }
-  }
-
-  _getCursorPosition() {
-    return getCursorPosition(this.editorEl.value, this.editorEl.selectionStart);
+    updateHighlight(this.highlightLayer, this.editorEl, file.lang);
   }
 
   updateStatusBar() {
     if (!this.statusBar || !this.editorEl) return;
     const file = this.openFiles.get(this.activeFile);
     if (!file) { this.statusBar.replaceChildren(); return; }
-
-    const { line, col, totalLines } = this._getCursorPosition();
-    const modified = this.isModified(this.activeFile);
-
-    this.statusBar.replaceChildren(
-      _el('span', 'status-item', file.lang),
-      _el('span', 'status-item', `Ln ${line}, Col ${col}`),
-      _el('span', 'status-item', `${totalLines} lines`),
-      _el('span', modified ? 'status-item status-modified' : 'status-item status-saved', modified ? 'Modified' : 'Saved'),
-      _el('span', 'status-save-hint', modified ? '\u2318S to save' : ''),
-    );
+    updateStatusBar(this.statusBar, this.editorEl, file);
   }
 
   async saveActive() {
     const file = this.openFiles.get(this.activeFile);
-    if (!file || file.error) return;
-
-    const result = await window.api.fs.writefile(this.activeFile, file.content);
-    if (result.error) {
-      this.statusBar.replaceChildren(_el('span', 'status-item status-error', `Save failed: ${result.error}`));
-      return;
-    }
-
-    file.savedContent = file.content;
-    this.renderTabs();
-    this.updateStatusBar();
-
-    // Flash save indicator
-    this.statusBar.classList.add('save-flash');
-    setTimeout(() => this.statusBar.classList.remove('save-flash'), SAVE_FLASH_MS);
+    await saveFile(this.activeFile, file, this.statusBar, {
+      onSuccess: () => {
+        this.renderTabs();
+        this.updateStatusBar();
+      },
+    });
   }
 
   closeFile(filePath) {
@@ -352,17 +249,12 @@ export class FileViewer {
 
   // ===== Mode Bar =====
 
-  _buildStaticModeBtn({ key, label }) {
-    const btn = _el('button', `mode-btn${this.mode === key ? ' active' : ''}`, label);
-    btn.addEventListener('click', () => this.switchMode(key));
-    return btn;
-  }
-
   _renderModeBar() {
     this.modeBar.replaceChildren();
-
-    for (const mode of STATIC_MODES) {
-      this.modeBar.appendChild(this._buildStaticModeBtn(mode));
+    for (const { key, label } of STATIC_MODES) {
+      const btn = _el('button', `mode-btn${this.mode === key ? ' active' : ''}`, label);
+      btn.addEventListener('click', () => this.switchMode(key));
+      this.modeBar.appendChild(btn);
     }
     for (const wt of this._webviewMgr.webviewTabs) {
       this.modeBar.appendChild(this._webviewMgr.buildWebviewModeBtn(wt, this.mode));

--- a/src/components/flow-view.js
+++ b/src/components/flow-view.js
@@ -6,11 +6,11 @@ import {
   EMPTY_LIST_MESSAGE, UNCATEGORIZED, HEADER_BUTTONS,
   getFlowsForCategory, getUncategorizedFlows,
   removeFlowFromOrder, moveFlowInOrder, deleteCategoryData,
-  getLastRun,
 } from '../utils/flow-view-helpers.js';
 import { createCardHeader } from '../utils/flow-card-renderer.js';
 import { FlowCardTerminalManager } from './flow-card-terminal.js';
-import { createCategoryGroup, cleanupAllDragState } from './flow-category-renderer.js';
+import { createCategoryGroup } from './flow-category-renderer.js';
+import { setupCardDrag, buildCardBody, setupCardHeaderClick } from '../utils/flow-card-setup.js';
 
 
 export class FlowView {
@@ -25,9 +25,8 @@ export class FlowView {
     this._collapsedCategories = new Set();
     this._runningMap = {};
 
-    // Drag state
-    this._dragFlowId = null;
-    this._dragSourceCat = null;
+    // Drag state (shared mutable object for use with setupCardDrag)
+    this._drag = { flowId: null, catId: null };
 
     this._unsubStarted = window.api.flow.onRunStarted(({ flowId, ptyId }) => {
       this._runningMap[flowId] = ptyId;
@@ -129,8 +128,8 @@ export class FlowView {
         this._renderList();
       },
       dragState: {
-        getDragFlowId: () => this._dragFlowId,
-        clearDrag: () => { this._dragFlowId = null; this._dragSourceCat = null; },
+        getDragFlowId: () => this._drag.flowId,
+        clearDrag: () => { this._drag.flowId = null; this._drag.catId = null; },
       },
     });
 
@@ -177,7 +176,7 @@ export class FlowView {
     if (isRunning) card.classList.add('flow-card-running');
     if (isExpanded) card.classList.add('flow-card-expanded');
 
-    this._setupCardDrag(card, flow.id, catId);
+    setupCardDrag(card, flow.id, catId, this._drag);
 
     const headerRow = createCardHeader(flow, isRunning, isExpanded, {
       onToggleOutput: (flowId) => {
@@ -195,68 +194,17 @@ export class FlowView {
     });
     card.appendChild(headerRow);
 
-    const body = this._buildCardBody(flow, isRunning, isExpanded);
+    const body = buildCardBody(flow, isRunning, isExpanded, this._termManager, this._runningMap);
     if (body) card.appendChild(body);
 
-    this._setupCardHeaderClick(headerRow, flow, isRunning);
+    setupCardHeaderClick(headerRow, flow, isRunning, {
+      expandedCards: this._expandedCards,
+      onRenderList: () => this._renderList(),
+      onOpenModal: (f) => this._openModal(f),
+      termManager: this._termManager,
+    });
 
     return card;
-  }
-
-  _setupCardDrag(card, flowId, catId) {
-    card.addEventListener('dragstart', (e) => {
-      this._dragFlowId = flowId;
-      this._dragSourceCat = catId;
-      card.classList.add('flow-dragging');
-      e.dataTransfer.effectAllowed = 'move';
-      e.dataTransfer.setData('text/plain', flowId);
-    });
-
-    card.addEventListener('dragend', () => {
-      card.classList.remove('flow-dragging');
-      this._dragFlowId = null;
-      this._dragSourceCat = null;
-      cleanupAllDragState();
-    });
-  }
-
-  _buildCardBody(flow, isRunning, isExpanded) {
-    if (isRunning) {
-      const container = this._termManager.createLiveTerminal(flow.id, this._runningMap[flow.id]);
-      container.style.display = isExpanded ? '' : 'none';
-      return container;
-    }
-    if (isExpanded) {
-      const lastRun = getLastRun(flow);
-      if (lastRun) {
-        const termArea = _el('div', 'flow-card-terminal');
-        this._termManager.loadLogIntoContainer(flow.id, lastRun, termArea);
-        return termArea;
-      }
-    }
-    return null;
-  }
-
-  _setupCardHeaderClick(headerRow, flow, isRunning) {
-    headerRow.addEventListener('click', () => {
-      if (isRunning) {
-        if (this._expandedCards.has(flow.id)) this._expandedCards.delete(flow.id);
-        else this._expandedCards.add(flow.id);
-        this._renderList();
-        return;
-      }
-      if (!flow.runs?.length) {
-        this._openModal(flow);
-        return;
-      }
-      if (this._expandedCards.has(flow.id)) {
-        this._expandedCards.delete(flow.id);
-        this._termManager.disposeLogTerminal(flow.id);
-      } else {
-        this._expandedCards.add(flow.id);
-      }
-      this._renderList();
-    });
   }
 
 

--- a/src/components/terminal-panel.js
+++ b/src/components/terminal-panel.js
@@ -1,25 +1,20 @@
 import { bus } from '../utils/events.js';
 import { _el } from '../utils/dom.js';
 import { trackMouse } from '../utils/drag-helpers.js';
-import { TerminalInstance } from '../utils/terminal-instance.js';
 import {
-  DRAG_GRIP, SplitNode, RESIZE_CURSOR,
-  isSameDirectionSplit, createSplitContainer, adjacentPanels, equalizeChildren, doResize,
+  SplitNode, RESIZE_CURSOR,
+  isSameDirectionSplit, createSplitContainer, equalizeChildren, doResize,
 } from '../utils/terminal-panel-helpers.js';
-import {
-  findClosestInDirection,
-  directionFromSide,
-  isInsertBefore,
-} from '../utils/split-helpers.js';
 import { DropIndicatorManager } from '../utils/terminal-drop-indicator.js';
 import { registerComponent } from '../utils/component-registry.js';
 import { serializeLayout, serializeElement } from '../utils/terminal-serializer.js';
+import { detachElement } from '../utils/split-layout-ops.js';
 import {
-  detachElement,
-  moveToCenter,
-  insertIntoSplit,
-  wrapInNewSplit,
-} from '../utils/split-layout-ops.js';
+  buildTopBar,
+  createTerminalNode as createTerminalNodeHelper,
+  buildFromTree as buildFromTreeHelper,
+} from '../utils/terminal-node-builder.js';
+import { moveTerminal as moveTerminalHelper, splitTerminal, focusDirection as focusDirectionHelper } from '../utils/terminal-split-ops.js';
 
 export class TerminalPanel {
   constructor(container, cwd) {
@@ -57,25 +52,10 @@ export class TerminalPanel {
   }
 
   _buildTopBar(node) {
-    const topBar = _el('div', 'terminal-top-bar');
-
-    const dragHandle = _el('div', 'terminal-drag-handle', { title: 'Drag to move' });
-    dragHandle.appendChild(_el('span', 'drag-grip', { textContent: DRAG_GRIP }));
-
-    const closeBtn = _el('button', 'terminal-close-btn', {
-      textContent: '×',
-      title: 'Close terminal',
+    return buildTopBar(node, {
+      onClose: () => this.removeTerminal(node.terminal.id),
+      setupDrag: (handle, n) => this.setupDrag(handle, n),
     });
-    closeBtn.addEventListener('click', (e) => {
-      e.stopPropagation();
-      this.removeTerminal(node.terminal.id);
-    });
-
-    topBar.appendChild(dragHandle);
-    topBar.appendChild(closeBtn);
-
-    this.setupDrag(dragHandle, node);
-    return topBar;
   }
 
   init() {
@@ -105,50 +85,17 @@ export class TerminalPanel {
   }
 
   buildFromTree(tree) {
-    if (tree.type === 'terminal') {
-      const node = this.createTerminalNode(tree.cwd);
-      node.element.style.flex = String(tree.flex || 1);
-      return node;
-    }
-
-    const splitEl = createSplitContainer(tree.direction, tree.flex || 1);
-
-    const splitNode = new SplitNode('split');
-    splitNode.direction = tree.direction;
-    splitNode.element = splitEl;
-
-    for (let i = 0; i < tree.children.length; i++) {
-      if (i > 0) splitEl.appendChild(this._createSplitHandle(tree.direction, splitEl));
-      const childNode = this.buildFromTree(tree.children[i]);
-      splitEl.appendChild(childNode.element);
-      splitNode.children.push(childNode);
-      childNode.parent = splitNode;
-    }
-
-    return splitNode;
+    return buildFromTreeHelper(tree, {
+      createTerminalNode: (cwd) => this.createTerminalNode(cwd),
+      createSplitHandle: (d, s) => this._createSplitHandle(d, s),
+    });
   }
 
   createTerminalNode(cwd = null) {
-    const spawnCwd = cwd || this.cwd;
-    const node = new SplitNode('terminal');
-
-    const wrapper = _el('div', 'terminal-wrapper');
-    const termContainer = _el('div', 'terminal-container');
-
-    wrapper.appendChild(this._buildTopBar(node));
-    wrapper.appendChild(termContainer);
-
-    node.element = wrapper;
-    node.terminal = new TerminalInstance(termContainer, spawnCwd);
-    this.terminals.set(node.terminal.id, node);
-
-    bus.emit('terminal:created', { id: node.terminal.id, cwd: spawnCwd });
-
-    wrapper.addEventListener('mousedown', () => {
-      this.setActive(node);
+    return createTerminalNodeHelper(cwd, this.cwd, this.terminals, {
+      buildTopBar: (node) => this._buildTopBar(node),
+      onMousedown: (node) => this.setActive(node),
     });
-
-    return node;
   }
 
   // ===== Drag & Drop =====
@@ -179,37 +126,11 @@ export class TerminalPanel {
   }
 
   moveTerminal(sourceId, targetId, side) {
-    const sourceNode = this.terminals.get(sourceId);
-    const targetNode = this.terminals.get(targetId);
-    if (!sourceNode || !targetNode) return;
-    if (sourceNode === targetNode) return;
-
-    const sourceEl = sourceNode.element;
-    const targetEl = targetNode.element;
-
-    detachElement(sourceEl);
-
-    if (side === 'center') {
-      moveToCenter(sourceEl, targetEl);
-    } else {
-      const direction = directionFromSide(side);
-      const before = isInsertBefore(side);
-      const parentEl = targetEl.parentElement;
-
-      if (isSameDirectionSplit(parentEl, direction)) {
-        insertIntoSplit(sourceEl, targetEl, direction, before, parentEl,
-          (d, s) => this._createSplitHandle(d, s),
-          (s) => equalizeChildren(s));
-      } else {
-        wrapInNewSplit(sourceEl, targetEl, direction, before, parentEl,
-          (d, f) => createSplitContainer(d, f),
-          (d, s) => this._createSplitHandle(d, s));
-      }
-    }
-
-    this.fitAll();
-    this.setActive(sourceNode);
-    bus.emit('layout:changed');
+    moveTerminalHelper(sourceId, targetId, side, this.terminals, {
+      createSplitHandle: (d, s) => this._createSplitHandle(d, s),
+      fitAll: () => this.fitAll(),
+      setActive: (node) => this.setActive(node),
+    });
   }
 
   setActive(node) {
@@ -235,55 +156,17 @@ export class TerminalPanel {
   }
 
   focusDirection(dir) {
-    if (!this.activeTerminal || this.terminals.size < 2) return;
-
-    const activeRect = this.activeTerminal.element.getBoundingClientRect();
-    const activeCenter = {
-      cx: activeRect.left + activeRect.width / 2,
-      cy: activeRect.top + activeRect.height / 2,
-    };
-
-    const candidates = [];
-    for (const [id, node] of this.terminals) {
-      if (node === this.activeTerminal) continue;
-      const rect = node.element.getBoundingClientRect();
-      candidates.push({ id, cx: rect.left + rect.width / 2, cy: rect.top + rect.height / 2 });
-    }
-
-    const bestId = findClosestInDirection(activeCenter, candidates, dir);
-    if (bestId) this.setActive(this.terminals.get(bestId));
+    focusDirectionHelper(this.activeTerminal, this.terminals, dir, (node) => this.setActive(node));
   }
 
   split(targetNode, direction) {
-    const parentEl = targetNode.element.parentElement;
-
-    const sourceCwd = targetNode.terminal ? targetNode.terminal.cwd : this.cwd;
-    const newTermNode = this.createTerminalNode(sourceCwd);
-
-    if (isSameDirectionSplit(parentEl, direction)) {
-      const handle = this._createSplitHandle(direction, parentEl);
-      targetNode.element.insertAdjacentElement('afterend', handle);
-      handle.insertAdjacentElement('afterend', newTermNode.element);
-      equalizeChildren(parentEl);
-    } else {
-      const splitEl = createSplitContainer(direction, targetNode.element.style.flex || '1');
-      parentEl.replaceChild(splitEl, targetNode.element);
-
-      splitEl.appendChild(targetNode.element);
-      splitEl.appendChild(this._createSplitHandle(direction, splitEl));
-      splitEl.appendChild(newTermNode.element);
-      equalizeChildren(splitEl);
-
-      if (this.root === targetNode) {
-        const newSplitNode = new SplitNode('split');
-        newSplitNode.direction = direction;
-        newSplitNode.element = splitEl;
-        this.root = newSplitNode;
-      }
-    }
-
-    this.fitAll();
-    this.setActive(newTermNode);
+    splitTerminal(targetNode, direction, { cwd: this.cwd, root: this.root }, {
+      createTerminalNode: (cwd) => this.createTerminalNode(cwd),
+      createSplitHandle: (d, s) => this._createSplitHandle(d, s),
+      fitAll: () => this.fitAll(),
+      setActive: (node) => this.setActive(node),
+      setRoot: (node) => { this.root = node; },
+    });
   }
 
   setupResizeHandle(handle, splitEl, direction) {

--- a/src/utils/file-editor-renderer.js
+++ b/src/utils/file-editor-renderer.js
@@ -1,0 +1,149 @@
+/**
+ * DOM construction and event binding helpers for the FileViewer editor mode.
+ * Extracted from file-viewer.js to reduce component size.
+ */
+
+import { _el } from './dom.js';
+import { getCursorPosition, insertTab, SAVE_FLASH_MS, TAB_SPACES } from './editor-helpers.js';
+
+/**
+ * Build the line-numbers, highlight layer, and textarea DOM elements,
+ * appending them into `editorWrapper`.
+ * Returns { lineNumbers, highlightLayer, editorEl }.
+ *
+ * @param {HTMLElement} editorWrapper
+ * @param {Object} file - { content }
+ * @returns {{ lineNumbers: HTMLElement, highlightLayer: HTMLElement, editorEl: HTMLTextAreaElement }}
+ */
+export function createEditorDOM(editorWrapper, file) {
+  const lineNumbers = _el('div', 'editor-line-numbers');
+  const highlightLayer = _el('pre', 'editor-highlight-layer');
+
+  const editorEl = _el('textarea', 'editor-textarea');
+  editorEl.value = file.content;
+  editorEl.spellcheck = false;
+  editorEl.setAttribute('autocorrect', 'off');
+  editorEl.setAttribute('autocapitalize', 'off');
+
+  const editArea = _el('div', 'editor-edit-area');
+  editArea.append(highlightLayer, editorEl);
+  editorWrapper.append(lineNumbers, editArea);
+
+  return { lineNumbers, highlightLayer, editorEl };
+}
+
+/**
+ * Bind input, scroll, and keydown events to the editor textarea.
+ *
+ * @param {HTMLTextAreaElement} editorEl
+ * @param {HTMLElement} lineNumbers
+ * @param {HTMLElement} highlightLayer
+ * @param {Object} file - mutable file object (content is updated on input)
+ * @param {{ onUpdate: Function, onSave: Function }} callbacks
+ */
+export function bindEditorEvents(editorEl, lineNumbers, highlightLayer, file, { onUpdate, onSave }) {
+  editorEl.addEventListener('input', () => {
+    file.content = editorEl.value;
+    onUpdate();
+  });
+
+  editorEl.addEventListener('scroll', () => {
+    lineNumbers.scrollTop = editorEl.scrollTop;
+    highlightLayer.scrollTop = editorEl.scrollTop;
+    highlightLayer.scrollLeft = editorEl.scrollLeft;
+  });
+
+  editorEl.addEventListener('keydown', (e) => {
+    if ((e.metaKey || e.ctrlKey) && e.key === 's') {
+      e.preventDefault();
+      e.stopPropagation();
+      onSave();
+      return;
+    }
+    if (e.key === 'Tab') {
+      e.preventDefault();
+      const result = insertTab(editorEl.value, editorEl.selectionStart, editorEl.selectionEnd, TAB_SPACES);
+      editorEl.value = result.text;
+      editorEl.selectionStart = editorEl.selectionEnd = result.cursorPos;
+      editorEl.dispatchEvent(new Event('input'));
+    }
+  });
+}
+
+/**
+ * Rebuild the line-numbers element from current editor content.
+ *
+ * @param {HTMLElement} lineNumbers
+ * @param {HTMLTextAreaElement} editorEl
+ */
+export function updateLineNumbers(lineNumbers, editorEl) {
+  if (!lineNumbers || !editorEl) return;
+  const count = editorEl.value.split('\n').length;
+  const frag = document.createDocumentFragment();
+  for (let i = 1; i <= count; i++) {
+    if (i > 1) frag.appendChild(document.createTextNode('\n'));
+    frag.appendChild(_el('span', null, String(i)));
+  }
+  lineNumbers.replaceChildren(frag);
+}
+
+/**
+ * Rebuild the syntax-highlight layer from current editor content.
+ *
+ * @param {HTMLElement} highlightLayer
+ * @param {HTMLTextAreaElement} editorEl
+ * @param {string} lang - highlight.js language identifier
+ */
+export function updateHighlight(highlightLayer, editorEl, lang) {
+  if (!highlightLayer || !editorEl) return;
+  const code = document.createElement('code');
+  code.className = `language-${lang}`;
+  // Trailing newline keeps pre sizing in sync with textarea
+  code.textContent = editorEl.value + '\n';
+  highlightLayer.replaceChildren(code);
+  if (window.hljs) {
+    window.hljs.highlightElement(code);
+  }
+}
+
+/**
+ * Rebuild the status bar from current editor/file state.
+ *
+ * @param {HTMLElement} statusBar
+ * @param {HTMLTextAreaElement} editorEl
+ * @param {Object} file - { lang, content, savedContent }
+ */
+export function updateStatusBar(statusBar, editorEl, file) {
+  if (!statusBar || !editorEl || !file) return;
+  const { line, col, totalLines } = getCursorPosition(editorEl.value, editorEl.selectionStart);
+  const modified = file.content !== file.savedContent;
+  statusBar.replaceChildren(
+    _el('span', 'status-item', file.lang),
+    _el('span', 'status-item', `Ln ${line}, Col ${col}`),
+    _el('span', 'status-item', `${totalLines} lines`),
+    _el('span', modified ? 'status-item status-modified' : 'status-item status-saved', modified ? 'Modified' : 'Saved'),
+    _el('span', 'status-save-hint', modified ? '\u2318S to save' : ''),
+  );
+}
+
+/**
+ * Persist the active file to disk and flash the status bar.
+ * Mutates file.savedContent on success.
+ *
+ * @param {string} filePath
+ * @param {Object} file - { content, savedContent, error }
+ * @param {HTMLElement} statusBar
+ * @param {{ onSuccess: Function }} callbacks
+ */
+export async function saveFile(filePath, file, statusBar, { onSuccess }) {
+  if (!file || file.error) return;
+  const result = await window.api.fs.writefile(filePath, file.content);
+  if (result.error) {
+    statusBar.replaceChildren(_el('span', 'status-item status-error', `Save failed: ${result.error}`));
+    return;
+  }
+  file.savedContent = file.content;
+  onSuccess();
+  statusBar.classList.add('save-flash');
+  setTimeout(() => statusBar.classList.remove('save-flash'), SAVE_FLASH_MS);
+}

--- a/src/utils/file-tree-drop.js
+++ b/src/utils/file-tree-drop.js
@@ -1,0 +1,123 @@
+/**
+ * Drag-and-drop (file drop) and inline-input helpers for FileTree.
+ * Extracted from file-tree.js to reduce component size.
+ */
+
+import { bus } from './events.js';
+import { _el, setupInlineInput } from './dom.js';
+import { INPUT_BLUR_DELAY, computeIndent } from './file-tree-helpers.js';
+
+/**
+ * Attach dragover / dragleave / drop listeners to an element so that files
+ * dropped from the OS file manager are copied into a target directory.
+ *
+ * @param {HTMLElement} el - element to receive drop events
+ * @param {string|Function} getTargetDir - target dir path or a function returning it
+ * @param {Function} handleFileDrop - async (files, destDir) => void
+ */
+export function setupDropZone(el, getTargetDir, handleFileDrop) {
+  el.addEventListener('dragover', (e) => {
+    if (!e.dataTransfer.types.includes('Files')) return;
+    e.preventDefault();
+    e.stopPropagation();
+    e.dataTransfer.dropEffect = 'copy';
+    el.classList.add('drop-target');
+  });
+
+  el.addEventListener('dragleave', (e) => {
+    e.stopPropagation();
+    el.classList.remove('drop-target');
+  });
+
+  el.addEventListener('drop', async (e) => {
+    e.preventDefault();
+    e.stopPropagation();
+    el.classList.remove('drop-target');
+    const targetDir = typeof getTargetDir === 'function' ? getTargetDir() : getTargetDir;
+    if (!targetDir) return;
+    await handleFileDrop(e.dataTransfer.files, targetDir);
+  });
+}
+
+/**
+ * Copy an array of OS-provided files into `destDir` via the filesystem API.
+ *
+ * @param {FileList|File[]} files
+ * @param {string} destDir
+ */
+export async function handleFileDrop(files, destDir) {
+  for (const file of files) {
+    if (file.path) {
+      await window.api.fs.copyTo(file.path, destDir);
+    }
+  }
+}
+
+/**
+ * Show an inline rename input in place of `nameEl` and rename the entry
+ * on commit.
+ *
+ * @param {string} entryPath
+ * @param {HTMLElement} nameEl
+ */
+export function promptRename(entryPath, nameEl) {
+  const oldName = entryPath.split('/').pop();
+  const input = _el('input', { className: 'file-tree-rename-input', type: 'text', value: oldName });
+
+  nameEl.style.display = 'none';
+  nameEl.parentElement.appendChild(input);
+  input.focus();
+  const dotIndex = oldName.lastIndexOf('.');
+  input.setSelectionRange(0, dotIndex > 0 ? dotIndex : oldName.length);
+
+  setupInlineInput(input, {
+    blurDelay: INPUT_BLUR_DELAY,
+    onCommit: async (newName) => {
+      input.remove();
+      nameEl.style.display = '';
+      if (!newName || newName === oldName) return;
+      await window.api.fs.rename(entryPath, newName);
+    },
+    onCancel: () => {
+      input.remove();
+      nameEl.style.display = '';
+    },
+  });
+}
+
+/**
+ * Show an inline input at the top of `parentContentEl` for creating a new
+ * file or folder inside `dirPath`.
+ *
+ * @param {string} dirPath
+ * @param {HTMLElement} parentContentEl
+ * @param {number} depth
+ * @param {Set<string>} expandedDirs
+ * @param {'file'|'folder'} type
+ */
+export function promptNewEntry(dirPath, parentContentEl, depth, expandedDirs, type) {
+  const input = _el('input', {
+    className: 'file-tree-new-input',
+    type: 'text',
+    placeholder: type === 'folder' ? 'folder name' : 'filename',
+    style: { marginLeft: `${computeIndent(depth + 1)}px` },
+  });
+
+  parentContentEl.prepend(input);
+  input.focus();
+
+  setupInlineInput(input, {
+    blurDelay: INPUT_BLUR_DELAY,
+    onCommit: async (name) => {
+      input.remove();
+      if (!name) return;
+      const newPath = dirPath + '/' + name;
+      if (type === 'folder') {
+        await window.api.fs.mkdir(newPath);
+      } else {
+        await window.api.fs.writefile(newPath, '');
+        bus.emit('file:open', { path: newPath, name });
+      }
+    },
+  });
+}

--- a/src/utils/file-tree-renderer.js
+++ b/src/utils/file-tree-renderer.js
@@ -1,0 +1,113 @@
+/**
+ * Directory-entry rendering helpers for FileTree.
+ * Extracted from file-tree.js to reduce component size.
+ */
+
+import { bus } from './events.js';
+import { _el } from './dom.js';
+import { computeIndent, CHEVRON_EXPANDED, CHEVRON_COLLAPSED } from './file-tree-helpers.js';
+import { showFileContextMenu, showDirContextMenu } from './file-tree-context-menu.js';
+
+/**
+ * Build a generic row element with a chevron and name span.
+ *
+ * @param {Object} entry - { name }
+ * @param {number} depth
+ * @returns {{ row: HTMLElement, chevron: HTMLElement, name: HTMLElement }}
+ */
+export function buildRow(entry, depth) {
+  const chevron = _el('span', { className: 'file-tree-chevron' });
+  const name = _el('span', { className: 'file-tree-name', textContent: entry.name });
+  const row = _el('div', {
+    className: 'file-tree-item',
+    style: { paddingLeft: `${computeIndent(depth)}px` },
+  }, chevron, name);
+  return { row, chevron, name };
+}
+
+/**
+ * Render a single directory entry into `parentEl`, with expand/collapse
+ * and context-menu behaviour wired up.
+ *
+ * @param {Object} entry - { name, path, isDirectory }
+ * @param {HTMLElement} parentEl
+ * @param {number} depth
+ * @param {Set<string>} expandedDirs
+ * @param {Object} callbacks
+ * @param {Function} callbacks.setupDropZone - (el, targetDir) => void
+ * @param {Function} callbacks.expandDir - (dirPath, childContainer, chevron, depth, expandedDirs) => Promise
+ * @param {Function} callbacks.collapseDir - (dirPath, childContainer, chevron, expandedDirs) => void
+ * @param {Function} callbacks.renderDir - (dirPath, parentEl, depth, expandedDirs) => Promise
+ * @param {Function} callbacks.findRootCwd - (entryPath) => string
+ * @param {Function} callbacks.promptRename - (path, nameEl) => void
+ * @param {Function} callbacks.promptNewEntry - (dirPath, contentEl, depth, expandedDirs, type) => void
+ */
+export async function renderDirEntry(entry, parentEl, depth, expandedDirs, callbacks) {
+  const { setupDropZone, expandDir, collapseDir, findRootCwd, promptRename, promptNewEntry } = callbacks;
+  const { row, chevron, name } = buildRow(entry, depth);
+  const isExpanded = expandedDirs.has(entry.path);
+  chevron.textContent = isExpanded ? CHEVRON_EXPANDED : CHEVRON_COLLAPSED;
+  chevron.classList.toggle('expanded', isExpanded);
+
+  const childContainer = _el('div', { className: 'file-tree-children' });
+  parentEl.append(row, childContainer);
+
+  if (isExpanded) {
+    await callbacks.renderDir(entry.path, childContainer, depth + 1, expandedDirs);
+  }
+
+  setupDropZone(row, entry.path);
+
+  row.addEventListener('click', async () => {
+    if (expandedDirs.has(entry.path)) {
+      collapseDir(entry.path, childContainer, chevron, expandedDirs);
+    } else {
+      await expandDir(entry.path, childContainer, chevron, depth, expandedDirs);
+    }
+  });
+
+  row.addEventListener('contextmenu', async (e) => {
+    e.preventDefault();
+    e.stopPropagation();
+    if (!expandedDirs.has(entry.path)) {
+      await expandDir(entry.path, childContainer, chevron, depth, expandedDirs);
+    }
+    showDirContextMenu(
+      e.clientX, e.clientY, entry.path, findRootCwd(entry.path),
+      childContainer, depth + 1, expandedDirs, name,
+      (path, nameEl) => promptRename(path, nameEl),
+      (dirPath, cEl, d, eDirs, type) => promptNewEntry(dirPath, cEl, d, eDirs, type),
+    );
+  });
+}
+
+/**
+ * Render a single file entry into `parentEl`, wiring up click and
+ * context-menu listeners.
+ *
+ * @param {Object} entry - { name, path }
+ * @param {HTMLElement} parentEl
+ * @param {number} depth
+ * @param {{ activeRowRef: { current: HTMLElement|null }, findRootCwd: Function, promptRename: Function }} callbacks
+ */
+export function renderFileEntry(entry, parentEl, depth, callbacks) {
+  const { activeRowRef, findRootCwd, promptRename } = callbacks;
+  const { row, name } = buildRow(entry, depth);
+  parentEl.appendChild(row);
+
+  row.addEventListener('click', () => {
+    if (activeRowRef.current) activeRowRef.current.classList.remove('active');
+    row.classList.add('active');
+    activeRowRef.current = row;
+    bus.emit('file:open', { path: entry.path, name: entry.name });
+  });
+
+  row.addEventListener('contextmenu', (e) => {
+    e.preventDefault();
+    e.stopPropagation();
+    showFileContextMenu(
+      e.clientX, e.clientY, entry.path, name, findRootCwd(entry.path),
+      (path, nameEl) => promptRename(path, nameEl),
+    );
+  });
+}

--- a/src/utils/file-viewer-tabs.js
+++ b/src/utils/file-viewer-tabs.js
@@ -1,0 +1,66 @@
+/**
+ * Tab rendering helpers for FileViewer.
+ * Extracted from file-viewer.js to reduce component size.
+ */
+
+import { _el } from './dom.js';
+import { contextMenu } from '../components/context-menu.js';
+
+/**
+ * Build a single tab element for the given file path.
+ *
+ * @param {string} filePath
+ * @param {Object} file - { name }
+ * @param {string|null} activeFile - currently active file path
+ * @param {Function} isPinned - (filePath) => boolean
+ * @param {Function} isModified - (filePath) => boolean
+ * @param {Object} callbacks
+ * @param {Function} callbacks.onClose - (filePath) => void
+ * @param {Function} callbacks.onActivate - (filePath) => void
+ * @param {Function} callbacks.onTogglePin - (filePath) => void
+ * @returns {HTMLElement}
+ */
+export function createTabEl(filePath, file, activeFile, isPinned, isModified, { onClose, onActivate, onTogglePin }) {
+  const tab = _el('div', 'file-tab');
+  if (filePath === activeFile) tab.classList.add('active');
+
+  const pinned = isPinned(filePath);
+  const modified = isModified(filePath);
+
+  if (pinned) tab.appendChild(_el('span', 'file-tab-pin', '\u{1F4CC}'));
+  tab.appendChild(_el('span', 'file-tab-modified', modified ? '\u25CF' : ''));
+  tab.appendChild(_el('span', null, file.name));
+
+  const close = _el('span', 'file-tab-close', '\u00D7');
+  close.addEventListener('click', (e) => { e.stopPropagation(); onClose(filePath); });
+  tab.appendChild(close);
+
+  tab.addEventListener('click', () => onActivate(filePath));
+  tab.addEventListener('contextmenu', (e) => {
+    e.preventDefault();
+    contextMenu.show(e.clientX, e.clientY, [
+      { label: pinned ? 'Unpin from all workspaces' : 'Pin across workspaces', action: () => onTogglePin(filePath) },
+      { separator: true },
+      { label: 'Close', action: () => onClose(filePath) },
+    ]);
+  });
+
+  return tab;
+}
+
+/**
+ * Rebuild the entire tabs bar from the current open-files map.
+ *
+ * @param {HTMLElement} tabsBar
+ * @param {Map<string, Object>} openFiles - path → file object
+ * @param {string|null} activeFile
+ * @param {Function} isPinned
+ * @param {Function} isModified
+ * @param {Object} callbacks - forwarded to createTabEl
+ */
+export function renderTabs(tabsBar, openFiles, activeFile, isPinned, isModified, callbacks) {
+  tabsBar.replaceChildren();
+  for (const [filePath, file] of openFiles) {
+    tabsBar.appendChild(createTabEl(filePath, file, activeFile, isPinned, isModified, callbacks));
+  }
+}

--- a/src/utils/flow-card-setup.js
+++ b/src/utils/flow-card-setup.js
@@ -1,0 +1,98 @@
+/**
+ * Card setup helpers for FlowView — wiring drag events and building card body content.
+ * Extracted from flow-view.js to reduce component size.
+ */
+
+import { _el } from './dom.js';
+import { getLastRun } from './flow-view-helpers.js';
+import { cleanupAllDragState } from '../components/flow-category-renderer.js';
+
+/**
+ * Attach dragstart / dragend handlers to a flow card element.
+ *
+ * @param {HTMLElement} card
+ * @param {string} flowId
+ * @param {string} catId
+ * @param {Object} dragState - mutable drag state object
+ * @param {string|null} dragState.flowId
+ * @param {string|null} dragState.catId
+ */
+export function setupCardDrag(card, flowId, catId, dragState) {
+  card.addEventListener('dragstart', (e) => {
+    dragState.flowId = flowId;
+    dragState.catId = catId;
+    card.classList.add('flow-dragging');
+    e.dataTransfer.effectAllowed = 'move';
+    e.dataTransfer.setData('text/plain', flowId);
+  });
+
+  card.addEventListener('dragend', () => {
+    card.classList.remove('flow-dragging');
+    dragState.flowId = null;
+    dragState.catId = null;
+    cleanupAllDragState();
+  });
+}
+
+/**
+ * Build the collapsible body portion of a flow card (terminal or log view).
+ * Returns null when nothing should be rendered.
+ *
+ * @param {Object} flow
+ * @param {boolean} isRunning
+ * @param {boolean} isExpanded
+ * @param {Object} termManager - FlowCardTerminalManager instance
+ * @param {Object} runningMap - { [flowId]: ptyId }
+ * @returns {HTMLElement|null}
+ */
+export function buildCardBody(flow, isRunning, isExpanded, termManager, runningMap) {
+  if (isRunning) {
+    const container = termManager.createLiveTerminal(flow.id, runningMap[flow.id]);
+    container.style.display = isExpanded ? '' : 'none';
+    return container;
+  }
+  if (isExpanded) {
+    const lastRun = getLastRun(flow);
+    if (lastRun) {
+      const termArea = _el('div', 'flow-card-terminal');
+      termManager.loadLogIntoContainer(flow.id, lastRun, termArea);
+      return termArea;
+    }
+  }
+  return null;
+}
+
+/**
+ * Wire a click listener on the card header row that toggles card expansion
+ * or opens the flow modal when there are no runs.
+ *
+ * @param {HTMLElement} headerRow
+ * @param {Object} flow
+ * @param {boolean} isRunning
+ * @param {Object} callbacks
+ * @param {Set<string>} callbacks.expandedCards
+ * @param {Function} callbacks.onRenderList
+ * @param {Function} callbacks.onOpenModal - (flow) => void
+ * @param {Object} callbacks.termManager
+ */
+export function setupCardHeaderClick(headerRow, flow, isRunning, { expandedCards, onRenderList, onOpenModal, termManager }) {
+  headerRow.addEventListener('click', () => {
+    if (isRunning) {
+      if (expandedCards.has(flow.id)) expandedCards.delete(flow.id);
+      else expandedCards.add(flow.id);
+      onRenderList();
+      return;
+    }
+    if (!flow.runs?.length) {
+      onOpenModal(flow);
+      return;
+    }
+    if (expandedCards.has(flow.id)) {
+      expandedCards.delete(flow.id);
+      termManager.disposeLogTerminal(flow.id);
+    } else {
+      expandedCards.add(flow.id);
+    }
+    onRenderList();
+  });
+}

--- a/src/utils/terminal-node-builder.js
+++ b/src/utils/terminal-node-builder.js
@@ -1,0 +1,100 @@
+/**
+ * Terminal node construction helpers for TerminalPanel.
+ * Extracted from terminal-panel.js to reduce component size.
+ */
+
+import { bus } from './events.js';
+import { _el } from './dom.js';
+import { SplitNode, DRAG_GRIP, createSplitContainer } from './terminal-panel-helpers.js';
+import { TerminalInstance } from './terminal-instance.js';
+
+/**
+ * Build the top-bar DOM element for a terminal wrapper.
+ * Wires up the close button and delegates drag setup to a callback.
+ *
+ * @param {SplitNode} node - the terminal node
+ * @param {{ onClose: Function, setupDrag: Function }} callbacks
+ * @returns {HTMLElement}
+ */
+export function buildTopBar(node, { onClose, setupDrag }) {
+  const topBar = _el('div', 'terminal-top-bar');
+
+  const dragHandle = _el('div', 'terminal-drag-handle', { title: 'Drag to move' });
+  dragHandle.appendChild(_el('span', 'drag-grip', { textContent: DRAG_GRIP }));
+
+  const closeBtn = _el('button', 'terminal-close-btn', {
+    textContent: '×',
+    title: 'Close terminal',
+  });
+  closeBtn.addEventListener('click', (e) => {
+    e.stopPropagation();
+    onClose();
+  });
+
+  topBar.appendChild(dragHandle);
+  topBar.appendChild(closeBtn);
+
+  setupDrag(dragHandle, node);
+  return topBar;
+}
+
+/**
+ * Create a new terminal node (wrapper + TerminalInstance) and register it.
+ *
+ * @param {string|null} cwd - working directory for the terminal
+ * @param {string} defaultCwd - fallback cwd when `cwd` is null
+ * @param {Map<string, SplitNode>} terminals - mutable registry
+ * @param {{ buildTopBar: Function, onMousedown: Function }} callbacks
+ * @returns {SplitNode}
+ */
+export function createTerminalNode(cwd, defaultCwd, terminals, { buildTopBar: buildTopBarFn, onMousedown }) {
+  const spawnCwd = cwd || defaultCwd;
+  const node = new SplitNode('terminal');
+
+  const wrapper = _el('div', 'terminal-wrapper');
+  const termContainer = _el('div', 'terminal-container');
+
+  wrapper.appendChild(buildTopBarFn(node));
+  wrapper.appendChild(termContainer);
+
+  node.element = wrapper;
+  node.terminal = new TerminalInstance(termContainer, spawnCwd);
+  terminals.set(node.terminal.id, node);
+
+  bus.emit('terminal:created', { id: node.terminal.id, cwd: spawnCwd });
+
+  wrapper.addEventListener('mousedown', () => onMousedown(node));
+
+  return node;
+}
+
+/**
+ * Recursively build a split-panel tree from a serialised layout descriptor.
+ *
+ * @param {Object} tree - serialized node ({ type, cwd?, flex?, direction?, children? })
+ * @param {{ createTerminalNode: Function, createSplitHandle: Function }} callbacks
+ * @returns {SplitNode}
+ */
+export function buildFromTree(tree, { createTerminalNode: createTerminalNodeFn, createSplitHandle }) {
+  if (tree.type === 'terminal') {
+    const node = createTerminalNodeFn(tree.cwd);
+    node.element.style.flex = String(tree.flex || 1);
+    return node;
+  }
+
+  const splitEl = createSplitContainer(tree.direction, tree.flex || 1);
+
+  const splitNode = new SplitNode('split');
+  splitNode.direction = tree.direction;
+  splitNode.element = splitEl;
+
+  for (let i = 0; i < tree.children.length; i++) {
+    if (i > 0) splitEl.appendChild(createSplitHandle(tree.direction, splitEl));
+    const childNode = buildFromTree(tree.children[i], { createTerminalNode: createTerminalNodeFn, createSplitHandle });
+    splitEl.appendChild(childNode.element);
+    splitNode.children.push(childNode);
+    childNode.parent = splitNode;
+  }
+
+  return splitNode;
+}

--- a/src/utils/terminal-split-ops.js
+++ b/src/utils/terminal-split-ops.js
@@ -1,0 +1,129 @@
+/**
+ * Split-panel layout manipulation helpers for TerminalPanel.
+ * Extracted from terminal-panel.js to reduce component size.
+ */
+
+import { bus } from './events.js';
+import { SplitNode, isSameDirectionSplit, createSplitContainer, equalizeChildren } from './terminal-panel-helpers.js';
+import { directionFromSide, isInsertBefore, findClosestInDirection } from './split-helpers.js';
+import { detachElement, moveToCenter, insertIntoSplit, wrapInNewSplit } from './split-layout-ops.js';
+
+/**
+ * Move a terminal from `sourceId` to a position relative to `targetId`.
+ *
+ * @param {string} sourceId
+ * @param {string} targetId
+ * @param {string} side - 'center'|'left'|'right'|'top'|'bottom'
+ * @param {Map<string, SplitNode>} terminals
+ * @param {Object} callbacks
+ * @param {Function} callbacks.createSplitHandle - (direction, splitEl) => HTMLElement
+ * @param {Function} callbacks.fitAll - () => void
+ * @param {Function} callbacks.setActive - (node) => void
+ */
+export function moveTerminal(sourceId, targetId, side, terminals, { createSplitHandle, fitAll, setActive }) {
+  const sourceNode = terminals.get(sourceId);
+  const targetNode = terminals.get(targetId);
+  if (!sourceNode || !targetNode) return;
+  if (sourceNode === targetNode) return;
+
+  const sourceEl = sourceNode.element;
+  const targetEl = targetNode.element;
+
+  detachElement(sourceEl);
+
+  if (side === 'center') {
+    moveToCenter(sourceEl, targetEl);
+  } else {
+    const direction = directionFromSide(side);
+    const before = isInsertBefore(side);
+    const parentEl = targetEl.parentElement;
+
+    if (isSameDirectionSplit(parentEl, direction)) {
+      insertIntoSplit(sourceEl, targetEl, direction, before, parentEl,
+        (d, s) => createSplitHandle(d, s),
+        (s) => equalizeChildren(s));
+    } else {
+      wrapInNewSplit(sourceEl, targetEl, direction, before, parentEl,
+        (d, f) => createSplitContainer(d, f),
+        (d, s) => createSplitHandle(d, s));
+    }
+  }
+
+  fitAll();
+  setActive(sourceNode);
+  bus.emit('layout:changed');
+}
+
+/**
+ * Split a target terminal node in the given direction, creating a new terminal.
+ *
+ * @param {SplitNode} targetNode
+ * @param {string} direction - 'horizontal'|'vertical'
+ * @param {Object} state - mutable panel state
+ * @param {string} state.cwd - default working directory
+ * @param {SplitNode|null} state.root - root split node (may be updated)
+ * @param {Object} callbacks
+ * @param {Function} callbacks.createTerminalNode - (cwd) => SplitNode
+ * @param {Function} callbacks.createSplitHandle - (direction, splitEl) => HTMLElement
+ * @param {Function} callbacks.fitAll - () => void
+ * @param {Function} callbacks.setActive - (node) => void
+ * @param {Function} callbacks.setRoot - (node) => void
+ */
+export function splitTerminal(targetNode, direction, state, { createTerminalNode, createSplitHandle, fitAll, setActive, setRoot }) {
+  const parentEl = targetNode.element.parentElement;
+  const sourceCwd = targetNode.terminal ? targetNode.terminal.cwd : state.cwd;
+  const newTermNode = createTerminalNode(sourceCwd);
+
+  if (isSameDirectionSplit(parentEl, direction)) {
+    const handle = createSplitHandle(direction, parentEl);
+    targetNode.element.insertAdjacentElement('afterend', handle);
+    handle.insertAdjacentElement('afterend', newTermNode.element);
+    equalizeChildren(parentEl);
+  } else {
+    const splitEl = createSplitContainer(direction, targetNode.element.style.flex || '1');
+    parentEl.replaceChild(splitEl, targetNode.element);
+
+    splitEl.appendChild(targetNode.element);
+    splitEl.appendChild(createSplitHandle(direction, splitEl));
+    splitEl.appendChild(newTermNode.element);
+    equalizeChildren(splitEl);
+
+    if (state.root === targetNode) {
+      const newSplitNode = new SplitNode('split');
+      newSplitNode.direction = direction;
+      newSplitNode.element = splitEl;
+      setRoot(newSplitNode);
+    }
+  }
+
+  fitAll();
+  setActive(newTermNode);
+}
+
+/**
+ * Focus the nearest terminal in `dir` relative to `activeTerminal`.
+ *
+ * @param {SplitNode} activeTerminal
+ * @param {Map<string, SplitNode>} terminals
+ * @param {string} dir - 'left'|'right'|'up'|'down'
+ * @param {Function} setActive - (node) => void
+ */
+export function focusDirection(activeTerminal, terminals, dir, setActive) {
+  if (!activeTerminal || terminals.size < 2) return;
+
+  const activeRect = activeTerminal.element.getBoundingClientRect();
+  const activeCenter = {
+    cx: activeRect.left + activeRect.width / 2,
+    cy: activeRect.top + activeRect.height / 2,
+  };
+
+  const candidates = [];
+  for (const [id, node] of terminals) {
+    if (node === activeTerminal) continue;
+    const rect = node.element.getBoundingClientRect();
+    candidates.push({ id, cx: rect.left + rect.width / 2, cy: rect.top + rect.height / 2 });
+  }
+
+  const bestId = findClosestInDirection(activeCenter, candidates, dir);
+  if (bestId) setActive(terminals.get(bestId));
+}


### PR DESCRIPTION
## Summary

Closes #3

Reduces component size for the 4 files that were still over 300 lines by extracting cohesive blocks of functionality into new utility modules. Public APIs of all components remain unchanged.

### Files refactored

| Component | Before | After | Extracted into |
|---|---|---|---|
| `src/components/file-viewer.js` | 401 | 293 | `src/utils/file-editor-renderer.js`, `src/utils/file-viewer-tabs.js` |
| `src/components/file-tree.js` | 381 | 283 | `src/utils/file-tree-renderer.js`, `src/utils/file-tree-drop.js` |
| `src/components/terminal-panel.js` | 356 | 239 | `src/utils/terminal-node-builder.js`, `src/utils/terminal-split-ops.js` |
| `src/components/flow-view.js` | 352 | 300 | `src/utils/flow-card-setup.js` |
| `src/components/settings-modal.js` | 168 | 168 | already under 300 lines — no changes |

### New utility modules

- `src/utils/file-editor-renderer.js` — editor DOM construction, event binding, line numbers, syntax highlight, status bar, save
- `src/utils/file-viewer-tabs.js` — tab element creation and tabs bar rendering
- `src/utils/file-tree-renderer.js` — directory and file entry rendering (rows, click/contextmenu wiring)
- `src/utils/file-tree-drop.js` — OS file drag-drop zone setup, rename and new-entry inline inputs
- `src/utils/terminal-node-builder.js` — terminal node/wrapper construction and tree restoration
- `src/utils/terminal-split-ops.js` — split, move, and focusDirection layout operations

## Test plan

- [x] `npm run build` passes
- [x] `npm test` passes — 204/204 tests green
- [x] All component public APIs unchanged (no call-site changes required)

🤖 Generated with [Claude Code](https://claude.com/claude-code)