### PR TITLE
refactor: remove dead exports (toggleAppTheme, setupDropZone)

### DIFF
--- a/src/utils/app-theme.js
+++ b/src/utils/app-theme.js
@@ -17,10 +17,3 @@ export function applyAppTheme(theme) {
     document.documentElement.removeAttribute('data-theme');
   }
 }
-
-export function toggleAppTheme() {
-  const current = getAppTheme();
-  const next = current === 'dark' ? 'light' : 'dark';
-  setAppTheme(next);
-  return next;
-}

--- a/src/utils/dom.js
+++ b/src/utils/dom.js
@@ -111,36 +111,6 @@ export function showPromptDialog({ title, placeholder = '', defaultValue = '', c
 }
 
 /**
- * Attach file-drop drag-and-drop listeners to an element.
- * Adds/removes `className` on dragover/dragleave, then calls `onDrop` with the
- * dropped FileList on drop.
- *
- * @param {HTMLElement} el - target element
- * @param {{ onDrop: (files: FileList) => void, className?: string }} opts
- */
-export function setupDropZone(el, { onDrop, className = 'drop-target' }) {
-  el.addEventListener('dragover', (e) => {
-    if (!e.dataTransfer.types.includes('Files')) return;
-    e.preventDefault();
-    e.stopPropagation();
-    e.dataTransfer.dropEffect = 'copy';
-    el.classList.add(className);
-  });
-
-  el.addEventListener('dragleave', (e) => {
-    e.stopPropagation();
-    el.classList.remove(className);
-  });
-
-  el.addEventListener('drop', (e) => {
-    e.preventDefault();
-    e.stopPropagation();
-    el.classList.remove(className);
-    onDrop(e.dataTransfer.files);
-  });
-}
-
-/**
  * Clamp (x, y) so a box of (width, height) stays within the viewport.
  * @param {number} x
  * @param {number} y


### PR DESCRIPTION
## Refactoring

- Removed `toggleAppTheme` from `src/utils/app-theme.js` — never imported anywhere
- Removed `setupDropZone` from `src/utils/dom.js` — dead export, duplicate of `file-tree-drop.js` version
- Kept `getFileIcon` in `src/utils/file-icons.js` — used by tests, acceptable as test-facing export

Closes #42

## Fichier(s) modifié(s)

- `src/utils/app-theme.js`
- `src/utils/dom.js`

## Vérifications

- [x] Build OK
- [x] Tests OK (16 files, 204 tests passed)

---

📂 Path local : `/Users/rekta/projet/coding/refactor-pikagent`
🤖 PR créée automatiquement par l'Agent Refactor