### PR TITLE
refactor: fix cross-layer violations by moving shared modules to utils

### DIFF
--- a/src/components/config-manager.js
+++ b/src/components/config-manager.js
@@ -1,4 +1,4 @@
-import { contextMenu } from './context-menu.js';
+import { contextMenu } from '../utils/context-menu.js';
 import { showPromptDialog } from '../utils/dom.js';
 import {
   AUTO_SAVE_DELAY,

--- a/src/components/flow-view.js
+++ b/src/components/flow-view.js
@@ -9,7 +9,7 @@ import {
 } from '../utils/flow-view-helpers.js';
 import { createCardHeader } from '../utils/flow-card-renderer.js';
 import { FlowCardTerminalManager } from './flow-card-terminal.js';
-import { createCategoryGroup } from './flow-category-renderer.js';
+import { createCategoryGroup } from '../utils/flow-category-renderer.js';
 import { setupCardDrag, buildCardBody, setupCardHeaderClick } from '../utils/flow-card-setup.js';
 
 

--- a/src/utils/context-menu.js
+++ b/src/utils/context-menu.js
@@ -1,4 +1,4 @@
-import { _el, positionInViewport } from '../utils/dom.js';
+import { _el, positionInViewport } from './dom.js';
 
 export class ContextMenu {
   constructor() {

--- a/src/utils/file-tree-context-menu.js
+++ b/src/utils/file-tree-context-menu.js
@@ -3,7 +3,7 @@
  * Extracted from FileTree to reduce component size.
  */
 import { bus } from './events.js';
-import { contextMenu } from '../components/context-menu.js';
+import { contextMenu } from './context-menu.js';
 import { getRelativePath } from './file-tree-helpers.js';
 
 /**

--- a/src/utils/file-viewer-tabs.js
+++ b/src/utils/file-viewer-tabs.js
@@ -4,7 +4,7 @@
  */
 
 import { _el } from './dom.js';
-import { contextMenu } from '../components/context-menu.js';
+import { contextMenu } from './context-menu.js';
 
 /**
  * Build a single tab element for the given file path.

--- a/src/utils/flow-card-setup.js
+++ b/src/utils/flow-card-setup.js
@@ -5,7 +5,7 @@
 
 import { _el } from './dom.js';
 import { getLastRun } from './flow-view-helpers.js';
-import { cleanupAllDragState } from '../components/flow-category-renderer.js';
+import { cleanupAllDragState } from './flow-category-renderer.js';
 
 /**
  * Attach dragstart / dragend handlers to a flow card element.

--- a/src/utils/flow-category-renderer.js
+++ b/src/utils/flow-category-renderer.js
@@ -3,8 +3,8 @@
  * Handles category headers, collapse state, and drag-drop zone setup.
  * Extracted from flow-view.js to reduce component size.
  */
-import { _el } from '../utils/dom.js';
-import { CATEGORY_ACTIONS, UNCATEGORIZED } from '../utils/flow-view-helpers.js';
+import { _el } from './dom.js';
+import { CATEGORY_ACTIONS, UNCATEGORIZED } from './flow-view-helpers.js';
 
 /**
  * Create a category group DOM element with header and flow items.

--- a/src/utils/tab-renderer.js
+++ b/src/utils/tab-renderer.js
@@ -5,7 +5,7 @@
 import { _el, setupInlineInput } from './dom.js';
 import { COLOR_GROUPS } from './tab-manager-helpers.js';
 import { setupTabDrag } from './tab-drag.js';
-import { contextMenu } from '../components/context-menu.js';
+import { contextMenu } from './context-menu.js';
 
 /**
  * Build a single tab DOM element.


### PR DESCRIPTION
## Refactoring

- Moved `context-menu.js` from `src/components/` to `src/utils/` — it's used as a shared utility by 3+ utils files
- Moved `flow-category-renderer.js` from `src/components/` to `src/utils/` — used by `flow-card-setup.js`
- Updated all import paths across the codebase

This eliminates 4 cross-layer violations where utils files were importing from components.

Closes #41

## Fichier(s) modifié(s)

- `src/utils/context-menu.js` (moved from components)
- `src/utils/flow-category-renderer.js` (moved from components)
- All files with updated import paths

## Vérifications

- [x] Build OK
- [x] Tests OK

---

📂 Path local : `/Users/rekta/projet/coding/refactor-pikagent`
🤖 PR créée automatiquement par l'Agent Refactor