### PR TITLE
refactor: fix cross-layer import paths for context-menu.js

### DIFF
--- a/src/components/file-tree.js
+++ b/src/components/file-tree.js
@@ -7,7 +7,7 @@ import {
 } from '../utils/file-tree-helpers.js';
 import { registerComponent } from '../utils/component-registry.js';
 import { buildDirContextItems } from '../utils/file-tree-context-menu.js';
-import { attachContextMenu } from './context-menu.js';
+import { attachContextMenu } from '../utils/context-menu.js';
 import { renderDirEntry, renderFileEntry } from '../utils/file-tree-renderer.js';
 import {
   setupDropZone, handleFileDrop,

--- a/src/utils/file-tree-renderer.js
+++ b/src/utils/file-tree-renderer.js
@@ -7,7 +7,7 @@ import { bus } from './events.js';
 import { _el } from './dom.js';
 import { computeIndent, CHEVRON_EXPANDED, CHEVRON_COLLAPSED } from './file-tree-helpers.js';
 import { buildFileContextItems, buildDirContextItems } from './file-tree-context-menu.js';
-import { attachContextMenu } from '../components/context-menu.js';
+import { attachContextMenu } from './context-menu.js';
 
 /**
  * Build a generic row element with a chevron and name span.

--- a/src/utils/tab-color-filter.js
+++ b/src/utils/tab-color-filter.js
@@ -4,7 +4,7 @@
  */
 import { _el } from './dom.js';
 import { COLOR_GROUPS } from './tab-manager-helpers.js';
-import { attachContextMenu } from '../components/context-menu.js';
+import { attachContextMenu } from './context-menu.js';
 
 /**
  * Check if a tab is visible given the current filter state.


### PR DESCRIPTION
## Refactoring

Corrige 3 imports qui pointaient encore vers l'ancien chemin `components/context-menu.js` après que le fichier a été déplacé dans `utils/`.

Closes #41

## Fichier(s) modifié(s)

- `src/utils/file-tree-renderer.js` — `../components/context-menu.js` → `./context-menu.js`
- `src/utils/tab-color-filter.js` — `../components/context-menu.js` → `./context-menu.js`
- `src/components/file-tree.js` — `./context-menu.js` → `../utils/context-menu.js`

## Vérifications

- [x] Build OK
- [x] Tests OK (204/204)

---

📂 Path local : `/Users/rekta/projet/coding/refactor-pikagent`
🤖 PR créée automatiquement par l'Agent Refactor