### PR TITLE
refactor: standardize error handling with centralized logger

### DIFF
--- a/main/config-manager.js
+++ b/main/config-manager.js
@@ -3,7 +3,9 @@ const path = require('path');
 const { CONFIG_DIR, META_FILE } = require('./paths');
 const { readJson, writeJson, ensureDirOnce, readDirJson } = require('./fs-utils');
 const { DEFAULT_META, sanitizeName, buildConfigRecord, formatConfigList } = require('./config-helpers');
+const { createLogger } = require('./logger');
 
+const log = createLogger('config-manager');
 const ensureDir = ensureDirOnce(CONFIG_DIR);
 let _metaCache = null;
 
@@ -42,7 +44,7 @@ async function list() {
     const configs = await readDirJson(CONFIG_DIR);
     return formatConfigList(configs, meta.defaultConfig);
   } catch (err) {
-    console.warn('config-manager: list failed:', err.message);
+    log.warn('list failed', err);
     return [];
   }
 }
@@ -57,7 +59,7 @@ async function remove(name) {
     }
     return true;
   } catch (err) {
-    console.warn('config-manager: remove failed:', err.message);
+    log.warn('remove failed', err);
     return false;
   }
 }

--- a/main/flow-manager.js
+++ b/main/flow-manager.js
@@ -12,7 +12,9 @@ const {
 const { safeSend } = require('./ipc-helpers');
 const { PollingTimer } = require('./polling-timer');
 const { buildRecord } = require('./record-helpers');
+const { createLogger } = require('./logger');
 
+const log = createLogger('flow-manager');
 const ensureDir = ensureDirOnce(LOGS_DIR);
 
 class FlowManager {
@@ -135,7 +137,7 @@ class FlowManager {
     try {
       await fsp.writeFile(logPath(flowId, runTimestamp), output, 'utf-8');
     } catch (e) {
-      console.warn('Failed to save flow log:', e);
+      log.warn('save log failed', e);
     }
   }
 
@@ -193,7 +195,7 @@ class FlowManager {
         this._ptyManager.write(ptyId, cmd);
       }, SHELL_INIT_DELAY_MS);
     } catch (err) {
-      console.error('Flow execution failed:', err);
+      log.error('execution failed', err);
       this._recordRun(flow.id, 'error', runTimestamp);
     }
   }

--- a/main/git-manager.js
+++ b/main/git-manager.js
@@ -1,7 +1,9 @@
 const { execFile } = require('child_process');
 const { promisify } = require('util');
 const { DIFF_MAX_BUFFER, execOpts, parseNameStatus, parseUntracked } = require('./git-helpers');
+const { createLogger } = require('./logger');
 
+const log = createLogger('git-manager');
 const execFileAsync = promisify(execFile);
 
 // ---------------------------------------------------------------------------
@@ -15,7 +17,7 @@ async function runGit(cwd, args, { fallback = null, maxBuffer } = {}) {
     const { stdout } = await execFileAsync('git', args, opts);
     return stdout.trim();
   } catch (err) {
-    console.error(`[git-manager] git ${args[0]} failed in ${cwd}:`, err.message);
+    log.warn(`git ${args[0]} failed in ${cwd}`, err);
     return fallback;
   }
 }
@@ -46,7 +48,7 @@ async function getLocalChanges(cwd) {
 
     return { staged, unstaged, untracked };
   } catch (err) {
-    console.error('[git-manager] getLocalChanges failed:', err.message);
+    log.warn('getLocalChanges failed', err);
     return { staged: [], unstaged: [], untracked: [] };
   }
 }

--- a/main/logger.js
+++ b/main/logger.js
@@ -1,0 +1,20 @@
+/**
+ * Lightweight logger factory for main-process modules.
+ * Standardises log format: [module] message
+ *
+ * @param {string} module - module name shown in the prefix
+ * @returns {{ warn: Function, error: Function }}
+ */
+function createLogger(module) {
+  const prefix = `[${module}]`;
+  return {
+    warn(msg, err) {
+      console.warn(prefix, msg, err instanceof Error ? err.message : (err ?? ''));
+    },
+    error(msg, err) {
+      console.error(prefix, msg, err instanceof Error ? err.message : (err ?? ''));
+    },
+  };
+}
+
+module.exports = { createLogger };

--- a/main/session-manager.js
+++ b/main/session-manager.js
@@ -3,7 +3,9 @@ const { BASE_DIR, SESSIONS_FILE } = require('./paths');
 const { readJson, writeJson, ensureDirOnce } = require('./fs-utils');
 const { generateSessionId, durationSec, isFlowTerminal, buildEndedRecord, buildActiveRecord, trimSessions } = require('./session-helpers');
 const { PollingTimer } = require('./polling-timer');
+const { createLogger } = require('./logger');
 
+const log = createLogger('session-manager');
 const POLL_INTERVAL_MS = 5000;
 
 const ensureDir = ensureDirOnce(BASE_DIR);
@@ -51,7 +53,7 @@ class SessionManager {
 
       this._previousAgents = { ...currentAgents };
     } catch (err) {
-      console.warn('session-manager: poll failed:', err.message);
+      log.warn('poll failed', err);
     } finally {
       this._polling = false;
     }
@@ -64,7 +66,7 @@ class SessionManager {
     try {
       cwd = await this._ptyManager.getCwd(termId);
     } catch (err) {
-      console.warn('session-manager: getCwd failed:', err.message);
+      log.warn('getCwd failed', err);
     }
 
     this._activeSessions[termId] = {
@@ -97,7 +99,7 @@ class SessionManager {
     this._sessionsCache = trimSessions([...(this._sessionsCache || []), record]);
 
     writeJson(SESSIONS_FILE, this._sessionsCache)
-      .catch((err) => console.warn('session-manager: write failed:', err.message));
+      .catch((err) => log.warn('write failed', err));
   }
 
   async _loadAll() {

--- a/src/components/file-tree.js
+++ b/src/components/file-tree.js
@@ -7,7 +7,7 @@ import {
 } from '../utils/file-tree-helpers.js';
 import { registerComponent } from '../utils/component-registry.js';
 import { buildDirContextItems } from '../utils/file-tree-context-menu.js';
-import { attachContextMenu } from './context-menu.js';
+import { attachContextMenu } from '../utils/context-menu.js';
 import { renderDirEntry, renderFileEntry } from '../utils/file-tree-renderer.js';
 import {
   setupDropZone, handleFileDrop,

--- a/src/utils/file-tree-renderer.js
+++ b/src/utils/file-tree-renderer.js
@@ -7,7 +7,7 @@ import { bus } from './events.js';
 import { _el } from './dom.js';
 import { computeIndent, CHEVRON_EXPANDED, CHEVRON_COLLAPSED } from './file-tree-helpers.js';
 import { buildFileContextItems, buildDirContextItems } from './file-tree-context-menu.js';
-import { attachContextMenu } from '../components/context-menu.js';
+import { attachContextMenu } from './context-menu.js';
 
 /**
  * Build a generic row element with a chevron and name span.

--- a/src/utils/tab-color-filter.js
+++ b/src/utils/tab-color-filter.js
@@ -4,7 +4,7 @@
  */
 import { _el } from './dom.js';
 import { COLOR_GROUPS } from './tab-manager-helpers.js';
-import { attachContextMenu } from '../components/context-menu.js';
+import { attachContextMenu } from './context-menu.js';
 
 /**
  * Check if a tab is visible given the current filter state.


### PR DESCRIPTION
## Refactoring

Crée un module `main/logger.js` avec une factory `createLogger(module)` et remplace les 9 appels `console.warn`/`console.error` inconsistants dans les 4 managers par des appels uniformes avec préfixe `[module]`.

Closes #50

## Fichier(s) modifié(s)

- `main/logger.js` (nouveau) — factory `createLogger`
- `main/config-manager.js` — 2 occurrences standardisées
- `main/session-manager.js` — 3 occurrences standardisées
- `main/git-manager.js` — 2 occurrences standardisées
- `main/flow-manager.js` — 2 occurrences standardisées
- `src/utils/file-tree-renderer.js`, `src/utils/tab-color-filter.js`, `src/components/file-tree.js` — fix import paths (from #41)

## Vérifications

- [x] Build OK
- [x] Tests OK (204/204)

---

📂 Path local : `/Users/rekta/projet/coding/refactor-pikagent`
🤖 PR créée automatiquement par l'Agent Refactor