### PR TITLE
refactor: replace IPC builder functions with declarative API schema

### DIFF
--- a/api-schema.js
+++ b/api-schema.js
@@ -1,0 +1,85 @@
+/**
+ * Declarative API schema shared between preload (client-side builders)
+ * and main process (handler registration).
+ *
+ * Each entry describes how a renderer method maps to an IPC channel.
+ *
+ * Types:
+ *   'fwd'     — single-arg ipcRenderer.invoke
+ *   'pack'    — multi-arg → keyed object → ipcRenderer.invoke
+ *   'on'      — ipcRenderer.on listener (returns unsubscribe)
+ *   'custom'  — handler provided at build time (not in schema)
+ *
+ * Channel convention: `${domain}:${method}` unless `channel` is explicit.
+ */
+
+const API_SCHEMA = {
+  pty: {
+    create:      { type: 'fwd' },
+    write:       { type: 'fwd' },
+    resize:      { type: 'fwd' },
+    kill:        { type: 'fwd' },
+    getCwd:      { type: 'fwd', channel: 'pty:getcwd' },
+    checkAgents: { type: 'fwd' },
+    // onData + onExit are custom (targeted channels), injected at build time
+  },
+  fs: {
+    readdir:   { type: 'fwd' },
+    readfile:  { type: 'fwd' },
+    mkdir:     { type: 'fwd' },
+    homedir:   { type: 'fwd' },
+    copy:      { type: 'fwd' },
+    trash:     { type: 'fwd' },
+    writefile: { type: 'pack', keys: ['filePath', 'content'] },
+    rename:    { type: 'pack', keys: ['oldPath', 'newName'] },
+    copyTo:    { type: 'pack', keys: ['srcPath', 'destDir'] },
+    watch:     { type: 'pack', keys: ['id', 'dirPath'] },
+    unwatch:   { type: 'pack', keys: ['id'] },
+    onChanged: { type: 'on' },
+  },
+  shell: {
+    showInFolder: { type: 'fwd' },
+    openExternal: { type: 'fwd' },
+    openPath:     { type: 'fwd' },
+  },
+  clipboard: {
+    write: { type: 'fwd' },
+  },
+  dialog: {
+    openFolder: { type: 'fwd' },
+  },
+  git: {
+    branch:       { type: 'fwd' },
+    remote:       { type: 'fwd' },
+    localChanges: { type: 'fwd' },
+    fileDiff:     { type: 'pack', keys: ['cwd', 'filePath', 'isStaged'] },
+  },
+  flow: {
+    save:           { type: 'fwd' },
+    get:            { type: 'fwd' },
+    list:           { type: 'fwd' },
+    delete:         { type: 'fwd' },
+    toggle:         { type: 'fwd' },
+    runNow:         { type: 'fwd' },
+    getRunning:     { type: 'fwd' },
+    getRunLog:      { type: 'pack', keys: ['flowId', 'logTimestamp'] },
+    getCategories:  { type: 'fwd' },
+    saveCategories: { type: 'fwd' },
+    onRunStarted:   { type: 'on' },
+    onRunComplete:  { type: 'on' },
+  },
+  usage: {
+    getMetrics: { type: 'fwd' },
+  },
+  config: {
+    save:        { type: 'pack', keys: ['name', 'data'] },
+    load:        { type: 'fwd' },
+    list:        { type: 'fwd' },
+    delete:      { type: 'fwd' },
+    setDefault:  { type: 'fwd' },
+    getDefault:  { type: 'fwd' },
+    loadDefault: { type: 'fwd' },
+  },
+};
+
+module.exports = { API_SCHEMA };

--- a/api-schema.js
+++ b/api-schema.js
@@ -35,7 +35,7 @@ const API_SCHEMA = {
     copyTo:    { type: 'pack', keys: ['srcPath', 'destDir'] },
     watch:     { type: 'pack', keys: ['id', 'dirPath'] },
     unwatch:   { type: 'pack', keys: ['id'] },
-    onChanged: { type: 'on' },
+    onChanged: { type: 'on', channel: 'fs:changed' },
   },
   shell: {
     showInFolder: { type: 'fwd' },
@@ -65,8 +65,8 @@ const API_SCHEMA = {
     getRunLog:      { type: 'pack', keys: ['flowId', 'logTimestamp'] },
     getCategories:  { type: 'fwd' },
     saveCategories: { type: 'fwd' },
-    onRunStarted:   { type: 'on' },
-    onRunComplete:  { type: 'on' },
+    onRunStarted:   { type: 'on', channel: 'flow:runStarted' },
+    onRunComplete:  { type: 'on', channel: 'flow:runComplete' },
   },
   usage: {
     getMetrics: { type: 'fwd' },

--- a/preload-helpers.js
+++ b/preload-helpers.js
@@ -44,4 +44,28 @@ function _createTargetedChannel(channel, extract) {
   };
 }
 
-module.exports = { _onIpc, _fwd, _pack, _createTargetedChannel };
+/**
+ * Build a flat API object from a schema, merging custom overrides.
+ *
+ * @param {Object} schema - domain → method → { type, channel?, keys? }
+ * @param {Object} [overrides] - domain → method → handler (for 'custom' entries)
+ * @returns {Object} flat API: { domain: { method: handler } }
+ */
+function buildApiFromSchema(schema, overrides = {}) {
+  const api = {};
+  for (const [domain, methods] of Object.entries(schema)) {
+    const domainApi = {};
+    for (const [method, def] of Object.entries(methods)) {
+      const ch = def.channel || `${domain}:${method}`;
+      if (def.type === 'fwd')       domainApi[method] = _fwd(ch);
+      else if (def.type === 'pack') domainApi[method] = _pack(ch, def.keys);
+      else if (def.type === 'on')   domainApi[method] = _onIpc(ch);
+    }
+    // Merge custom overrides for this domain
+    if (overrides[domain]) Object.assign(domainApi, overrides[domain]);
+    api[domain] = domainApi;
+  }
+  return api;
+}
+
+module.exports = { _onIpc, _fwd, _pack, _createTargetedChannel, buildApiFromSchema };

--- a/preload.js
+++ b/preload.js
@@ -1,105 +1,14 @@
 const { contextBridge } = require('electron');
-const { _onIpc, _fwd, _pack, _createTargetedChannel } = require('./preload-helpers');
+const { _createTargetedChannel, buildApiFromSchema } = require('./preload-helpers');
+const { API_SCHEMA } = require('./api-schema');
 
 // --- Targeted PTY dispatch (one listener per event, routed by terminal ID) ---
 
 const _onPtyData = _createTargetedChannel('pty:data', ({ id, data }) => ({ id, value: data }));
 const _onPtyExit = _createTargetedChannel('pty:exit', ({ id, exitCode }) => ({ id, value: { id, exitCode } }));
 
-// --- API builder functions ---
+// --- Build & expose the renderer API from the declarative schema ---
 
-function buildTerminalApi() {
-  return {
-    pty: {
-      create:      _fwd('pty:create'),
-      write:       _fwd('pty:write'),
-      resize:      _fwd('pty:resize'),
-      kill:        _fwd('pty:kill'),
-      getCwd:      _fwd('pty:getcwd'),
-      checkAgents: _fwd('pty:checkAgents'),
-      onData:      _onPtyData,
-      onExit:      _onPtyExit,
-    },
-  };
-}
-
-function buildFileApi() {
-  return {
-    fs: {
-      readdir:   _fwd('fs:readdir'),
-      readfile:  _fwd('fs:readfile'),
-      mkdir:     _fwd('fs:mkdir'),
-      homedir:   _fwd('fs:homedir'),
-      copy:      _fwd('fs:copy'),
-      trash:     _fwd('fs:trash'),
-      writefile: _pack('fs:writefile', ['filePath', 'content']),
-      rename:    _pack('fs:rename', ['oldPath', 'newName']),
-      copyTo:    _pack('fs:copyTo', ['srcPath', 'destDir']),
-      watch:     _pack('fs:watch', ['id', 'dirPath']),
-      unwatch:   _pack('fs:unwatch', ['id']),
-      onChanged: _onIpc('fs:changed'),
-    },
-    shell: {
-      showInFolder: _fwd('shell:showInFolder'),
-      openExternal: _fwd('shell:openExternal'),
-      openPath:     _fwd('shell:openPath'),
-    },
-    clipboard: { write: _fwd('clipboard:write') },
-    dialog:    { openFolder: _fwd('dialog:openFolder') },
-  };
-}
-
-function buildGitApi() {
-  return {
-    git: {
-      branch:       _fwd('git:branch'),
-      remote:       _fwd('git:remote'),
-      localChanges: _fwd('git:localChanges'),
-      fileDiff:     _pack('git:fileDiff', ['cwd', 'filePath', 'isStaged']),
-    },
-  };
-}
-
-function buildFlowApi() {
-  return {
-    flow: {
-      save:          _fwd('flow:save'),
-      get:           _fwd('flow:get'),
-      list:          _fwd('flow:list'),
-      delete:        _fwd('flow:delete'),
-      toggle:        _fwd('flow:toggle'),
-      runNow:        _fwd('flow:runNow'),
-      getRunning:    _fwd('flow:getRunning'),
-      getRunLog:     _pack('flow:getRunLog', ['flowId', 'logTimestamp']),
-      getCategories: _fwd('flow:getCategories'),
-      saveCategories: _fwd('flow:saveCategories'),
-      onRunStarted:  _onIpc('flow:runStarted'),
-      onRunComplete: _onIpc('flow:runComplete'),
-    },
-  };
-}
-
-function buildConfigApi() {
-  return {
-    usage: { getMetrics: _fwd('usage:getMetrics') },
-    config: {
-      save:        _pack('config:save', ['name', 'data']),
-      load:        _fwd('config:load'),
-      list:        _fwd('config:list'),
-      delete:      _fwd('config:delete'),
-      setDefault:  _fwd('config:setDefault'),
-      getDefault:  _fwd('config:getDefault'),
-      loadDefault: _fwd('config:loadDefault'),
-    },
-  };
-}
-
-// --- Exposed API ---
-
-contextBridge.exposeInMainWorld('api', {
-  ...buildTerminalApi(),
-  ...buildFileApi(),
-  ...buildGitApi(),
-  ...buildFlowApi(),
-  ...buildConfigApi(),
-});
+contextBridge.exposeInMainWorld('api', buildApiFromSchema(API_SCHEMA, {
+  pty: { onData: _onPtyData, onExit: _onPtyExit },
+}));

--- a/src/components/file-tree.js
+++ b/src/components/file-tree.js
@@ -7,7 +7,7 @@ import {
 } from '../utils/file-tree-helpers.js';
 import { registerComponent } from '../utils/component-registry.js';
 import { buildDirContextItems } from '../utils/file-tree-context-menu.js';
-import { attachContextMenu } from './context-menu.js';
+import { attachContextMenu } from '../utils/context-menu.js';
 import { renderDirEntry, renderFileEntry } from '../utils/file-tree-renderer.js';
 import {
   setupDropZone, handleFileDrop,

--- a/src/utils/file-tree-renderer.js
+++ b/src/utils/file-tree-renderer.js
@@ -7,7 +7,7 @@ import { bus } from './events.js';
 import { _el } from './dom.js';
 import { computeIndent, CHEVRON_EXPANDED, CHEVRON_COLLAPSED } from './file-tree-helpers.js';
 import { buildFileContextItems, buildDirContextItems } from './file-tree-context-menu.js';
-import { attachContextMenu } from '../components/context-menu.js';
+import { attachContextMenu } from './context-menu.js';
 
 /**
  * Build a generic row element with a chevron and name span.

--- a/src/utils/tab-color-filter.js
+++ b/src/utils/tab-color-filter.js
@@ -4,7 +4,7 @@
  */
 import { _el } from './dom.js';
 import { COLOR_GROUPS } from './tab-manager-helpers.js';
-import { attachContextMenu } from '../components/context-menu.js';
+import { attachContextMenu } from './context-menu.js';
 
 /**
  * Check if a tab is visible given the current filter state.


### PR DESCRIPTION
## Refactoring

Remplace les 5 fonctions builder répétitives dans `preload.js` (buildTerminalApi, buildFileApi, buildGitApi, buildFlowApi, buildConfigApi) par un schéma déclaratif `api-schema.js` et une factory `buildApiFromSchema()`.

- `preload.js` : **106 → 14 lignes**
- Ajout d'un point unique de vérité pour les canaux IPC

Closes #48

## Fichier(s) modifié(s)

- `api-schema.js` (nouveau) — schéma déclaratif des canaux IPC
- `preload-helpers.js` — ajout de `buildApiFromSchema()`
- `preload.js` — réduit de 106 à 14 lignes
- Fix import paths context-menu.js (from #41)

## Vérifications

- [x] Build OK
- [x] Tests OK (204/204)

---

📂 Path local : `/Users/rekta/projet/coding/refactor-pikagent`
🤖 PR créée automatiquement par l'Agent Refactor