### PR TITLE
refactor: decouple tab-lifecycle from TabManager context

### DIFF
--- a/src/components/file-tree.js
+++ b/src/components/file-tree.js
@@ -7,7 +7,7 @@ import {
 } from '../utils/file-tree-helpers.js';
 import { registerComponent } from '../utils/component-registry.js';
 import { buildDirContextItems } from '../utils/file-tree-context-menu.js';
-import { attachContextMenu } from './context-menu.js';
+import { attachContextMenu } from '../utils/context-menu.js';
 import { renderDirEntry, renderFileEntry } from '../utils/file-tree-renderer.js';
 import {
   setupDropZone, handleFileDrop,

--- a/src/components/tab-manager.js
+++ b/src/components/tab-manager.js
@@ -98,7 +98,7 @@ export class TabManager {
   }
 
   // Find which tab owns a terminal
-  _findTabForTerminal(termId) { return findTabForTerminal(this, termId); }
+  _findTabForTerminal(termId) { return findTabForTerminal(this.tabs, termId); }
 
   _activeTab() {
     return this.tabs.get(this.activeTabId);
@@ -207,7 +207,7 @@ export class TabManager {
     );
   }
 
-  _onTerminalCwdChanged(termId, cwd) { onTerminalCwdChanged(this, termId, cwd); }
+  _onTerminalCwdChanged(termId, cwd) { onTerminalCwdChanged(this.tabs, this.activeTabId, termId, cwd); }
 
   _disposeSideView(mode) { disposeSideView(this, mode); }
 

--- a/src/utils/file-tree-renderer.js
+++ b/src/utils/file-tree-renderer.js
@@ -7,7 +7,7 @@ import { bus } from './events.js';
 import { _el } from './dom.js';
 import { computeIndent, CHEVRON_EXPANDED, CHEVRON_COLLAPSED } from './file-tree-helpers.js';
 import { buildFileContextItems, buildDirContextItems } from './file-tree-context-menu.js';
-import { attachContextMenu } from '../components/context-menu.js';
+import { attachContextMenu } from './context-menu.js';
 
 /**
  * Build a generic row element with a chevron and name span.

--- a/src/utils/tab-color-filter.js
+++ b/src/utils/tab-color-filter.js
@@ -4,7 +4,7 @@
  */
 import { _el } from './dom.js';
 import { COLOR_GROUPS } from './tab-manager-helpers.js';
-import { attachContextMenu } from '../components/context-menu.js';
+import { attachContextMenu } from './context-menu.js';
 
 /**
  * Check if a tab is visible given the current filter state.

--- a/src/utils/tab-lifecycle.js
+++ b/src/utils/tab-lifecycle.js
@@ -2,7 +2,22 @@
  * Tab Lifecycle — extracted from tab-manager.js.
  *
  * Handles tab creation, removal, and activation (switchTo) logic.
- * All functions receive a `ctx` (TabManager instance) as their first argument.
+ *
+ * Functions that mutate state receive a narrow context object instead of
+ * the full TabManager — see TabLifecycleCtx typedef below.
+ * Pure lookup functions (findTabForTerminal, onTerminalCwdChanged) accept
+ * only the data they need.
+ *
+ * @typedef {Object} TabLifecycleCtx
+ * @property {Map<string, WorkspaceTab>} tabs
+ * @property {string|null} activeTabId
+ * @property {string} defaultCwd
+ * @property {string|null} activeColorFilter
+ * @property {string} sidebarMode
+ * @property {Function} renderTabBar
+ * @property {Function} renderActivityBar
+ * @property {Function} renderWorkspace
+ * @property {{ scheduleAutoSave: Function }} configManager
  */
 
 import { generateId } from './id.js';
@@ -18,7 +33,7 @@ import { detachSidebarView } from './sidebar-manager.js';
 
 /**
  * Create a new tab and switch to it.
- * @param {object} ctx    - TabManager instance
+ * @param {TabLifecycleCtx} ctx
  * @param {string|null} name - Optional tab name
  * @param {string|null} cwd  - Optional working directory
  * @returns {WorkspaceTab}
@@ -39,7 +54,7 @@ export function createTab(ctx, name = null, cwd = null) {
 
 /**
  * Close a tab by id, prompting the user for confirmation.
- * @param {object} ctx - TabManager instance
+ * @param {TabLifecycleCtx} ctx
  * @param {string} id  - Tab id to close
  */
 export async function closeTab(ctx, id) {
@@ -73,7 +88,7 @@ export async function closeTab(ctx, id) {
 
 /**
  * Activate a tab by id, handling sidebar mode transitions and DOM attachment.
- * @param {object} ctx - TabManager instance
+ * @param {TabLifecycleCtx} ctx
  * @param {string} id  - Tab id to activate
  */
 export function switchTo(ctx, id) {
@@ -123,16 +138,16 @@ export function switchTo(ctx, id) {
   }
 }
 
-// ── Terminal CWD tracking ──
+// ── Terminal CWD tracking (decoupled — no ctx dependency) ──
 
 /**
  * Find which tab owns a given terminal id.
- * @param {object} ctx     - TabManager instance
+ * @param {Map<string, WorkspaceTab>} tabs
  * @param {string} termId  - Terminal id to look up
  * @returns {WorkspaceTab|null}
  */
-export function findTabForTerminal(ctx, termId) {
-  for (const [, tab] of ctx.tabs) {
+export function findTabForTerminal(tabs, termId) {
+  for (const [, tab] of tabs) {
     if (tab.terminalPanel?.terminals?.has(termId)) return tab;
   }
   return null;
@@ -140,12 +155,13 @@ export function findTabForTerminal(ctx, termId) {
 
 /**
  * Handle terminal cwd changes — update file tree and active-tab header.
- * @param {object} ctx     - TabManager instance
+ * @param {Map<string, WorkspaceTab>} tabs
+ * @param {string|null} activeTabId
  * @param {string} termId  - Terminal id that changed
  * @param {string} cwd     - New working directory
  */
-export function onTerminalCwdChanged(ctx, termId, cwd) {
-  const tab = findTabForTerminal(ctx, termId);
+export function onTerminalCwdChanged(tabs, activeTabId, termId, cwd) {
+  const tab = findTabForTerminal(tabs, termId);
   if (!tab) return;
 
   // Update file tree (works even for inactive tabs)
@@ -155,7 +171,7 @@ export function onTerminalCwdChanged(ctx, termId, cwd) {
 
   // Update header path/branch only for the active tab's active terminal
   if (
-    tab.id === ctx.activeTabId &&
+    tab.id === activeTabId &&
     tab.terminalPanel?.activeTerminal?.terminal?.id === termId
   ) {
     tab.cwd = cwd;


### PR DESCRIPTION
## Refactoring

Première étape pour éliminer le couplage contextuel `ctx` dans les utils extraits de TabManager.

**tab-lifecycle.js :**
- `findTabForTerminal(tabs, termId)` — accepte `tabs` Map directement au lieu du TabManager complet
- `onTerminalCwdChanged(tabs, activeTabId, termId, cwd)` — accepte uniquement les données nécessaires
- Ajout d'un `@typedef TabLifecycleCtx` JSDoc qui documente l'interface minimale requise par `createTab`, `closeTab`, `switchTo`

Les mêmes patterns peuvent être appliqués à `workspace-layout.js` et `sidebar-manager.js` dans des PRs suivantes.

Closes #47

## Fichier(s) modifié(s)

- `src/utils/tab-lifecycle.js` — signatures découpées + JSDoc typedef
- `src/components/tab-manager.js` — call sites adaptés
- Fix import paths context-menu.js (from #41)

## Vérifications

- [x] Build OK
- [x] Tests OK (204/204)

---

📂 Path local : `/Users/rekta/projet/coding/refactor-pikagent`
🤖 PR créée automatiquement par l'Agent Refactor