### PR TITLE
refactor: add EVENT_CATALOG to document all bus events

### DIFF
--- a/src/components/file-tree.js
+++ b/src/components/file-tree.js
@@ -7,7 +7,7 @@ import {
 } from '../utils/file-tree-helpers.js';
 import { registerComponent } from '../utils/component-registry.js';
 import { buildDirContextItems } from '../utils/file-tree-context-menu.js';
-import { attachContextMenu } from './context-menu.js';
+import { attachContextMenu } from '../utils/context-menu.js';
 import { renderDirEntry, renderFileEntry } from '../utils/file-tree-renderer.js';
 import {
   setupDropZone, handleFileDrop,

--- a/src/utils/events.js
+++ b/src/utils/events.js
@@ -1,3 +1,70 @@
+/**
+ * Centralized event bus with documented event catalog.
+ *
+ * EVENT_CATALOG is the single source of truth for all bus events.
+ * Adding a new event requires registering it here first.
+ */
+
+/**
+ * @typedef {Object} EventDef
+ * @property {string} description
+ * @property {string} payload - JSDoc-style payload type description
+ * @property {string[]} emitters - files that emit this event
+ * @property {string[]} listeners - files that listen for this event
+ */
+
+/** @type {Record<string, EventDef>} */
+export const EVENT_CATALOG = {
+  'terminal:cwdChanged': {
+    description: 'Terminal working directory changed',
+    payload: '{ id: string, cwd: string }',
+    emitters: ['terminal-instance.js'],
+    listeners: ['tab-manager.js'],
+  },
+  'terminal:created': {
+    description: 'New terminal spawned in a tab',
+    payload: '{ id: string, cwd: string }',
+    emitters: ['terminal-node-builder.js'],
+    listeners: ['tab-manager.js'],
+  },
+  'terminal:removed': {
+    description: 'Terminal closed and removed from panel',
+    payload: '{ id: string }',
+    emitters: ['terminal-panel.js'],
+    listeners: ['tab-manager.js'],
+  },
+  'terminal:exited': {
+    description: 'Terminal process exited',
+    payload: '{ id: string }',
+    emitters: ['terminal-instance.js'],
+    listeners: ['board-view.js'],
+  },
+  'layout:changed': {
+    description: 'Workspace layout changed (panel resize, split, etc.)',
+    payload: 'undefined',
+    emitters: ['file-viewer.js', 'file-viewer-webview.js', 'terminal-panel.js', 'terminal-split-ops.js'],
+    listeners: ['tab-manager.js'],
+  },
+  'workspace:activated': {
+    description: 'Workspace tab activated or re-shown',
+    payload: 'undefined',
+    emitters: ['tab-lifecycle.js', 'workspace-layout.js'],
+    listeners: ['file-viewer.js'],
+  },
+  'workspace:openFromFolder': {
+    description: 'User requested to open a folder as a new workspace tab',
+    payload: '{ cwd: string }',
+    emitters: ['file-tree-context-menu.js'],
+    listeners: ['tab-manager.js'],
+  },
+  'file:open': {
+    description: 'User requested to open a file in the editor',
+    payload: '{ path: string, name: string }',
+    emitters: ['file-tree-renderer.js', 'file-tree-drop.js', 'git-changes-view.js'],
+    listeners: ['file-viewer.js'],
+  },
+};
+
 export class EventBus {
   constructor() {
     this.listeners = new Map();

--- a/src/utils/file-tree-renderer.js
+++ b/src/utils/file-tree-renderer.js
@@ -7,7 +7,7 @@ import { bus } from './events.js';
 import { _el } from './dom.js';
 import { computeIndent, CHEVRON_EXPANDED, CHEVRON_COLLAPSED } from './file-tree-helpers.js';
 import { buildFileContextItems, buildDirContextItems } from './file-tree-context-menu.js';
-import { attachContextMenu } from '../components/context-menu.js';
+import { attachContextMenu } from './context-menu.js';
 
 /**
  * Build a generic row element with a chevron and name span.

--- a/src/utils/tab-color-filter.js
+++ b/src/utils/tab-color-filter.js
@@ -4,7 +4,7 @@
  */
 import { _el } from './dom.js';
 import { COLOR_GROUPS } from './tab-manager-helpers.js';
-import { attachContextMenu } from '../components/context-menu.js';
+import { attachContextMenu } from './context-menu.js';
 
 /**
  * Check if a tab is visible given the current filter state.


### PR DESCRIPTION
## Refactoring

Ajoute un `EVENT_CATALOG` centralisé dans `events.js` qui documente chaque événement du bus global :

- **8 événements documentés** avec description, payload, émetteurs et consommateurs
- Rend le couplage implicite explicite et traçable
- Sert de point de référence unique pour les développeurs

Étape préparatoire avant une éventuelle migration vers des événements typés ou un pattern Mediator.

Closes #49

## Fichier(s) modifié(s)

- `src/utils/events.js` — ajout de `EVENT_CATALOG`
- Fix import paths context-menu.js (from #41)

## Vérifications

- [x] Build OK
- [x] Tests OK (204/204)

---

📂 Path local : `/Users/rekta/projet/coding/refactor-pikagent`
🤖 PR créée automatiquement par l'Agent Refactor