### PR TITLE
refactor: centralize DOM builders, modals, and keyboard handlers

### DIFF
--- a/src/utils/context-menu.js
+++ b/src/utils/context-menu.js
@@ -1,4 +1,4 @@
-import { _el, positionInViewport } from './dom.js';
+import { _el, positionInViewport, setupKeyboardShortcuts } from './dom.js';
 
 export class ContextMenu {
   constructor() {

--- a/src/utils/dom.js
+++ b/src/utils/dom.js
@@ -49,15 +49,57 @@ export function setupInlineInput(input, { onCommit, onCancel, blurDelay = 0 }) {
     else input.remove();
   };
 
-  input.addEventListener('keydown', (e) => {
-    if (e.key === 'Enter') { e.preventDefault(); e.stopPropagation(); commit(); }
-    if (e.key === 'Escape') { e.stopPropagation(); cancel(); }
+  setupKeyboardShortcuts(input, {
+    onEnter: (e) => { e.preventDefault(); e.stopPropagation(); commit(); },
+    onEscape: (e) => { e.stopPropagation(); cancel(); },
   });
   input.addEventListener('blur', () => {
     if (blurDelay > 0) setTimeout(() => { if (!committed) commit(); }, blurDelay);
     else if (!committed) commit();
   });
   input.addEventListener('click', (e) => e.stopPropagation());
+}
+
+/**
+ * Create a <button> element with common options.
+ * @param {{ label?: string, title?: string, className?: string, onClick?: Function }} opts
+ * @returns {HTMLButtonElement}
+ */
+export function createButton({ label = '', title, className, onClick } = {}) {
+  const btn = _el('button', className || '', label);
+  if (title) btn.title = title;
+  if (onClick) btn.addEventListener('click', onClick);
+  return btn;
+}
+
+/**
+ * Create a <select> element from an options map.
+ * @param {{ options: Object<string, string>, value?: string, className?: string, onChange?: Function }} opts
+ * @returns {HTMLSelectElement}
+ */
+export function createSelect({ options, value, className, onChange } = {}) {
+  const select = _el('select', { className: className || '' });
+  for (const [val, label] of Object.entries(options)) {
+    select.appendChild(_el('option', { value: val, textContent: label }));
+  }
+  if (value !== undefined) select.value = value;
+  if (onChange) select.addEventListener('change', onChange);
+  return select;
+}
+
+/**
+ * Wire up Enter / Escape keyboard shortcuts on an element.
+ * @param {HTMLElement} el
+ * @param {{ onEnter?: Function, onEscape?: Function }} handlers
+ * @returns {Function} cleanup — removes the listener
+ */
+export function setupKeyboardShortcuts(el, { onEnter, onEscape } = {}) {
+  const handler = (e) => {
+    if (e.key === 'Enter' && onEnter) { onEnter(e); }
+    if (e.key === 'Escape' && onEscape) { onEscape(e); }
+  };
+  el.addEventListener('keydown', handler);
+  return () => el.removeEventListener('keydown', handler);
 }
 
 /** Safely call fitAddon.fit(), swallowing errors from detached terminals. */
@@ -88,17 +130,17 @@ export function showPromptDialog({ title, placeholder = '', defaultValue = '', c
     const confirm = () => { const v = input.value.trim(); close(v || null); };
 
     const input = _el('input', { className: 'prompt-dialog-input', type: 'text', value: defaultValue, placeholder });
-    input.addEventListener('keydown', (e) => {
-      if (e.key === 'Enter') confirm();
-      if (e.key === 'Escape') close(null);
+    setupKeyboardShortcuts(input, {
+      onEnter: () => confirm(),
+      onEscape: () => close(null),
     });
 
     const box = _el('div', 'prompt-dialog-box',
       _el('label', 'prompt-dialog-label', title),
       input,
       _el('div', 'prompt-dialog-btns',
-        _el('button', { className: 'prompt-dialog-cancel', textContent: cancelLabel, onClick: () => close(null) }),
-        _el('button', { className: 'prompt-dialog-confirm', textContent: confirmLabel, onClick: confirm }),
+        createButton({ label: cancelLabel, className: 'prompt-dialog-cancel', onClick: () => close(null) }),
+        createButton({ label: confirmLabel, className: 'prompt-dialog-confirm', onClick: confirm }),
       ),
     );
 
@@ -140,8 +182,8 @@ export function showConfirmDialog(message, { confirmLabel = 'OK', cancelLabel = 
     else box.appendChild(message);
 
     const btnRow = _el('div', 'confirm-buttons',
-      _el('button', { className: 'confirm-cancel', textContent: cancelLabel, onClick: () => cleanup(false) }),
-      _el('button', { className: 'confirm-ok', textContent: confirmLabel, onClick: () => cleanup(true) }),
+      createButton({ label: cancelLabel, className: 'confirm-cancel', onClick: () => cleanup(false) }),
+      createButton({ label: confirmLabel, className: 'confirm-ok', onClick: () => cleanup(true) }),
     );
     box.appendChild(btnRow);
     overlay.appendChild(box);

--- a/src/utils/flow-card-renderer.js
+++ b/src/utils/flow-card-renderer.js
@@ -2,18 +2,21 @@
  * Pure rendering helpers for flow cards.
  * Extracted from flow-view.js to reduce component size.
  */
-import { _el } from './dom.js';
+import { _el, createButton } from './dom.js';
 import { formatSchedule } from './flow-schedule-helpers.js';
 import { MAX_VISIBLE_RUNS, buildDotTooltip, buildCardActionEntries } from './flow-view-helpers.js';
 
 /**
  * Create a single action button for a flow card.
+ * Thin wrapper around the centralized `createButton` factory.
  */
 function createFlowActionButton(icon, title, onClick, extraClass = '') {
-  const btn = _el('button', extraClass ? `flow-card-btn ${extraClass}` : 'flow-card-btn', icon);
-  btn.title = title;
-  btn.addEventListener('click', (e) => { e.stopPropagation(); onClick(); });
-  return btn;
+  return createButton({
+    label: icon,
+    title,
+    className: extraClass ? `flow-card-btn ${extraClass}` : 'flow-card-btn',
+    onClick: (e) => { e.stopPropagation(); onClick(); },
+  });
 }
 
 /**

--- a/src/utils/flow-modal-helpers.js
+++ b/src/utils/flow-modal-helpers.js
@@ -1,4 +1,4 @@
-import { _el } from './dom.js';
+import { _el, createSelect } from './dom.js';
 import { SCHEDULE_TYPE_CONFIG } from './flow-schedule-helpers.js';
 
 // --- Constants ---
@@ -22,13 +22,12 @@ export function _vis(el, show) {
   el.style.display = show ? 'flex' : 'none';
 }
 
+/**
+ * Create a <select> for flow modals.
+ * Thin wrapper around the centralized `createSelect` factory.
+ */
 export function _createSelect(options, value) {
-  const select = _el('select', { className: 'flow-modal-select' });
-  for (const [val, label] of Object.entries(options)) {
-    select.appendChild(_el('option', { value: val, textContent: label }));
-  }
-  select.value = value;
-  return select;
+  return createSelect({ options, value, className: 'flow-modal-select' });
 }
 
 export function _createChip(icon, content, extra = {}) {

--- a/src/utils/settings-helpers.js
+++ b/src/utils/settings-helpers.js
@@ -1,15 +1,13 @@
-import { _el } from './dom.js';
+import { createButton } from './dom.js';
 
 /**
  * Build a button element from a descriptor.
+ * Thin wrapper around the centralized `createButton` factory.
  * @param {{ label: string, title?: string, cls?: string, onClick: Function }} desc
  * @returns {HTMLButtonElement}
  */
 export function buildActionBtn({ label, title, cls, onClick }) {
-  const btn = _el('button', cls, label);
-  if (title) btn.title = title;
-  btn.addEventListener('click', onClick);
-  return btn;
+  return createButton({ label, title, className: cls, onClick });
 }
 
 /** Fade-out duration (ms) before removing the modal overlay. */


### PR DESCRIPTION
## Summary

- Added three centralized factories to `src/utils/dom.js`: `createButton({ label, title, className, onClick })`, `createSelect({ options, value, className, onChange })`, and `setupKeyboardShortcuts(el, { onEnter, onEscape })`
- Updated all consumer files to delegate to these factories, keeping local function names as thin wrappers for readability
- Replaced inline Enter/Escape keyboard handling in `setupInlineInput()`, `showPromptDialog()` with `setupKeyboardShortcuts()`
- Replaced inline button creation in `showPromptDialog()`, `showConfirmDialog()` with `createButton()`

## Files modified

| File | Change |
|------|--------|
| `src/utils/dom.js` | Added `createButton()`, `createSelect()`, `setupKeyboardShortcuts()`; refactored internal usages |
| `src/utils/settings-helpers.js` | `buildActionBtn()` now wraps `createButton()` |
| `src/utils/flow-modal-helpers.js` | `_createSelect()` now wraps `createSelect()` |
| `src/utils/flow-card-renderer.js` | `createFlowActionButton()` now wraps `createButton()` |
| `src/utils/context-menu.js` | Imports `setupKeyboardShortcuts` for availability |

## Checks

- [x] `npm test` — 204 tests passed
- [x] `npm run build` — build complete

Closes #58

---
Worktree: `/Users/rekta/projet/coding/wt-refactor-dom-builders`