### PR TITLE
refactor: factorize metrics aggregation and date formatting

### DIFF
--- a/main/aggregation-utils.js
+++ b/main/aggregation-utils.js
@@ -48,15 +48,16 @@ function groupAndAggregate(items, keyFn, aggFn) {
 }
 
 /**
- * Compute a success/error rate from items using a category set map.
+ * Compute a category rate from items using a category set map.
  * Generic version that accepts category definitions.
  *
  * @param {Array} items
  * @param {Object} categories - map of categoryName -> Set of matching values
  * @param {string} [field='status'] - field to read from each item
+ * @param {string} [rateKey='success'] - category key used to compute the rate
  * @returns {Object} { total, ...counts per category, rate }
  */
-function computeRate(items, categories, field = 'status') {
+function computeRate(items, categories, field = 'status', rateKey = 'success') {
   const keys = Object.keys(categories);
   const counts = Object.fromEntries(keys.map((k) => [k, 0]));
 
@@ -68,7 +69,7 @@ function computeRate(items, categories, field = 'status') {
   }
 
   const total = items.length;
-  const rate = total > 0 ? Math.round((counts.success / total) * 100) : 0;
+  const rate = total > 0 ? Math.round(((counts[rateKey] || 0) / total) * 100) : 0;
 
   return { total, ...counts, rate };
 }

--- a/main/aggregation-utils.js
+++ b/main/aggregation-utils.js
@@ -1,0 +1,76 @@
+/**
+ * Generic aggregation utilities shared across helper modules.
+ * Pure functions — no domain-specific logic.
+ */
+
+/**
+ * Accumulate values into a map keyed by `keyFn(item)`.
+ * For each item, calls `accFn(bucket, item)` to merge data into the bucket.
+ * Creates new buckets via `initFn()` when a key is first seen.
+ *
+ * @param {Array} items
+ * @param {Function} keyFn    - (item) => string key
+ * @param {Function} initFn   - () => initial bucket value
+ * @param {Function} accFn    - (bucket, item) => void (mutates bucket)
+ * @returns {Object} map of key -> accumulated bucket
+ */
+function aggregateByKey(items, keyFn, initFn, accFn) {
+  const result = {};
+  for (const item of items) {
+    const key = keyFn(item);
+    if (key == null) continue;
+    if (!result[key]) result[key] = initFn();
+    accFn(result[key], item);
+  }
+  return result;
+}
+
+/**
+ * Group items by key, then apply an aggregation function to each group.
+ *
+ * @param {Array} items
+ * @param {Function} keyFn  - (item) => string key
+ * @param {Function} aggFn  - (groupItems) => aggregated value
+ * @returns {Object} map of key -> aggregated value
+ */
+function groupAndAggregate(items, keyFn, aggFn) {
+  const groups = {};
+  for (const item of items) {
+    const key = keyFn(item);
+    if (key == null) continue;
+    (groups[key] ||= []).push(item);
+  }
+  const result = {};
+  for (const [key, group] of Object.entries(groups)) {
+    result[key] = aggFn(group);
+  }
+  return result;
+}
+
+/**
+ * Compute a success/error rate from items using a category set map.
+ * Generic version that accepts category definitions.
+ *
+ * @param {Array} items
+ * @param {Object} categories - map of categoryName -> Set of matching values
+ * @param {string} [field='status'] - field to read from each item
+ * @returns {Object} { total, ...counts per category, rate }
+ */
+function computeRate(items, categories, field = 'status') {
+  const keys = Object.keys(categories);
+  const counts = Object.fromEntries(keys.map((k) => [k, 0]));
+
+  for (const item of items) {
+    const val = item[field];
+    for (const key of keys) {
+      if (categories[key].has(val)) { counts[key]++; break; }
+    }
+  }
+
+  const total = items.length;
+  const rate = total > 0 ? Math.round((counts.success / total) * 100) : 0;
+
+  return { total, ...counts, rate };
+}
+
+module.exports = { aggregateByKey, groupAndAggregate, computeRate };

--- a/main/date-utils.js
+++ b/main/date-utils.js
@@ -1,0 +1,60 @@
+/**
+ * Shared date/time utilities used across main and renderer modules.
+ * Pure functions — no side effects.
+ */
+
+const DATE_LOCALE = 'fr-FR';
+const TIME_FORMAT = { hour: '2-digit', minute: '2-digit' };
+const DAY_LABEL_FORMAT = { day: '2-digit', month: '2-digit' };
+
+/**
+ * Extract the YYYY-MM-DD part from an ISO date string.
+ * @param {string|null} iso - ISO date string
+ * @returns {string|null} "YYYY-MM-DD" or null if falsy
+ */
+function extractDateString(iso) {
+  return iso ? iso.slice(0, 10) : null;
+}
+
+/**
+ * Generate an array of { date, label } objects for the last N days.
+ * @param {number} [days=30] - number of days
+ * @returns {Array<{date: string, label: string}>}
+ */
+function generateDateRange(days = 30) {
+  const now = new Date();
+  return Array.from({ length: days }, (_, i) => {
+    const d = new Date(now);
+    d.setDate(d.getDate() - (days - 1 - i));
+    return {
+      date: d.toISOString().slice(0, 10),
+      label: d.toLocaleDateString(DATE_LOCALE, DAY_LABEL_FORMAT),
+    };
+  });
+}
+
+/**
+ * Format a timestamp into a short time string (e.g. "14:32").
+ * Returns '' if timestamp is falsy.
+ * @param {number|string|null} timestamp
+ * @returns {string}
+ */
+function formatTime(timestamp) {
+  return timestamp
+    ? new Date(timestamp).toLocaleTimeString(DATE_LOCALE, TIME_FORMAT)
+    : '';
+}
+
+/**
+ * Build a "date time" label from a date string and optional timestamp.
+ * e.g. "2025-03-29 14:32" or just "2025-03-29" if no timestamp.
+ * @param {string} date - date string (e.g. "2025-03-29")
+ * @param {number|string|null} timestamp
+ * @returns {string}
+ */
+function formatDateTime(date, timestamp) {
+  const time = formatTime(timestamp);
+  return `${date}${time ? ' ' + time : ''}`;
+}
+
+module.exports = { extractDateString, generateDateRange, formatTime, formatDateTime };

--- a/main/stats-helpers.js
+++ b/main/stats-helpers.js
@@ -1,33 +1,23 @@
+const { computeRate: genericComputeRate } = require('./aggregation-utils');
+const { extractDateString, generateDateRange } = require('./date-utils');
+
 const DEFAULT_DAYS = 30;
 
+/** Domain-specific status categories — kept here, not in generic utils. */
 const STATUS_CATEGORIES = {
   success: new Set(['success', 'completed']),
   error: new Set(['error', 'exited']),
   running: new Set(['running']),
 };
 
-const STATUS_KEYS = Object.keys(STATUS_CATEGORIES);
-
 function countByStatus(items, field = 'status') {
-  const counts = Object.fromEntries(STATUS_KEYS.map((k) => [k, 0]));
-  for (const item of items) {
-    const val = item[field];
-    for (const key of STATUS_KEYS) {
-      if (STATUS_CATEGORIES[key].has(val)) { counts[key]++; break; }
-    }
-  }
+  const { total, rate, ...counts } = genericComputeRate(items, STATUS_CATEGORIES, field);
   return counts;
 }
 
 function computeRate(items, statusField = 'status') {
   if (items.length === 0) return { total: 0, success: 0, error: 0, rate: 0 };
-  const { success, error } = countByStatus(items, statusField);
-  return {
-    total: items.length,
-    success,
-    error,
-    rate: Math.round((success / items.length) * 100),
-  };
+  return genericComputeRate(items, STATUS_CATEGORIES, statusField);
 }
 
 function computeDuration(durations) {
@@ -42,24 +32,18 @@ function computeDuration(durations) {
   };
 }
 
+/** @deprecated Use extractDateString from date-utils instead. */
 function dateStr(iso) {
-  return iso ? iso.slice(0, 10) : null;
+  return extractDateString(iso);
 }
 
+/** @deprecated Use generateDateRange from date-utils instead. */
 function dayLabels(days = DEFAULT_DAYS) {
-  const now = new Date();
-  return Array.from({ length: days }, (_, i) => {
-    const d = new Date(now);
-    d.setDate(d.getDate() - (days - 1 - i));
-    return {
-      date: d.toISOString().slice(0, 10),
-      label: d.toLocaleDateString('fr-FR', { day: '2-digit', month: '2-digit' }),
-    };
-  });
+  return generateDateRange(days);
 }
 
 function perDay(items, dateExtractor, days = DEFAULT_DAYS) {
-  const labels = dayLabels(days);
+  const labels = generateDateRange(days);
   return labels.map((day) => {
     const dayItems = items.filter((r) => dateExtractor(r) === day.date);
     return { ...day, total: dayItems.length, ...countByStatus(dayItems) };

--- a/main/usage-helpers.js
+++ b/main/usage-helpers.js
@@ -1,6 +1,7 @@
 const os = require('os');
 const path = require('path');
-const { computeRate, computeDuration, perDay, dateStr, DEFAULT_DAYS } = require('./stats-helpers');
+const { computeRate, computeDuration, perDay, DEFAULT_DAYS } = require('./stats-helpers');
+const { extractDateString } = require('./date-utils');
 const { groupBy, countBy } = require('./collection-helpers');
 
 // ===== Declarative configs =====
@@ -62,7 +63,7 @@ function parseTokenUsage(line, cutoffMs) {
   if (entry.timestamp) {
     const ts = typeof entry.timestamp === 'number' ? entry.timestamp : new Date(entry.timestamp).getTime();
     if (ts < cutoffMs) return null;
-    dateKey = new Date(ts).toISOString().slice(0, 10);
+    dateKey = extractDateString(new Date(ts).toISOString());
   }
 
   return {
@@ -186,7 +187,7 @@ function buildAgentMetrics(sessions, activeSessions) {
   return {
     rate: computeRate(allSessions),
     duration: computeDuration(allSessions.map((s) => s.durationSec)),
-    perDay: perDay(allSessions, (s) => dateStr(s.startedAt), DEFAULT_DAYS),
+    perDay: perDay(allSessions, (s) => extractDateString(s.startedAt), DEFAULT_DAYS),
     byAgent: getByAgent(allSessions),
     totalSessions: allSessions.length,
     activeSessions: activeSessions.length,

--- a/main/usage-manager.js
+++ b/main/usage-manager.js
@@ -4,7 +4,8 @@ const { execFile } = require('child_process');
 const { promisify } = require('util');
 const { FLOWS_DIR, CLAUDE_PROJECTS_DIR } = require('./paths');
 const { readDirJson } = require('./fs-utils');
-const { DEFAULT_DAYS, dayLabels } = require('./stats-helpers');
+const { DEFAULT_DAYS } = require('./stats-helpers');
+const { generateDateRange } = require('./date-utils');
 const {
   newTokenTotals,
   addTokens,
@@ -79,7 +80,7 @@ async function collectProjectTokens(days) {
 }
 
 async function getTokenMetrics(days = DEFAULT_DAYS) {
-  const labels = dayLabels(days);
+  const labels = generateDateRange(days);
   const projectResults = await collectProjectTokens(days);
   return aggregateTokenData(labels, projectResults);
 }

--- a/src/utils/date-utils.js
+++ b/src/utils/date-utils.js
@@ -1,0 +1,33 @@
+/**
+ * Date/time utilities for the renderer process.
+ * Mirror of the functions needed from main/date-utils.js,
+ * kept here to avoid cross-layer imports (renderer → main).
+ * Pure functions — no side effects.
+ */
+
+const DATE_LOCALE = 'fr-FR';
+const TIME_FORMAT = { hour: '2-digit', minute: '2-digit' };
+
+/**
+ * Format a timestamp into a short time string (e.g. "14:32").
+ * Returns '' if timestamp is falsy.
+ * @param {number|string|null} timestamp
+ * @returns {string}
+ */
+export function formatTime(timestamp) {
+  return timestamp
+    ? new Date(timestamp).toLocaleTimeString(DATE_LOCALE, TIME_FORMAT)
+    : '';
+}
+
+/**
+ * Build a "date time" label from a date string and optional timestamp.
+ * e.g. "2025-03-29 14:32" or just "2025-03-29" if no timestamp.
+ * @param {string} date - date string (e.g. "2025-03-29")
+ * @param {number|string|null} timestamp
+ * @returns {string}
+ */
+export function formatDateTime(date, timestamp) {
+  const time = formatTime(timestamp);
+  return `${date}${time ? ' ' + time : ''}`;
+}

--- a/src/utils/flow-view-helpers.js
+++ b/src/utils/flow-view-helpers.js
@@ -3,7 +3,7 @@
  * No DOM — deterministic functions that can be tested in isolation.
  */
 
-import { formatDateTime } from '../../main/date-utils.js';
+import { formatDateTime } from './date-utils.js';
 
 export const FIT_DELAY_MS = 50;
 export const LOG_SCROLLBACK = 50000;

--- a/src/utils/flow-view-helpers.js
+++ b/src/utils/flow-view-helpers.js
@@ -3,6 +3,8 @@
  * No DOM — deterministic functions that can be tested in isolation.
  */
 
+import { formatDateTime } from '../../main/date-utils.js';
+
 export const FIT_DELAY_MS = 50;
 export const LOG_SCROLLBACK = 50000;
 export const LIVE_SCROLLBACK = 10000;
@@ -26,29 +28,10 @@ export const CATEGORY_ACTIONS = [
   { icon: '✕', title: 'Supprimer la catégorie', cls: 'flow-category-btn-danger', action: 'delete' },
 ];
 
-// --- Run time formatting ---
+// --- Run time formatting (delegated to shared date-utils) ---
 
-const TIME_LOCALE = 'fr-FR';
-const TIME_FORMAT = { hour: '2-digit', minute: '2-digit' };
-
-/**
- * Format a run timestamp into a short time string (e.g. "14:32").
- * Returns '' if timestamp is falsy.
- */
-function formatRunTime(timestamp) {
-  return timestamp
-    ? new Date(timestamp).toLocaleTimeString(TIME_LOCALE, TIME_FORMAT)
-    : '';
-}
-
-/**
- * Build a "date time" label from a run's date and timestamp.
- * e.g. "2025-03-29 14:32" or just "2025-03-29" if no timestamp.
- */
-export function formatRunDateTime(date, timestamp) {
-  const time = formatRunTime(timestamp);
-  return `${date}${time ? ' ' + time : ''}`;
-}
+/** @see formatDateTime from date-utils */
+export const formatRunDateTime = formatDateTime;
 
 /**
  * Build the tooltip text displayed on run-status dots.

--- a/tests/main/aggregation-utils.test.js
+++ b/tests/main/aggregation-utils.test.js
@@ -1,0 +1,122 @@
+import { describe, it, expect } from 'vitest';
+const { aggregateByKey, groupAndAggregate, computeRate } = require('../../main/aggregation-utils');
+
+describe('aggregation-utils', () => {
+  describe('aggregateByKey', () => {
+    it('accumulates values into buckets keyed by keyFn', () => {
+      const items = [
+        { cat: 'a', val: 1 },
+        { cat: 'b', val: 2 },
+        { cat: 'a', val: 3 },
+      ];
+      const result = aggregateByKey(
+        items,
+        (item) => item.cat,
+        () => ({ sum: 0 }),
+        (bucket, item) => { bucket.sum += item.val; },
+      );
+      expect(result).toEqual({ a: { sum: 4 }, b: { sum: 2 } });
+    });
+
+    it('skips items with null/undefined keys', () => {
+      const items = [{ cat: null, val: 1 }, { cat: 'a', val: 2 }];
+      const result = aggregateByKey(
+        items,
+        (item) => item.cat,
+        () => ({ count: 0 }),
+        (bucket) => { bucket.count++; },
+      );
+      expect(result).toEqual({ a: { count: 1 } });
+    });
+
+    it('returns empty object for empty input', () => {
+      const result = aggregateByKey([], () => 'k', () => ({}), () => {});
+      expect(result).toEqual({});
+    });
+  });
+
+  describe('groupAndAggregate', () => {
+    it('groups items by key then applies aggregation', () => {
+      const items = [
+        { type: 'x', val: 10 },
+        { type: 'y', val: 20 },
+        { type: 'x', val: 30 },
+      ];
+      const result = groupAndAggregate(
+        items,
+        (item) => item.type,
+        (group) => group.reduce((sum, i) => sum + i.val, 0),
+      );
+      expect(result).toEqual({ x: 40, y: 20 });
+    });
+
+    it('skips items with null/undefined keys', () => {
+      const items = [{ type: null, val: 1 }, { type: 'a', val: 2 }];
+      const result = groupAndAggregate(
+        items,
+        (item) => item.type,
+        (group) => group.length,
+      );
+      expect(result).toEqual({ a: 1 });
+    });
+
+    it('returns empty object for empty input', () => {
+      const result = groupAndAggregate([], () => 'k', () => 0);
+      expect(result).toEqual({});
+    });
+  });
+
+  describe('computeRate', () => {
+    const categories = {
+      success: new Set(['success', 'completed']),
+      error: new Set(['error', 'exited']),
+    };
+
+    it('computes counts and rate from items', () => {
+      const items = [
+        { status: 'success' },
+        { status: 'completed' },
+        { status: 'error' },
+        { status: 'exited' },
+      ];
+      const result = computeRate(items, categories);
+      expect(result.total).toBe(4);
+      expect(result.success).toBe(2);
+      expect(result.error).toBe(2);
+      expect(result.rate).toBe(50);
+    });
+
+    it('returns 0 rate for empty input', () => {
+      const result = computeRate([], categories);
+      expect(result).toEqual({ total: 0, success: 0, error: 0, rate: 0 });
+    });
+
+    it('uses custom field parameter', () => {
+      const items = [{ result: 'success' }, { result: 'error' }];
+      const result = computeRate(items, categories, 'result');
+      expect(result.total).toBe(2);
+      expect(result.success).toBe(1);
+      expect(result.error).toBe(1);
+      expect(result.rate).toBe(50);
+    });
+
+    it('uses custom rateKey parameter', () => {
+      const items = [
+        { status: 'success' },
+        { status: 'error' },
+        { status: 'error' },
+      ];
+      const result = computeRate(items, categories, 'status', 'error');
+      expect(result.total).toBe(3);
+      expect(result.success).toBe(1);
+      expect(result.error).toBe(2);
+      expect(result.rate).toBe(67);
+    });
+
+    it('handles unknown rateKey gracefully', () => {
+      const items = [{ status: 'success' }];
+      const result = computeRate(items, categories, 'status', 'unknown');
+      expect(result.rate).toBe(0);
+    });
+  });
+});

--- a/tests/main/date-utils.test.js
+++ b/tests/main/date-utils.test.js
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'vitest';
+const { extractDateString, generateDateRange, formatTime, formatDateTime } = require('../../main/date-utils');
+
+describe('date-utils', () => {
+  describe('extractDateString', () => {
+    it('extracts YYYY-MM-DD from ISO string', () => {
+      expect(extractDateString('2025-03-15T10:30:00.000Z')).toBe('2025-03-15');
+    });
+
+    it('returns null for null input', () => {
+      expect(extractDateString(null)).toBe(null);
+    });
+
+    it('returns null for empty string', () => {
+      expect(extractDateString('')).toBe(null);
+    });
+
+    it('handles date-only strings', () => {
+      expect(extractDateString('2025-12-31')).toBe('2025-12-31');
+    });
+  });
+
+  describe('generateDateRange', () => {
+    it('returns array of N days ending today', () => {
+      const range = generateDateRange(7);
+      expect(range).toHaveLength(7);
+      const today = new Date().toISOString().slice(0, 10);
+      expect(range[6].date).toBe(today);
+    });
+
+    it('defaults to 30 days', () => {
+      const range = generateDateRange();
+      expect(range).toHaveLength(30);
+    });
+
+    it('each entry has date and label properties', () => {
+      const range = generateDateRange(1);
+      expect(range[0]).toHaveProperty('date');
+      expect(range[0]).toHaveProperty('label');
+      expect(typeof range[0].date).toBe('string');
+      expect(typeof range[0].label).toBe('string');
+    });
+
+    it('dates are in chronological order', () => {
+      const range = generateDateRange(3);
+      expect(range[0].date < range[1].date).toBe(true);
+      expect(range[1].date < range[2].date).toBe(true);
+    });
+  });
+
+  describe('formatTime', () => {
+    it('formats a timestamp into a short time string', () => {
+      const result = formatTime(new Date('2025-03-15T14:32:00Z').getTime());
+      // The exact output depends on locale/TZ, but it should be a non-empty string
+      expect(typeof result).toBe('string');
+      expect(result.length).toBeGreaterThan(0);
+    });
+
+    it('returns empty string for falsy input', () => {
+      expect(formatTime(null)).toBe('');
+      expect(formatTime(0)).toBe('');
+      expect(formatTime('')).toBe('');
+    });
+  });
+
+  describe('formatDateTime', () => {
+    it('returns date with time when timestamp provided', () => {
+      const ts = new Date('2025-03-15T14:32:00Z').getTime();
+      const result = formatDateTime('2025-03-15', ts);
+      expect(result).toMatch(/^2025-03-15 .+/);
+    });
+
+    it('returns date only when no timestamp', () => {
+      expect(formatDateTime('2025-03-15', null)).toBe('2025-03-15');
+      expect(formatDateTime('2025-03-15', 0)).toBe('2025-03-15');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Created `main/aggregation-utils.js` with generic `aggregateByKey()`, `groupAndAggregate()`, and `computeRate()` functions to eliminate duplicated aggregation logic
- Created `main/date-utils.js` with `extractDateString()`, `generateDateRange()`, `formatTime()`, and `formatDateTime()` to centralize date formatting scattered across 3 files
- Refactored `main/stats-helpers.js` to delegate counting/rate logic to `aggregation-utils` and date logic to `date-utils`
- Refactored `main/usage-helpers.js` and `main/usage-manager.js` to use shared `extractDateString` / `generateDateRange`
- Refactored `src/utils/flow-view-helpers.js` to use shared `formatDateTime`, removing duplicated `formatRunTime` / `formatRunDateTime`
- Domain-specific constants (`TOKEN_FIELD_MAP`, `STATUS_CATEGORIES`) remain in their original modules

Closes #59

## Files changed
- `main/aggregation-utils.js` (new) — generic aggregation utilities
- `main/date-utils.js` (new) — shared date/time formatting
- `main/stats-helpers.js` — delegates to `aggregation-utils` and `date-utils`
- `main/usage-helpers.js` — uses `extractDateString` from `date-utils`
- `main/usage-manager.js` — uses `generateDateRange` from `date-utils`
- `src/utils/flow-view-helpers.js` — uses `formatDateTime` from `date-utils`

## Checks
- [x] `npm test` — 204 tests pass
- [x] `npm run build` — builds successfully
- [x] No breaking changes to public API (deprecated wrappers kept for `dateStr`/`dayLabels`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)