### PR TITLE
refactor: centralize IPC registration and cache management

### DIFF
--- a/main/cache.js
+++ b/main/cache.js
@@ -1,0 +1,45 @@
+/**
+ * Reusable cache with optional TTL support.
+ *
+ * Usage:
+ *   const cache = new Cache();            // no TTL (never expires)
+ *   const cache = new Cache(30000);       // 30 s TTL
+ *
+ *   cache.set(value);
+ *   cache.get();        // returns value or null if expired / unset
+ *   cache.clear();
+ */
+class Cache {
+  /**
+   * @param {number|null} ttl - Time-to-live in ms. Null or 0 means no expiration.
+   */
+  constructor(ttl = null) {
+    this._ttl = ttl || 0;
+    this._value = null;
+    this._updatedAt = 0;
+  }
+
+  /** Return cached value, or null if unset / expired. */
+  get() {
+    if (this._value === null) return null;
+    if (this._ttl > 0 && (Date.now() - this._updatedAt) >= this._ttl) {
+      this._value = null;
+      return null;
+    }
+    return this._value;
+  }
+
+  /** Store a value and refresh the timestamp. */
+  set(value) {
+    this._value = value;
+    this._updatedAt = Date.now();
+  }
+
+  /** Clear the cache. */
+  clear() {
+    this._value = null;
+    this._updatedAt = 0;
+  }
+}
+
+module.exports = { Cache };

--- a/main/config-manager.js
+++ b/main/config-manager.js
@@ -3,25 +3,28 @@ const path = require('path');
 const { CONFIG_DIR, META_FILE } = require('./paths');
 const { readJson, writeJson, ensureDirOnce, readDirJson } = require('./fs-utils');
 const { DEFAULT_META, sanitizeName, buildConfigRecord, formatConfigList } = require('./config-helpers');
+const { Cache } = require('./cache');
 const { createLogger } = require('./logger');
 
 const log = createLogger('config-manager');
 const ensureDir = ensureDirOnce(CONFIG_DIR);
-let _metaCache = null;
+const _metaCache = new Cache();
 
 function configPath(name) {
   return path.join(CONFIG_DIR, `${sanitizeName(name)}.json`);
 }
 
 async function readMeta() {
-  if (_metaCache) return _metaCache;
-  _metaCache = (await readJson(META_FILE)) || { ...DEFAULT_META };
-  return _metaCache;
+  const cached = _metaCache.get();
+  if (cached) return cached;
+  const meta = (await readJson(META_FILE)) || { ...DEFAULT_META };
+  _metaCache.set(meta);
+  return meta;
 }
 
 async function writeMeta(meta) {
   await ensureDir();
-  _metaCache = meta;
+  _metaCache.set(meta);
   await writeJson(META_FILE, meta);
 }
 
@@ -81,21 +84,4 @@ async function loadDefault() {
   return load(name);
 }
 
-function registerHandlers(ipcMain) {
-  const { registerForward, registerSpread } = require('./ipc-helpers');
-
-  registerForward(ipcMain, { load, list, remove, setDefault, getDefault, loadDefault }, [
-    ['config:load',        'load'],
-    ['config:list',        'list'],
-    ['config:delete',      'remove'],
-    ['config:setDefault',  'setDefault'],
-    ['config:getDefault',  'getDefault'],
-    ['config:loadDefault', 'loadDefault'],
-  ]);
-
-  registerSpread(ipcMain, { save }, [
-    ['config:save', 'save', ['name', 'data']],
-  ]);
-}
-
-module.exports = { save, load, list, remove, setDefault, getDefault, loadDefault, registerHandlers };
+module.exports = { save, load, list, remove, setDefault, getDefault, loadDefault };

--- a/main/electron-handlers.js
+++ b/main/electron-handlers.js
@@ -1,25 +1,5 @@
-const { shell, clipboard, dialog } = require('electron');
-const { registerForward } = require('./ipc-helpers');
+// Shell and clipboard handlers are now registered centrally via FORWARD_TABLE
+// in ipc-helpers.js. Dialog handler is registered in ipc-handlers.js.
+// This module is kept as a placeholder for future Electron-specific handlers.
 
-function registerHandlers(ipcMain, { getWindow }) {
-  registerForward(ipcMain, shell, [
-    ['shell:showInFolder', 'showItemInFolder'],
-    ['shell:openExternal', 'openExternal'],
-    ['shell:openPath',     'openPath'],
-  ]);
-
-  registerForward(ipcMain, clipboard, [
-    ['clipboard:write', 'writeText'],
-  ]);
-
-  ipcMain.handle('dialog:openFolder', async () => {
-    const win = getWindow();
-    const result = await dialog.showOpenDialog(win, {
-      properties: ['openDirectory'],
-    });
-    if (result.canceled || !result.filePaths.length) return null;
-    return result.filePaths[0];
-  });
-}
-
-module.exports = { registerHandlers };
+module.exports = {};

--- a/main/flow-manager.js
+++ b/main/flow-manager.js
@@ -226,28 +226,6 @@ class FlowManager {
   cleanup() {
     this.stop();
   }
-
-  registerHandlers(ipcMain, { getWindow, ptyManager }) {
-    const { registerForward, registerSpread } = require('./ipc-helpers');
-
-    registerForward(ipcMain, this, [
-      ['flow:save',       'save'],
-      ['flow:get',        'get'],
-      ['flow:list',       'list'],
-      ['flow:delete',     'remove'],
-      ['flow:toggle',     'toggleEnabled'],
-      ['flow:runNow',     'runNow'],
-      ['flow:getRunning',    'getRunning'],
-      ['flow:getCategories', 'getCategories'],
-      ['flow:saveCategories', 'saveCategories'],
-    ]);
-
-    registerSpread(ipcMain, this, [
-      ['flow:getRunLog', 'getRunLog', ['flowId', 'logTimestamp']],
-    ]);
-
-    this.start(getWindow, ptyManager);
-  }
 }
 
 module.exports = new FlowManager();

--- a/main/fs-manager.js
+++ b/main/fs-manager.js
@@ -88,43 +88,8 @@ function getHomedir() {
   return os.homedir();
 }
 
-function registerHandlers(ipcMain, { getWindow }) {
-  const { shell } = require('electron');
-  const { safeSend, registerForward, registerSpread } = require('./ipc-helpers');
-
-  registerForward(ipcMain, { readDirectory, readFile, makeDir, getHomedir, copyEntry }, [
-    ['fs:readdir',  'readDirectory'],
-    ['fs:readfile', 'readFile'],
-    ['fs:mkdir',    'makeDir'],
-    ['fs:homedir',  'getHomedir'],
-    ['fs:copy',     'copyEntry'],
-  ]);
-
-  registerSpread(ipcMain, { writeFile, renameEntry, copyFileTo, unwatchDir }, [
-    ['fs:writefile', 'writeFile',  ['filePath', 'content']],
-    ['fs:rename',    'renameEntry', ['oldPath', 'newName']],
-    ['fs:copyTo',    'copyFileTo', ['srcPath', 'destDir']],
-    ['fs:unwatch',   'unwatchDir', ['id']],
-  ]);
-
-  ipcMain.handle('fs:watch', (_, { id, dirPath }) => {
-    watchDir(id, dirPath, (change) => {
-      safeSend(getWindow, 'fs:changed', change);
-    });
-  });
-
-  ipcMain.handle('fs:trash', async (_, filePath) => {
-    try {
-      await shell.trashItem(filePath);
-      return { success: true };
-    } catch (err) {
-      return { error: err.message };
-    }
-  });
-}
-
 function cleanup() {
   unwatchAll();
 }
 
-module.exports = { readDirectory, readFile, writeFile, makeDir, copyEntry, copyFileTo, renameEntry, getHomedir, watchDir, unwatchDir, unwatchAll, cleanup, registerHandlers };
+module.exports = { readDirectory, readFile, writeFile, makeDir, copyEntry, copyFileTo, renameEntry, getHomedir, watchDir, unwatchDir, unwatchAll, cleanup };

--- a/main/git-manager.js
+++ b/main/git-manager.js
@@ -59,18 +59,4 @@ async function getFileDiff(cwd, filePath, isStaged) {
   return result;
 }
 
-function registerHandlers(ipcMain) {
-  const { registerForward, registerSpread } = require('./ipc-helpers');
-
-  registerForward(ipcMain, { getBranch, getRemoteUrl, getLocalChanges }, [
-    ['git:branch',       'getBranch'],
-    ['git:remote',       'getRemoteUrl'],
-    ['git:localChanges', 'getLocalChanges'],
-  ]);
-
-  registerSpread(ipcMain, { getFileDiff }, [
-    ['git:fileDiff', 'getFileDiff', ['cwd', 'filePath', 'isStaged']],
-  ]);
-}
-
-module.exports = { getBranch, getRemoteUrl, getLocalChanges, getFileDiff, registerHandlers };
+module.exports = { getBranch, getRemoteUrl, getLocalChanges, getFileDiff };

--- a/main/ipc-handlers.js
+++ b/main/ipc-handlers.js
@@ -1,39 +1,94 @@
 const { ipcMain } = require('electron');
 const PtyManager = require('./pty-manager');
+const { registerManagerHandlers, safeSend } = require('./ipc-helpers');
 
 const ptyManager = new PtyManager();
 const sessionManager = require('./session-manager');
+const fsManager = require('./fs-manager');
+const gitManager = require('./git-manager');
+const configManager = require('./config-manager');
+const flowManager = require('./flow-manager');
+const usageManager = require('./usage-manager');
 
 /**
- * Handler modules registry.
- * Each module must export a registerHandlers(ipcMain, context) function.
- * To add a new manager, simply append it to this array.
+ * Modules that need lifecycle hooks (start / cleanup).
+ * Custom (non-table) IPC handlers are registered per-module below.
  */
-const HANDLER_MODULES = [
+const LIFECYCLE_MODULES = [
   sessionManager,
   ptyManager,
-  require('./fs-manager'),
-  require('./git-manager'),
-  require('./config-manager'),
-  require('./flow-manager'),
-  require('./usage-manager'),
-  require('./electron-handlers'),
+  fsManager,
+  flowManager,
+  usageManager,
 ];
 
 function register(getWindow) {
-  const context = {
-    getWindow,
-    ptyManager,
-    sessionManager,
+  const { shell, clipboard, dialog } = require('electron');
+
+  // -- Build target map used by FORWARD_TABLE / SPREAD_TABLE --
+  const targets = {
+    pty: ptyManager,
+    fs: fsManager,
+    git: gitManager,
+    config: configManager,
+    flow: flowManager,
+    usage: usageManager,
+    shell,
+    clipboard,
   };
 
-  for (const mod of HANDLER_MODULES) {
-    mod.registerHandlers(ipcMain, context);
-  }
+  // Register all declarative forward/spread handlers in one pass.
+  registerManagerHandlers(ipcMain, targets);
+
+  // -- Custom handlers that cannot be expressed declaratively --
+
+  // PTY: create needs onData/onExit wiring
+  ipcMain.handle('pty:create', (_, { id, cwd, cols, rows }) => {
+    const proc = ptyManager.create({ id, cwd, cols, rows });
+    proc.onData((data) => safeSend(getWindow, 'pty:data', { id, data }));
+    proc.onExit(({ exitCode }) => {
+      ptyManager.processes.delete(id);
+      sessionManager.onTerminalExit(id);
+      safeSend(getWindow, 'pty:exit', { id, exitCode });
+    });
+    return { pid: proc.pid };
+  });
+
+  // FS: watch needs safeSend callback
+  ipcMain.handle('fs:watch', (_, { id, dirPath }) => {
+    fsManager.watchDir(id, dirPath, (change) => {
+      safeSend(getWindow, 'fs:changed', change);
+    });
+  });
+
+  // FS: trash needs Electron shell
+  ipcMain.handle('fs:trash', async (_, filePath) => {
+    try {
+      await shell.trashItem(filePath);
+      return { success: true };
+    } catch (err) {
+      return { error: err.message };
+    }
+  });
+
+  // Dialog: needs window reference
+  ipcMain.handle('dialog:openFolder', async () => {
+    const win = getWindow();
+    const result = await dialog.showOpenDialog(win, {
+      properties: ['openDirectory'],
+    });
+    if (result.canceled || !result.filePaths.length) return null;
+    return result.filePaths[0];
+  });
+
+  // -- Lifecycle: start managers that need runtime context --
+  flowManager.start(getWindow, ptyManager);
+  sessionManager.start(ptyManager);
+  usageManager.init(sessionManager);
 }
 
 function cleanup() {
-  for (const mod of HANDLER_MODULES) {
+  for (const mod of LIFECYCLE_MODULES) {
     if (typeof mod.cleanup === 'function') mod.cleanup();
   }
 }

--- a/main/ipc-helpers.js
+++ b/main/ipc-helpers.js
@@ -103,4 +103,25 @@ function registerSpread(ipc, target, entries) {
   }
 }
 
-module.exports = { safeSend, FORWARD_TABLE, SPREAD_TABLE, registerForward, registerSpread };
+/**
+ * Register all handlers from FORWARD_TABLE and SPREAD_TABLE in one call.
+ * Resolves each targetKey from the provided targets map.
+ *
+ * @param {object} ipc - Electron ipcMain
+ * @param {Object<string, object>} targets - Map of targetKey -> target object
+ */
+function registerManagerHandlers(ipc, targets) {
+  for (const [channel, targetKey, method] of FORWARD_TABLE) {
+    const target = targets[targetKey];
+    if (!target) continue;
+    ipc.handle(channel, (_, arg) => target[method](arg));
+  }
+
+  for (const [channel, targetKey, method, keys] of SPREAD_TABLE) {
+    const target = targets[targetKey];
+    if (!target) continue;
+    ipc.handle(channel, (_, arg) => target[method](...keys.map(k => arg[k])));
+  }
+}
+
+module.exports = { safeSend, FORWARD_TABLE, SPREAD_TABLE, registerForward, registerSpread, registerManagerHandlers };

--- a/main/pty-manager.js
+++ b/main/pty-manager.js
@@ -115,32 +115,6 @@ class PtyManager {
   cleanup() {
     this.killAll();
   }
-
-  registerHandlers(ipcMain, { getWindow, sessionManager }) {
-    const { safeSend, registerForward, registerSpread } = require('./ipc-helpers');
-
-    registerForward(ipcMain, this, [
-      ['pty:checkAgents', 'checkAgents'],
-    ]);
-
-    registerSpread(ipcMain, this, [
-      ['pty:write',  'write',  ['id', 'data']],
-      ['pty:resize', 'resize', ['id', 'cols', 'rows']],
-      ['pty:kill',   'kill',   ['id']],
-      ['pty:getcwd', 'getCwd', ['id']],
-    ]);
-
-    ipcMain.handle('pty:create', (_, { id, cwd, cols, rows }) => {
-      const proc = this.create({ id, cwd, cols, rows });
-      proc.onData((data) => safeSend(getWindow, 'pty:data', { id, data }));
-      proc.onExit(({ exitCode }) => {
-        this.processes.delete(id);
-        sessionManager.onTerminalExit(id);
-        safeSend(getWindow, 'pty:exit', { id, exitCode });
-      });
-      return { pid: proc.pid };
-    });
-  }
 }
 
 module.exports = PtyManager;

--- a/main/session-manager.js
+++ b/main/session-manager.js
@@ -3,6 +3,7 @@ const { BASE_DIR, SESSIONS_FILE } = require('./paths');
 const { readJson, writeJson, ensureDirOnce } = require('./fs-utils');
 const { generateSessionId, durationSec, isFlowTerminal, buildEndedRecord, buildActiveRecord, trimSessions } = require('./session-helpers');
 const { PollingTimer } = require('./polling-timer');
+const { Cache } = require('./cache');
 const { createLogger } = require('./logger');
 
 const log = createLogger('session-manager');
@@ -17,7 +18,7 @@ class SessionManager {
     this._previousAgents = {};
     this._activeSessions = {};
     this._polling = false;
-    this._sessionsCache = null;
+    this._sessionsCache = new Cache();
   }
 
   async start(ptyManager) {
@@ -96,18 +97,19 @@ class SessionManager {
   async _saveRecord(record) {
     await ensureDir();
 
-    this._sessionsCache = trimSessions([...(this._sessionsCache || []), record]);
+    const sessions = trimSessions([...(this._sessionsCache.get() || []), record]);
+    this._sessionsCache.set(sessions);
 
-    writeJson(SESSIONS_FILE, this._sessionsCache)
+    writeJson(SESSIONS_FILE, sessions)
       .catch((err) => log.warn('write failed', err));
   }
 
   async _loadAll() {
-    this._sessionsCache = (await readJson(SESSIONS_FILE)) || [];
+    this._sessionsCache.set((await readJson(SESSIONS_FILE)) || []);
   }
 
   getSessions() {
-    return this._sessionsCache || [];
+    return this._sessionsCache.get() || [];
   }
 
   getActiveSessions() {
@@ -116,10 +118,6 @@ class SessionManager {
 
   cleanup() {
     this.stop();
-  }
-
-  registerHandlers(_ipcMain, { ptyManager }) {
-    this.start(ptyManager);
   }
 }
 

--- a/main/usage-manager.js
+++ b/main/usage-manager.js
@@ -20,12 +20,12 @@ const {
   TOP_FILES_LIMIT,
   GIT_TIMEOUT_MS,
 } = require('./usage-helpers');
+const { Cache } = require('./cache');
 
 const execFileAsync = promisify(execFile);
 
 let _sessionManager = null;
-let _metricsCache = null;
-let _metricsCacheTime = 0;
+const _metricsCache = new Cache(CACHE_TTL);
 
 function init(sessionMgr) {
   _sessionManager = sessionMgr;
@@ -106,10 +106,8 @@ async function getMostModifiedFiles(cwds) {
 // ===== Aggregation =====
 
 async function getMetrics() {
-  const now = Date.now();
-  if (_metricsCache && (now - _metricsCacheTime) < CACHE_TTL) {
-    return _metricsCache;
-  }
+  const cached = _metricsCache.get();
+  if (cached) return cached;
 
   const flows = await getAllFlows();
   const flowRuns = getFlowRuns(flows);
@@ -133,20 +131,9 @@ async function getMetrics() {
     hasData: flows.length > 0 || allSessions.length > 0 || tokens.total > 0,
   };
 
-  _metricsCache = result;
-  _metricsCacheTime = now;
+  _metricsCache.set(result);
 
   return result;
 }
 
-function registerHandlers(ipcMain, { sessionManager }) {
-  const { registerForward } = require('./ipc-helpers');
-
-  init(sessionManager);
-
-  registerForward(ipcMain, { getMetrics }, [
-    ['usage:getMetrics', 'getMetrics'],
-  ]);
-}
-
-module.exports = { getMetrics, registerHandlers };
+module.exports = { init, getMetrics };

--- a/tests/main/cache.test.js
+++ b/tests/main/cache.test.js
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+const { Cache } = require('../../main/cache');
+
+describe('Cache', () => {
+  describe('without TTL', () => {
+    it('returns null when empty', () => {
+      const cache = new Cache();
+      expect(cache.get()).toBeNull();
+    });
+
+    it('stores and retrieves a value', () => {
+      const cache = new Cache();
+      cache.set({ foo: 'bar' });
+      expect(cache.get()).toEqual({ foo: 'bar' });
+    });
+
+    it('overwrites previous value', () => {
+      const cache = new Cache();
+      cache.set('first');
+      cache.set('second');
+      expect(cache.get()).toBe('second');
+    });
+
+    it('clear resets to null', () => {
+      const cache = new Cache();
+      cache.set('value');
+      cache.clear();
+      expect(cache.get()).toBeNull();
+    });
+
+    it('never expires without TTL', () => {
+      vi.useFakeTimers();
+      const cache = new Cache();
+      cache.set('value');
+      vi.advanceTimersByTime(999999999);
+      expect(cache.get()).toBe('value');
+      vi.useRealTimers();
+    });
+  });
+
+  describe('with TTL', () => {
+    beforeEach(() => vi.useFakeTimers());
+    afterEach(() => vi.useRealTimers());
+
+    it('returns value before TTL expires', () => {
+      const cache = new Cache(1000);
+      cache.set('value');
+      vi.advanceTimersByTime(999);
+      expect(cache.get()).toBe('value');
+    });
+
+    it('returns null after TTL expires', () => {
+      const cache = new Cache(1000);
+      cache.set('value');
+      vi.advanceTimersByTime(1000);
+      expect(cache.get()).toBeNull();
+    });
+
+    it('refreshes TTL on set', () => {
+      const cache = new Cache(1000);
+      cache.set('first');
+      vi.advanceTimersByTime(800);
+      cache.set('second');
+      vi.advanceTimersByTime(800);
+      expect(cache.get()).toBe('second');
+    });
+  });
+});

--- a/tests/main/ipc-helpers.test.js
+++ b/tests/main/ipc-helpers.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-const { safeSend, FORWARD_TABLE, SPREAD_TABLE } = require('../../main/ipc-helpers');
+const { safeSend, FORWARD_TABLE, SPREAD_TABLE, registerManagerHandlers } = require('../../main/ipc-helpers');
 
 describe('ipc-helpers', () => {
   describe('safeSend', () => {
@@ -81,6 +81,49 @@ describe('ipc-helpers', () => {
           expect(typeof k).toBe('string');
         }
       }
+    });
+  });
+
+  describe('registerManagerHandlers', () => {
+    it('registers forward and spread handlers from tables', () => {
+      const handlers = {};
+      const ipc = {
+        handle: vi.fn((channel, handler) => { handlers[channel] = handler; }),
+      };
+
+      const myMethod = vi.fn((arg) => `result:${arg}`);
+      const mySpreadMethod = vi.fn((a, b) => `${a}+${b}`);
+
+      const targets = {
+        pty: { checkAgents: myMethod },
+        fs: { readDirectory: myMethod, readFile: myMethod, makeDir: myMethod, getHomedir: myMethod, copyEntry: myMethod, writeFile: mySpreadMethod, renameEntry: mySpreadMethod, copyFileTo: mySpreadMethod, unwatchDir: mySpreadMethod },
+        git: { getBranch: myMethod, getRemoteUrl: myMethod, getLocalChanges: myMethod, getFileDiff: mySpreadMethod },
+        config: { load: myMethod, list: myMethod, remove: myMethod, setDefault: myMethod, getDefault: myMethod, loadDefault: myMethod, save: mySpreadMethod },
+        flow: { save: myMethod, get: myMethod, list: myMethod, remove: myMethod, toggleEnabled: myMethod, runNow: myMethod, getRunning: myMethod, getCategories: myMethod, saveCategories: myMethod, getRunLog: mySpreadMethod },
+        usage: { getMetrics: myMethod },
+        shell: { showItemInFolder: myMethod, openExternal: myMethod, openPath: myMethod },
+        clipboard: { writeText: myMethod },
+      };
+
+      registerManagerHandlers(ipc, targets);
+
+      // Should register all channels from both tables
+      const totalExpected = FORWARD_TABLE.length + SPREAD_TABLE.length;
+      expect(ipc.handle).toHaveBeenCalledTimes(totalExpected);
+
+      // Verify a forward handler works
+      const forwardResult = handlers['fs:readdir'](null, '/some/path');
+      expect(myMethod).toHaveBeenCalledWith('/some/path');
+
+      // Verify a spread handler works
+      handlers['config:save'](null, { name: 'test', data: {} });
+      expect(mySpreadMethod).toHaveBeenCalledWith('test', {});
+    });
+
+    it('skips targets not in the map', () => {
+      const ipc = { handle: vi.fn() };
+      registerManagerHandlers(ipc, {});
+      expect(ipc.handle).not.toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
## Summary
- **IPC registration**: Replaced per-manager `registerHandlers()` boilerplate (6 managers) with a single `registerManagerHandlers(ipc, targets)` call in `ipc-handlers.js` that iterates `FORWARD_TABLE`/`SPREAD_TABLE` and resolves target objects from a centralized map. Custom handlers (`pty:create`, `fs:watch`, `fs:trash`, `dialog:openFolder`) remain in `ipc-handlers.js` with clear comments.
- **Cache class**: Created a reusable `Cache` class (`main/cache.js`) with optional TTL support, replacing ad-hoc cache patterns in `config-manager` (simple cache), `usage-manager` (TTL-based cache), and `session-manager` (persistent cache).
- **Removed ~160 lines** of duplicated registration boilerplate across 6 manager files.

Closes #57

## Files changed
| File | Change |
|------|--------|
| `main/cache.js` | New reusable Cache class with TTL |
| `main/ipc-helpers.js` | Added `registerManagerHandlers()` |
| `main/ipc-handlers.js` | Centralized registration + custom handlers + lifecycle init |
| `main/fs-manager.js` | Removed `registerHandlers` |
| `main/pty-manager.js` | Removed `registerHandlers` |
| `main/git-manager.js` | Removed `registerHandlers` |
| `main/config-manager.js` | Removed `registerHandlers`, adopted `Cache` |
| `main/flow-manager.js` | Removed `registerHandlers` |
| `main/usage-manager.js` | Removed `registerHandlers`, adopted `Cache(CACHE_TTL)` |
| `main/session-manager.js` | Removed `registerHandlers`, adopted `Cache` |
| `main/electron-handlers.js` | Emptied (handlers moved centrally) |
| `tests/main/cache.test.js` | Tests for Cache class (TTL, clear, set/get) |
| `tests/main/ipc-helpers.test.js` | Tests for `registerManagerHandlers()` |

## Test plan
- [x] All 214 existing tests pass (`npm test`)
- [x] Build succeeds (`npm run build`)
- [x] New Cache tests cover: no-TTL, TTL expiry, TTL refresh, clear
- [x] New `registerManagerHandlers` tests cover: full wiring, missing targets

Local path: `/Users/rekta/projet/coding/wt-refactor-ipc-cache`

🤖 Generated with [Claude Code](https://claude.com/claude-code)