### PR TITLE
refactor: document event bus contracts with EVENT_CATALOG

### DIFF
--- a/src/components/board-view.js
+++ b/src/components/board-view.js
@@ -215,8 +215,11 @@ export class BoardView {
 
     // Bus event listeners — single declaration drives both subscription and cleanup
     this._busListeners = subscribeBus([
+      /** @listens terminal:created {{ id: string, cwd: string }} */
       [EVT_CREATED, () => { if (!this.disposed) this.scanAgents(); }],
+      /** @listens terminal:removed {{ id: string }} */
       [EVT_REMOVED, onTerminalGone],
+      /** @listens terminal:exited {{ id: string }} */
       [EVT_EXITED, onTerminalGone],
     ]);
   }

--- a/src/components/file-viewer-webview.js
+++ b/src/components/file-viewer-webview.js
@@ -29,6 +29,7 @@ export class WebviewManager {
     this.webviewTabs.push(wt);
     this._createWebviewContainer(wt);
     this._switchMode(wt.id);
+    /** @emits layout:changed {undefined} — webview added */
     bus.emit('layout:changed');
   }
 
@@ -87,6 +88,7 @@ export class WebviewManager {
       const removedId = this.removeWebview(wt.id);
       if (currentMode === removedId) this._switchMode('files');
       else this._renderModeBar();
+      /** @emits layout:changed {undefined} — webview removed */
       bus.emit('layout:changed');
     });
     btn.appendChild(closeBtn);

--- a/src/components/file-viewer.js
+++ b/src/components/file-viewer.js
@@ -62,16 +62,19 @@ export class FileViewer {
   _setupListeners() {
     // Bus event listeners — single declaration drives both subscription and cleanup
     this._busListeners = subscribeBus([
+      /** @listens file:open {{ path: string, name: string }} */
       ['file:open', ({ path, name }) => {
         if (!this.isActive()) return;
         this.switchMode('files');
         this.openFile(path, name);
       }],
+      /** @listens terminal:cwdChanged {{ id: string, cwd: string }} */
       ['terminal:cwdChanged', ({ cwd }) => {
         if (!this.isActive()) return;
         this.gitChanges.setCwd(cwd);
         if (this.mode === 'git') this.gitChanges.loadChanges();
       }],
+      /** @listens workspace:activated {undefined} */
       ['workspace:activated', () => {
         if (!this.isActive()) return;
         this.loadPinnedFiles();
@@ -272,6 +275,7 @@ export class FileViewer {
     const removedId = this._webviewMgr.removeWebview(webviewId);
     if (this.mode === removedId) this.switchMode('files');
     else this._renderModeBar();
+    /** @emits layout:changed {undefined} — webview removed from file-viewer */
     bus.emit('layout:changed');
   }
 

--- a/src/components/git-changes-view.js
+++ b/src/components/git-changes-view.js
@@ -80,6 +80,7 @@ export class GitChangesView {
       _el('span', { className: 'git-file-name-label', textContent: file.path, title: file.path }),
       _el('span', { className: 'git-open-btn', textContent: '→', title: 'Open file', onClick: (e) => {
         e.stopPropagation();
+        /** @emits file:open {{ path: string, name: string }} */
         bus.emit('file:open', { path: `${this.gitCwd}/${file.path}`, name: file.path.split('/').pop() });
       }}),
     );

--- a/src/components/tab-manager.js
+++ b/src/components/tab-manager.js
@@ -86,22 +86,27 @@ export class TabManager {
 
     // Bus event listeners — single declaration drives both registration and cleanup
     this._busListeners = subscribeBus([
+      /** @listens terminal:cwdChanged {{ id: string, cwd: string }} */
       ['terminal:cwdChanged', ({ id, cwd }) => {
         this._onTerminalCwdChanged(id, cwd);
         this.configManager.scheduleAutoSave();
       }],
+      /** @listens terminal:created {{ id: string, cwd: string }} */
       ['terminal:created', ({ id, cwd }) => {
         const tab = this._findTabForTerminal(id) || this.tabs.get(this.activeTabId);
         if (tab?.fileTree) tab.fileTree.setTerminalRoot(id, cwd);
         this.configManager.scheduleAutoSave();
       }],
+      /** @listens terminal:removed {{ id: string }} */
       ['terminal:removed', ({ id }) => {
         for (const [, tab] of this.tabs) {
           if (tab.fileTree) tab.fileTree.removeTerminal(id);
         }
         this.configManager.scheduleAutoSave();
       }],
+      /** @listens layout:changed {undefined} */
       ['layout:changed', () => this.configManager.scheduleAutoSave()],
+      /** @listens workspace:openFromFolder {{ cwd: string }} */
       ['workspace:openFromFolder', ({ cwd }) => {
         const folderName = extractFolderName(cwd);
         this.createTab(folderName, cwd);

--- a/src/components/terminal-panel.js
+++ b/src/components/terminal-panel.js
@@ -174,6 +174,7 @@ export class TerminalPanel {
       e.preventDefault();
       trackMouse(RESIZE_CURSOR[direction],
         (ev) => doResize(ev, handle, splitEl, direction, () => this.fitAll()),
+        /** @emits layout:changed {undefined} — resize complete */
         () => bus.emit('layout:changed'),
       );
     });
@@ -195,6 +196,7 @@ export class TerminalPanel {
 
     node.terminal.dispose();
     this.terminals.delete(termId);
+    /** @emits terminal:removed {{ id: string }} */
     bus.emit('terminal:removed', { id: termId });
 
     if (this.terminals.size === 0) {

--- a/src/utils/events.js
+++ b/src/utils/events.js
@@ -13,50 +13,108 @@
  * @property {string[]} listeners - files that listen for this event
  */
 
-/** @type {Record<string, EventDef>} */
+/**
+ * Centralized event catalog — single source of truth for all bus events.
+ *
+ * Before adding a new event, register it here with its payload type,
+ * producers, and consumers so that the implicit coupling is documented.
+ *
+ * @type {Record<string, EventDef>}
+ */
 export const EVENT_CATALOG = {
+  /**
+   * Fired when a terminal's working directory changes (e.g. user ran `cd`).
+   * @event terminal:cwdChanged
+   * @type {{ id: string, cwd: string }}
+   */
   'terminal:cwdChanged': {
     description: 'Terminal working directory changed',
     payload: '{ id: string, cwd: string }',
     emitters: ['terminal-instance.js'],
-    listeners: ['tab-manager.js'],
+    listeners: ['tab-manager.js', 'file-viewer.js'],
   },
+
+  /**
+   * Fired after a new terminal process is spawned and attached to a tab.
+   * @event terminal:created
+   * @type {{ id: string, cwd: string }}
+   */
   'terminal:created': {
     description: 'New terminal spawned in a tab',
     payload: '{ id: string, cwd: string }',
     emitters: ['terminal-node-builder.js'],
-    listeners: ['tab-manager.js'],
+    listeners: ['tab-manager.js', 'board-view.js'],
   },
+
+  /**
+   * Fired when a terminal is closed and its DOM node removed from the panel.
+   * @event terminal:removed
+   * @type {{ id: string }}
+   */
   'terminal:removed': {
     description: 'Terminal closed and removed from panel',
     payload: '{ id: string }',
     emitters: ['terminal-panel.js'],
-    listeners: ['tab-manager.js'],
+    listeners: ['tab-manager.js', 'board-view.js'],
   },
+
+  /**
+   * Fired when a terminal's underlying PTY process exits.
+   * @event terminal:exited
+   * @type {{ id: string }}
+   */
   'terminal:exited': {
     description: 'Terminal process exited',
     payload: '{ id: string }',
     emitters: ['terminal-instance.js'],
     listeners: ['board-view.js'],
   },
+
+  /**
+   * Fired when workspace layout changes (panel resize, split, webview add/remove).
+   * Carries no payload.
+   * @event layout:changed
+   * @type {undefined}
+   */
   'layout:changed': {
     description: 'Workspace layout changed (panel resize, split, etc.)',
     payload: 'undefined',
     emitters: ['file-viewer.js', 'file-viewer-webview.js', 'terminal-panel.js', 'terminal-split-ops.js'],
     listeners: ['tab-manager.js'],
   },
+
+  /**
+   * Fired when a workspace tab is activated or re-shown (tab switch, restore).
+   * Carries no payload.
+   * @event workspace:activated
+   * @type {undefined}
+   */
   'workspace:activated': {
     description: 'Workspace tab activated or re-shown',
     payload: 'undefined',
     emitters: ['tab-lifecycle.js', 'workspace-layout.js'],
     listeners: ['file-viewer.js'],
   },
+
+  /**
+   * Fired when the user requests to open a folder as a new workspace tab
+   * (e.g. from the file-tree context menu).
+   * @event workspace:openFromFolder
+   * @type {{ cwd: string }}
+   */
   'workspace:openFromFolder': {
     description: 'User requested to open a folder as a new workspace tab',
     payload: '{ cwd: string }',
     emitters: ['file-tree-context-menu.js'],
     listeners: ['tab-manager.js'],
   },
+
+  /**
+   * Fired when the user requests to open a file in the editor
+   * (click in file tree, drag-drop, or git changes view).
+   * @event file:open
+   * @type {{ path: string, name: string }}
+   */
   'file:open': {
     description: 'User requested to open a file in the editor',
     payload: '{ path: string, name: string }',

--- a/src/utils/file-tree-context-menu.js
+++ b/src/utils/file-tree-context-menu.js
@@ -66,7 +66,10 @@ export function buildDirContextItems(dirPath, rootCwd, contentEl, depth, expande
     { label: 'New File', action: () => promptNewEntryFn(dirPath, contentEl, depth, expandedDirs, 'file') },
     { label: 'New Folder', action: () => promptNewEntryFn(dirPath, contentEl, depth, expandedDirs, 'folder') },
     { separator: true },
-    { label: 'Open as Workspace', action: () => bus.emit('workspace:openFromFolder', { cwd: dirPath }) },
+    { label: 'Open as Workspace', action: () => {
+      /** @emits workspace:openFromFolder {{ cwd: string }} */
+      bus.emit('workspace:openFromFolder', { cwd: dirPath });
+    } },
     { separator: true },
     ...buildCommonContextItems(dirPath, nameEl, rootCwd, promptRenameFn, `Delete folder "${dirName}" and all its contents?`),
   ];

--- a/src/utils/file-tree-drop.js
+++ b/src/utils/file-tree-drop.js
@@ -117,6 +117,7 @@ export function promptNewEntry(dirPath, parentContentEl, depth, expandedDirs, ty
         await window.api.fs.mkdir(newPath);
       } else {
         await window.api.fs.writefile(newPath, '');
+        /** @emits file:open {{ path: string, name: string }} */
         bus.emit('file:open', { path: newPath, name });
       }
     },

--- a/src/utils/file-tree-renderer.js
+++ b/src/utils/file-tree-renderer.js
@@ -98,6 +98,7 @@ export function renderFileEntry(entry, parentEl, depth, callbacks) {
     if (activeRowRef.current) activeRowRef.current.classList.remove('active');
     row.classList.add('active');
     activeRowRef.current = row;
+    /** @emits file:open {{ path: string, name: string }} */
     bus.emit('file:open', { path: entry.path, name: entry.name });
   });
 

--- a/src/utils/tab-lifecycle.js
+++ b/src/utils/tab-lifecycle.js
@@ -124,6 +124,7 @@ export function switchTo(deps, id) {
       if (tab.layoutElement) {
         reattachLayout({ workspaceContainer: deps.workspaceContainer }, tab);
         syncFileTree(tab);
+        /** @emits workspace:activated {undefined} — tab re-shown */
         bus.emit('workspace:activated');
       }
       deps.renderTabBar();
@@ -149,6 +150,7 @@ export function switchTo(deps, id) {
   if (tab.layoutElement) {
     reattachLayout({ workspaceContainer: deps.workspaceContainer }, tab);
     syncFileTree(tab);
+    /** @emits workspace:activated {undefined} — tab switched */
     bus.emit('workspace:activated');
   } else {
     // First time rendering this tab

--- a/src/utils/terminal-instance.js
+++ b/src/utils/terminal-instance.js
@@ -49,6 +49,7 @@ export class TerminalInstance {
     });
 
     this.unsubExit = window.api.pty.onExit(this.id, () => {
+      /** @emits terminal:exited {{ id: string }} */
       bus.emit('terminal:exited', { id: this.id });
     });
 
@@ -71,6 +72,7 @@ export class TerminalInstance {
       const cwd = await window.api.pty.getCwd({ id: this.id });
       if (cwd && cwd !== this.cwd) {
         this.cwd = cwd;
+        /** @emits terminal:cwdChanged {{ id: string, cwd: string }} */
         bus.emit('terminal:cwdChanged', { id: this.id, cwd });
       }
     }, CWD_POLL_MS);

--- a/src/utils/terminal-node-builder.js
+++ b/src/utils/terminal-node-builder.js
@@ -61,6 +61,7 @@ export function createTerminalNode(cwd, defaultCwd, terminals, { buildTopBar: bu
   node.terminal = new TerminalInstance(termContainer, spawnCwd);
   terminals.set(node.terminal.id, node);
 
+  /** @emits terminal:created {{ id: string, cwd: string }} */
   bus.emit('terminal:created', { id: node.terminal.id, cwd: spawnCwd });
 
   wrapper.addEventListener('mousedown', () => onMousedown(node));

--- a/src/utils/terminal-split-ops.js
+++ b/src/utils/terminal-split-ops.js
@@ -51,6 +51,7 @@ export function moveTerminal(sourceId, targetId, side, terminals, { createSplitH
 
   fitAll();
   setActive(sourceNode);
+  /** @emits layout:changed {undefined} — split operation complete */
   bus.emit('layout:changed');
 }
 

--- a/src/utils/workspace-layout.js
+++ b/src/utils/workspace-layout.js
@@ -242,6 +242,7 @@ export async function renderWorkspace({ workspaceContainer, activeTabId, getActi
   const branch = await window.api.git.branch(tab.cwd);
   if (branch) tab.branchBadgeEl.textContent = ` ${branch}`;
 
+  /** @emits workspace:activated {undefined} — workspace rendered for the first time */
   bus.emit('workspace:activated');
 }
 


### PR DESCRIPTION
## Summary
- Enriched `EVENT_CATALOG` in `src/utils/events.js` with per-event JSDoc (`@event`, `@type`) and corrected emitter/listener arrays (3 missing listeners fixed)
- Added `@emits` JSDoc annotations at all 13 `bus.emit()` call sites across 10 files
- Added `@listens` JSDoc annotations at all 11 `subscribeBus()` consumer entries across 3 files
- **No event flow or behavior change** — documentation/typing only

Closes #49

## Files changed (15)
- `src/utils/events.js` — EVENT_CATALOG with full JSDoc per event
- `src/utils/terminal-instance.js` — @emits terminal:cwdChanged, terminal:exited
- `src/utils/terminal-node-builder.js` — @emits terminal:created
- `src/components/terminal-panel.js` — @emits terminal:removed, layout:changed
- `src/utils/terminal-split-ops.js` — @emits layout:changed
- `src/components/file-viewer-webview.js` — @emits layout:changed (2 sites)
- `src/components/file-viewer.js` — @emits layout:changed, @listens file:open, terminal:cwdChanged, workspace:activated
- `src/components/git-changes-view.js` — @emits file:open
- `src/utils/file-tree-renderer.js` — @emits file:open
- `src/utils/file-tree-drop.js` — @emits file:open
- `src/utils/file-tree-context-menu.js` — @emits workspace:openFromFolder
- `src/utils/tab-lifecycle.js` — @emits workspace:activated (2 sites)
- `src/utils/workspace-layout.js` — @emits workspace:activated
- `src/components/tab-manager.js` — @listens 5 events
- `src/components/board-view.js` — @listens 3 events

## Test plan
- [x] `npm test` — 204 tests pass (no regressions)
- [x] `npm run build` — builds successfully
- [ ] Manual smoke test: open workspace, switch tabs, split terminals, open files from tree

🤖 Generated with [Claude Code](https://claude.com/claude-code)