### PR TITLE
refactor: remove dead exports from preload-helpers and managers

### DIFF
--- a/main/ipc-helpers.js
+++ b/main/ipc-helpers.js
@@ -39,6 +39,7 @@ function buildTablesFromSchema(schema) {
   return { forward, spread };
 }
 
+/** @internal — exported for tests only */
 const { forward: FORWARD_TABLE, spread: SPREAD_TABLE } = buildTablesFromSchema(API_SCHEMA);
 
 /**

--- a/main/session-helpers.js
+++ b/main/session-helpers.js
@@ -36,4 +36,4 @@ function trimSessions(sessions, max = MAX_SESSIONS) {
   return sessions.length > max ? sessions.slice(-max) : sessions;
 }
 
-module.exports = { generateSessionId, durationSec, isFlowTerminal, buildEndedRecord, buildActiveRecord, trimSessions, MAX_SESSIONS };
+module.exports = { generateSessionId, durationSec, isFlowTerminal, buildEndedRecord, buildActiveRecord, trimSessions };

--- a/tests/main/session-helpers.test.js
+++ b/tests/main/session-helpers.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-const { generateSessionId, durationSec, isFlowTerminal, buildEndedRecord, buildActiveRecord, trimSessions, MAX_SESSIONS } = require('../../main/session-helpers');
+const { generateSessionId, durationSec, isFlowTerminal, buildEndedRecord, buildActiveRecord, trimSessions } = require('../../main/session-helpers');
 
 describe('session-helpers', () => {
   describe('generateSessionId', () => {
@@ -65,11 +65,11 @@ describe('session-helpers', () => {
       expect(trimSessions(sessions)).toHaveLength(10);
     });
 
-    it('trims to last max entries', () => {
-      const sessions = Array.from({ length: MAX_SESSIONS + 50 }, (_, i) => ({ id: i }));
+    it('trims to last max entries (default 200)', () => {
+      const sessions = Array.from({ length: 250 }, (_, i) => ({ id: i }));
       const trimmed = trimSessions(sessions);
-      expect(trimmed).toHaveLength(MAX_SESSIONS);
-      expect(trimmed[0].id).toBe(50); // (MAX_SESSIONS + 50) - MAX_SESSIONS = 50
+      expect(trimmed).toHaveLength(200);
+      expect(trimmed[0].id).toBe(50); // 250 - 200 = 50
     });
   });
 });


### PR DESCRIPTION
## Summary

- Marked `FORWARD_TABLE` / `SPREAD_TABLE` as `@internal` in `main/ipc-helpers.js` (kept exported because tests rely on them)
- Removed `MAX_SESSIONS` from `main/session-helpers.js` exports (only used internally; test refactored to use literal value `200`)
- Confirmed `preload-helpers.js`, `main/fs-manager.js`, and `main/fs-manager-helpers.js` already had the dead exports (`_onIpc`, `_fwd`, `_pack`, `unwatchAll`, `safeAsync`) removed in prior work — no changes needed

Closes #60

## Fichier(s) modifie(s)

- `main/ipc-helpers.js`
- `main/session-helpers.js`
- `tests/main/session-helpers.test.js`

## Verifications

- [x] Build OK
- [x] Tests OK (325/325 passing)

---

Generated by Agent Refactor