### PR TITLE
refactor: remove dead code (electron-handlers.js + unused exports)

### DIFF
--- a/main/aggregation-utils.js
+++ b/main/aggregation-utils.js
@@ -4,6 +4,7 @@
  */
 
 /**
+ * @internal
  * Accumulate values into a map keyed by `keyFn(item)`.
  * For each item, calls `accFn(bucket, item)` to merge data into the bucket.
  * Creates new buckets via `initFn()` when a key is first seen.
@@ -26,6 +27,7 @@ function aggregateByKey(items, keyFn, initFn, accFn) {
 }
 
 /**
+ * @internal
  * Group items by key, then apply an aggregation function to each group.
  *
  * @param {Array} items

--- a/main/electron-handlers.js
+++ b/main/electron-handlers.js
@@ -1,5 +1,0 @@
-// Shell and clipboard handlers are now registered centrally via FORWARD_TABLE
-// in ipc-helpers.js. Dialog handler is registered in ipc-handlers.js.
-// This module is kept as a placeholder for future Electron-specific handlers.
-
-module.exports = {};

--- a/main/fs-manager.js
+++ b/main/fs-manager.js
@@ -88,43 +88,8 @@ function getHomedir() {
   return os.homedir();
 }
 
-function registerHandlers(ipcMain, { getWindow }) {
-  const { shell } = require('electron');
-  const { safeSend, registerForward, registerSpread } = require('./ipc-helpers');
-
-  registerForward(ipcMain, { readDirectory, readFile, makeDir, getHomedir, copyEntry }, [
-    ['fs:readdir',  'readDirectory'],
-    ['fs:readfile', 'readFile'],
-    ['fs:mkdir',    'makeDir'],
-    ['fs:homedir',  'getHomedir'],
-    ['fs:copy',     'copyEntry'],
-  ]);
-
-  registerSpread(ipcMain, { writeFile, renameEntry, copyFileTo, unwatchDir }, [
-    ['fs:writefile', 'writeFile',  ['filePath', 'content']],
-    ['fs:rename',    'renameEntry', ['oldPath', 'newName']],
-    ['fs:copyTo',    'copyFileTo', ['srcPath', 'destDir']],
-    ['fs:unwatch',   'unwatchDir', ['id']],
-  ]);
-
-  ipcMain.handle('fs:watch', (_, { id, dirPath }) => {
-    watchDir(id, dirPath, (change) => {
-      safeSend(getWindow, 'fs:changed', change);
-    });
-  });
-
-  ipcMain.handle('fs:trash', async (_, filePath) => {
-    try {
-      await shell.trashItem(filePath);
-      return { success: true };
-    } catch (err) {
-      return { error: err.message };
-    }
-  });
-}
-
 function cleanup() {
   unwatchAll();
 }
 
-module.exports = { readDirectory, readFile, writeFile, makeDir, copyEntry, copyFileTo, renameEntry, getHomedir, watchDir, unwatchDir, cleanup, registerHandlers };
+module.exports = { readDirectory, readFile, writeFile, makeDir, copyEntry, copyFileTo, renameEntry, getHomedir, watchDir, unwatchDir, cleanup };

--- a/main/stats-helpers.js
+++ b/main/stats-helpers.js
@@ -32,12 +32,12 @@ function computeDuration(durations) {
   };
 }
 
-/** @deprecated Use extractDateString from date-utils instead. */
+/** @internal @deprecated Use extractDateString from date-utils instead. */
 function dateStr(iso) {
   return extractDateString(iso);
 }
 
-/** @deprecated Use generateDateRange from date-utils instead. */
+/** @internal @deprecated Use generateDateRange from date-utils instead. */
 function dayLabels(days = DEFAULT_DAYS) {
   return generateDateRange(days);
 }

--- a/main/usage-helpers.js
+++ b/main/usage-helpers.js
@@ -42,6 +42,7 @@ function addTokens(target, source) {
   for (const k of TOKEN_KEYS) target[k] += source[k] || 0;
 }
 
+/** @internal */
 function parseLogTimestamp(logTs) {
   const parts = logTs.split('T');
   if (parts.length !== 2) return null;
@@ -72,6 +73,7 @@ function parseTokenUsage(line, cutoffMs) {
   };
 }
 
+/** @internal */
 function projectShortName(proj) {
   const parts = proj.split('-').filter(Boolean);
   return parts.length > 2 ? parts.slice(-2).join('/') : parts.join('/');
@@ -137,6 +139,7 @@ function getFlowRuns(flows) {
   );
 }
 
+/** @internal */
 function getFlowRunDuration(run) {
   if (!run.logTimestamp || !run.timestamp) return null;
   const start = parseLogTimestamp(run.logTimestamp);
@@ -200,6 +203,7 @@ function accumulatePerDay(perDayMap, usage) {
   for (const k of PERDAY_KEYS) perDayMap[usage.dateKey][k] += usage[k];
 }
 
+/** @internal */
 function buildFileKey(cwd, filePath) {
   return `${path.basename(path.dirname(cwd))}/${path.basename(cwd)}/${filePath}`;
 }
@@ -235,7 +239,6 @@ module.exports = {
   getFlowRuns,
   getFlowRunDuration,
   buildFlowMetrics,
-  getByAgent,
   buildAgentMetrics,
   collectUniqueCwds,
 };

--- a/src/components/tab-manager.js
+++ b/src/components/tab-manager.js
@@ -2,7 +2,6 @@ import { bus, subscribeBus, unsubscribeBus } from '../utils/events.js';
 import { ConfigManager } from './config-manager.js';
 import { extractFolderName } from '../utils/file-tree-helpers.js';
 import {
-  COLOR_GROUPS,
   reorderEntries, findCycleTarget, findColorGroupTarget,
 } from '../utils/tab-manager-helpers.js';
 import { isTabVisible, buildColorFilters } from '../utils/tab-color-filter.js';
@@ -24,8 +23,6 @@ import {
   onTerminalCwdChanged,
 } from '../utils/tab-lifecycle.js';
 import { _el } from '../utils/dom.js';
-
-export { COLOR_GROUPS };
 
 export class TabManager {
   constructor(tabBar, workspaceContainer) {

--- a/src/utils/date-utils.js
+++ b/src/utils/date-utils.js
@@ -14,7 +14,7 @@ const TIME_FORMAT = { hour: '2-digit', minute: '2-digit' };
  * @param {number|string|null} timestamp
  * @returns {string}
  */
-export function formatTime(timestamp) {
+function formatTime(timestamp) {
   return timestamp
     ? new Date(timestamp).toLocaleTimeString(DATE_LOCALE, TIME_FORMAT)
     : '';

--- a/src/utils/events.js
+++ b/src/utils/events.js
@@ -21,7 +21,7 @@
  *
  * @type {Record<string, EventDef>}
  */
-export const EVENT_CATALOG = {
+const EVENT_CATALOG = {
   /**
    * Fired when a terminal's working directory changes (e.g. user ran `cd`).
    * @event terminal:cwdChanged
@@ -123,7 +123,7 @@ export const EVENT_CATALOG = {
   },
 };
 
-export class EventBus {
+class EventBus {
   constructor() {
     this.listeners = new Map();
   }

--- a/src/utils/file-icons.js
+++ b/src/utils/file-icons.js
@@ -63,6 +63,7 @@ function _getExt(filename) {
   return filename.split('.').pop().toLowerCase();
 }
 
+/** @internal */
 export function getFileIcon(name, isDirectory) {
   if (isDirectory) return '📁';
   const cfg = FILE_CONFIG[_getExt(name)];

--- a/src/utils/tab-manager-helpers.js
+++ b/src/utils/tab-manager-helpers.js
@@ -19,7 +19,9 @@ export const WORKSPACE_PANELS = [
   { side: 'right', contentCls: 'file-viewer',                    widthKey: 'rightWidth', collapsedKey: 'rightCollapsed' },
 ];
 
+/** @internal */
 export const LEFT_MAX_WIDTH = SIDE_CONFIG.left.maxWidth;
+/** @internal */
 export const RIGHT_MAX_WIDTH = SIDE_CONFIG.right.maxWidth;
 
 // ── Activity bar buttons ──


### PR DESCRIPTION
## Summary

- Deleted `main/electron-handlers.js` (empty module, never imported anywhere)
- Removed `registerHandlers` from `main/fs-manager.js` (dead code -- IPC now centralized via `ipc-helpers.js`)
- Removed `getByAgent` export from `main/usage-helpers.js` (only used internally by `buildAgentMetrics`)
- Removed `COLOR_GROUPS` re-export from `src/components/tab-manager.js` (all consumers import from `tab-manager-helpers.js`)
- Removed `EVENT_CATALOG` and `EventBus` exports from `src/utils/events.js` (only the `bus` singleton is imported externally)
- Removed `formatTime` export from `src/utils/date-utils.js` (only used internally by `formatDateTime`)
- Added `@internal` JSDoc on 11 test-only exports across 6 files

## Test plan

- [x] Build passes (`npm run build`)
- [x] All 325 tests pass (`npm test`)
- [ ] Verify no runtime regression in Electron app

Closes #73

---
Generated with [Claude Code](https://claude.com/claude-code)