### PR TITLE
refactor: factor metrics aggregation and date formatting

### DIFF
--- a/main/stats-helpers.js
+++ b/main/stats-helpers.js
@@ -1,5 +1,5 @@
 const { computeRate: genericComputeRate } = require('./aggregation-utils');
-const { extractDateString, generateDateRange } = require('./date-utils');
+const { generateDateRange } = require('./date-utils');
 
 const DEFAULT_DAYS = 30;
 
@@ -32,16 +32,6 @@ function computeDuration(durations) {
   };
 }
 
-/** @internal @deprecated Use extractDateString from date-utils instead. */
-function dateStr(iso) {
-  return extractDateString(iso);
-}
-
-/** @internal @deprecated Use generateDateRange from date-utils instead. */
-function dayLabels(days = DEFAULT_DAYS) {
-  return generateDateRange(days);
-}
-
 function perDay(items, dateExtractor, days = DEFAULT_DAYS) {
   const labels = generateDateRange(days);
   return labels.map((day) => {
@@ -50,4 +40,4 @@ function perDay(items, dateExtractor, days = DEFAULT_DAYS) {
   });
 }
 
-module.exports = { DEFAULT_DAYS, countByStatus, computeRate, computeDuration, dateStr, dayLabels, perDay };
+module.exports = { DEFAULT_DAYS, countByStatus, computeRate, computeDuration, perDay };

--- a/main/usage-helpers.js
+++ b/main/usage-helpers.js
@@ -2,6 +2,7 @@ const os = require('os');
 const path = require('path');
 const { computeRate, computeDuration, perDay, DEFAULT_DAYS } = require('./stats-helpers');
 const { extractDateString } = require('./date-utils');
+const { aggregateByKey } = require('./aggregation-utils');
 const { groupBy, countBy } = require('./collection-helpers');
 
 // ===== Declarative configs =====
@@ -84,25 +85,26 @@ function aggregateTokenData(labels, projectResults) {
   for (const day of labels) globalPerDay[day.date] = newPerDayTotals();
 
   const totals = newTokenTotals();
-  const perProjectMap = {};
 
-  for (const { proj, totals: pt, perDayMap } of projectResults) {
+  for (const { totals: pt, perDayMap } of projectResults) {
     addTokens(totals, pt);
-
     for (const [dateKey, dayData] of Object.entries(perDayMap)) {
       if (globalPerDay[dateKey]) {
         for (const k of PERDAY_KEYS) globalPerDay[dateKey][k] += dayData[k];
       }
     }
-
-    const perDayTotal = PERDAY_KEYS.reduce((sum, k) => sum + pt[k], 0);
-    if (perDayTotal > 0) {
-      perProjectMap[projectShortName(proj)] = {
-        ...Object.fromEntries(PERDAY_KEYS.map(k => [k, pt[k]])),
-        total: perDayTotal,
-      };
-    }
   }
+
+  // Use aggregateByKey to accumulate per-project token data
+  const perProjectAgg = aggregateByKey(
+    projectResults.filter(({ totals: pt }) => PERDAY_KEYS.reduce((sum, k) => sum + pt[k], 0) > 0),
+    ({ proj }) => projectShortName(proj),
+    () => ({ ...Object.fromEntries(PERDAY_KEYS.map(k => [k, 0])), total: 0 }),
+    (bucket, { totals: pt }) => {
+      for (const k of PERDAY_KEYS) bucket[k] += pt[k];
+      bucket.total += PERDAY_KEYS.reduce((sum, k) => sum + pt[k], 0);
+    },
+  );
 
   const tokenPerDay = labels.map((day) => {
     const g = globalPerDay[day.date];
@@ -110,7 +112,7 @@ function aggregateTokenData(labels, projectResults) {
     return { ...day, ...g, total };
   });
 
-  const perProject = Object.entries(perProjectMap)
+  const perProject = Object.entries(perProjectAgg)
     .map(([project, data]) => ({ project, ...data }))
     .sort((a, b) => b.total - a.total)
     .slice(0, TOP_PROJECTS_LIMIT);

--- a/tests/main/stats-helpers.test.js
+++ b/tests/main/stats-helpers.test.js
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
-const { countByStatus, computeRate, computeDuration, dateStr, dayLabels } = require('../../main/stats-helpers');
+const { countByStatus, computeRate, computeDuration } = require('../../main/stats-helpers');
+const { extractDateString, generateDateRange } = require('../../main/date-utils');
 
 describe('stats-helpers', () => {
   describe('countByStatus', () => {
@@ -59,26 +60,26 @@ describe('stats-helpers', () => {
     });
   });
 
-  describe('dateStr', () => {
+  describe('extractDateString (from date-utils)', () => {
     it('extracts YYYY-MM-DD from ISO string', () => {
-      expect(dateStr('2025-03-15T10:30:00.000Z')).toBe('2025-03-15');
+      expect(extractDateString('2025-03-15T10:30:00.000Z')).toBe('2025-03-15');
     });
 
     it('returns null for falsy input', () => {
-      expect(dateStr(null)).toBe(null);
-      expect(dateStr('')).toBe(null);
+      expect(extractDateString(null)).toBe(null);
+      expect(extractDateString('')).toBe(null);
     });
   });
 
-  describe('dayLabels', () => {
+  describe('generateDateRange (from date-utils)', () => {
     it('returns array of N days ending today', () => {
-      const labels = dayLabels(7);
+      const labels = generateDateRange(7);
       expect(labels).toHaveLength(7);
       expect(labels[6].date).toBe(new Date().toISOString().slice(0, 10));
     });
 
     it('each entry has date and label', () => {
-      const labels = dayLabels(1);
+      const labels = generateDateRange(1);
       expect(labels[0]).toHaveProperty('date');
       expect(labels[0]).toHaveProperty('label');
     });


### PR DESCRIPTION
## Summary

- Removed deprecated `dateStr` and `dayLabels` aliases from `stats-helpers.js` — consumers now import `extractDateString`/`generateDateRange` directly from `date-utils.js`
- Replaced inline per-project accumulation loop in `aggregateTokenData()` with `aggregateByKey` from `aggregation-utils.js`
- Cleaned up unused `extractDateString` import from `stats-helpers.js`
- Updated tests to import date functions directly from `date-utils`

## Files modified

- `main/stats-helpers.js` — removed deprecated wrappers, cleaned imports
- `main/usage-helpers.js` — wired `aggregateByKey` for per-project aggregation
- `tests/main/stats-helpers.test.js` — updated imports to use `date-utils` directly

## Checks

- [x] Build OK
- [x] Tests OK (325 passed)

Closes #59