### PR TITLE
refactor: factor 4 duplications (findTabForTerminal, disposeTerminalMap, polling)

### DIFF
--- a/main/flow-helpers.js
+++ b/main/flow-helpers.js
@@ -44,6 +44,7 @@ function _buildAgentCmd(agent, prompt, opts = {}) {
   return parts.join(' ');
 }
 
+// Shared logic — keep in sync with src/utils/flow-view-helpers.js::getLastRun
 function getLastRun(flow) {
   return flow.runs?.at(-1) ?? null;
 }

--- a/src/components/board-view.js
+++ b/src/components/board-view.js
@@ -4,6 +4,7 @@ import { FilePathLinkProvider } from '../utils/file-link-provider.js';
 import { _el, _safeFit } from '../utils/dom.js';
 import { createTerminal, disposeTerminal, disposeTerminalMap } from '../utils/terminal-factory.js';
 import { registerComponent } from '../utils/component-registry.js';
+import { RendererPollingTimer } from '../utils/polling.js';
 import {
   DATA_VOLUME_THRESHOLD, POLL_INTERVAL_MS, FIT_SETTLE_DELAY_MS, FIT_UNHIDE_DELAY_MS,
   STATUS_CONFIG, ALL_CARD_CLASSES, EVT_CREATED, EVT_REMOVED, EVT_EXITED,
@@ -240,21 +241,20 @@ export class BoardView {
   }
 
   _startPolling() {
-    if (this._pollTimer || this.disposed) return;
-    this._pollTimer = setInterval(() => {
-      if (!this.disposed) {
-        this.scanAgents();
-        this._checkIdleCards();
-      }
-    }, POLL_INTERVAL_MS);
-    this.scanAgents();
+    if (this.disposed) return;
+    if (!this._pollTimer) {
+      this._pollTimer = new RendererPollingTimer(POLL_INTERVAL_MS, () => {
+        if (!this.disposed) {
+          this.scanAgents();
+          this._checkIdleCards();
+        }
+      });
+    }
+    this._pollTimer.start();
   }
 
   pause() {
-    if (this._pollTimer) {
-      clearInterval(this._pollTimer);
-      this._pollTimer = null;
-    }
+    if (this._pollTimer) this._pollTimer.stop();
   }
 
   resume() {

--- a/src/components/flow-card-terminal.js
+++ b/src/components/flow-card-terminal.js
@@ -3,7 +3,7 @@
  * Extracted from FlowView to reduce component size.
  */
 import { _el, _safeFit } from '../utils/dom.js';
-import { createReadonlyTerminal, disposeTerminal } from '../utils/terminal-factory.js';
+import { createReadonlyTerminal, disposeTerminal, disposeTerminalMap } from '../utils/terminal-factory.js';
 import {
   FIT_DELAY_MS, LOG_SCROLLBACK, LIVE_SCROLLBACK,
   STATUS_LABELS, NO_LOG_MESSAGE, NO_LOG_MODAL_MESSAGE,
@@ -31,12 +31,6 @@ export class FlowCardTerminalManager {
     if (!data) return;
     disposeTerminal(data);
     map.delete(flowId);
-  }
-
-  _disposeAllFromMap(map) {
-    for (const [flowId] of map) {
-      this._disposeTerminalEntry(map, flowId);
-    }
   }
 
   // === Live Terminal (for running flows) ===
@@ -127,11 +121,11 @@ export class FlowCardTerminalManager {
   }
 
   disposeAllLogTerminals() {
-    this._disposeAllFromMap(this._logTerminals);
+    disposeTerminalMap(this._logTerminals);
   }
 
   disposeAll() {
-    this._disposeAllFromMap(this._liveTerminals);
-    this._disposeAllFromMap(this._logTerminals);
+    disposeTerminalMap(this._liveTerminals);
+    disposeTerminalMap(this._logTerminals);
   }
 }

--- a/src/components/tab-manager.js
+++ b/src/components/tab-manager.js
@@ -118,7 +118,7 @@ export class TabManager {
   }
 
   // Find which tab owns a terminal
-  _findTabForTerminal(termId) { return findTabForTerminal(this.tabs, termId); }
+  _findTabForTerminal(termId) { return findTabForTerminal(this.tabs, termId)?.tab ?? null; }
 
   _activeTab() {
     return this.tabs.get(this.activeTabId);

--- a/src/utils/board-helpers.js
+++ b/src/utils/board-helpers.js
@@ -3,6 +3,9 @@
  * No DOM — deterministic functions that can be tested in isolation.
  */
 
+import { findTabForTerminal } from './tab-lifecycle.js';
+export { findTabForTerminal };
+
 // Minimum bytes of meaningful output per poll interval to consider agent "working".
 // ANSI escape codes (cursor moves, color resets, status bar refreshes) produce
 // small data bursts even when idle. Real agent output (streaming text, tool
@@ -57,19 +60,6 @@ export function formatCardLabel(agent, tabName) {
  */
 export function resolveCardStatus(dataBytes) {
   return dataBytes >= DATA_VOLUME_THRESHOLD ? 'running' : 'waiting';
-}
-
-/**
- * Find the tab containing a given terminal ID.
- * @param {Map} tabs - tabManager.tabs
- * @param {string} termId
- * @returns {{ tabId: string, tab: object } | null}
- */
-export function findTabForTerminal(tabs, termId) {
-  for (const [tabId, tab] of tabs) {
-    if (tab.terminalPanel?.terminals?.has(termId)) return { tabId, tab };
-  }
-  return null;
 }
 
 /**

--- a/src/utils/flow-view-helpers.js
+++ b/src/utils/flow-view-helpers.js
@@ -146,6 +146,7 @@ export function deleteCategoryData(catData, catId) {
 
 /**
  * Return the last run from a flow's runs array, or null if none.
+ * Shared logic — keep in sync with main/flow-helpers.js::getLastRun
  */
 export function getLastRun(flow) {
   return flow.runs?.at(-1) ?? null;

--- a/src/utils/polling.js
+++ b/src/utils/polling.js
@@ -1,0 +1,33 @@
+/**
+ * Reusable polling timer for the renderer process.
+ * Mirrors the API of main/polling-timer.js (start/stop/running)
+ * but lives in the renderer bundle.
+ */
+export class RendererPollingTimer {
+  /**
+   * @param {number} intervalMs  - Polling interval in milliseconds
+   * @param {Function} callback  - Called on each tick and immediately on start
+   */
+  constructor(intervalMs, callback) {
+    this._intervalMs = intervalMs;
+    this._callback = callback;
+    this._timer = null;
+  }
+
+  start() {
+    if (this._timer) return;
+    this._timer = setInterval(() => this._callback(), this._intervalMs);
+    this._callback();
+  }
+
+  stop() {
+    if (this._timer) {
+      clearInterval(this._timer);
+      this._timer = null;
+    }
+  }
+
+  get running() {
+    return this._timer !== null;
+  }
+}

--- a/src/utils/tab-lifecycle.js
+++ b/src/utils/tab-lifecycle.js
@@ -162,13 +162,15 @@ export function switchTo(deps, id) {
 
 /**
  * Find which tab owns a given terminal id.
+ * Returns the richer `{ tabId, tab }` format so callers needing just the tab
+ * can destructure while callers needing the id (e.g. navigation) also get it.
  * @param {Map<string, WorkspaceTab>} tabs
  * @param {string} termId  - Terminal id to look up
- * @returns {WorkspaceTab|null}
+ * @returns {{ tabId: string, tab: WorkspaceTab } | null}
  */
 export function findTabForTerminal(tabs, termId) {
-  for (const [, tab] of tabs) {
-    if (tab.terminalPanel?.terminals?.has(termId)) return tab;
+  for (const [tabId, tab] of tabs) {
+    if (tab.terminalPanel?.terminals?.has(termId)) return { tabId, tab };
   }
   return null;
 }
@@ -182,8 +184,9 @@ export function findTabForTerminal(tabs, termId) {
  * @param {{ gitBranch: Function }} api - injected API methods
  */
 export function onTerminalCwdChanged(tabs, activeTabId, termId, cwd, { gitBranch }) {
-  const tab = findTabForTerminal(tabs, termId);
-  if (!tab) return;
+  const match = findTabForTerminal(tabs, termId);
+  if (!match) return;
+  const { tab } = match;
 
   // Update file tree (works even for inactive tabs)
   if (tab.fileTree) {


### PR DESCRIPTION
## Summary

- Unified `findTabForTerminal` into a single implementation in `tab-lifecycle.js` returning `{ tabId, tab }`; `board-helpers.js` re-exports it, callers adapted
- Consolidated `disposeTerminalMap` — removed `_disposeAllFromMap` from `flow-card-terminal.js`, replaced with import from `terminal-factory.js`
- Extracted BoardView inline `setInterval`/`clearInterval` polling into a reusable `RendererPollingTimer` class (`src/utils/polling.js`)
- Documented cross-process `getLastRun` duplication with sync comments (main vs renderer boundary prevents shared import)

Closes #72

## Test plan

- [x] Build passes (`npm run build`)
- [x] All 326 tests pass (`npm test`)
- [ ] Manual: verify Board view polling (agent detection, idle status) still works
- [ ] Manual: verify flow card terminal cleanup on view refresh
- [ ] Manual: verify tab navigation from board card header button


🤖 Generated with [Claude Code](https://claude.com/claude-code)