### PR TITLE
refactor: remove dead exports from preload-helpers and managers

### DIFF
--- a/main/ipc-helpers.js
+++ b/main/ipc-helpers.js
@@ -39,7 +39,6 @@ function buildTablesFromSchema(schema) {
   return { forward, spread };
 }
 
-/** @internal — exported for tests only */
 const { forward: FORWARD_TABLE, spread: SPREAD_TABLE } = buildTablesFromSchema(API_SCHEMA);
 
 /**
@@ -93,4 +92,4 @@ function registerManagerHandlers(ipc, targets, skip = new Set()) {
   }
 }
 
-module.exports = { safeSend, FORWARD_TABLE, SPREAD_TABLE, buildTablesFromSchema, registerForward, registerSpread, registerManagerHandlers };
+module.exports = { safeSend, buildTablesFromSchema, registerForward, registerSpread, registerManagerHandlers };

--- a/tests/main/ipc-helpers.test.js
+++ b/tests/main/ipc-helpers.test.js
@@ -1,6 +1,9 @@
 import { describe, it, expect, vi } from 'vitest';
-const { safeSend, FORWARD_TABLE, SPREAD_TABLE, buildTablesFromSchema, registerForward, registerSpread, registerManagerHandlers } = require('../../main/ipc-helpers');
+const { safeSend, buildTablesFromSchema, registerForward, registerSpread, registerManagerHandlers } = require('../../main/ipc-helpers');
 const { API_SCHEMA } = require('../../api-schema');
+
+// Derive tables via public API (no longer exported directly)
+const { forward: FORWARD_TABLE, spread: SPREAD_TABLE } = buildTablesFromSchema(API_SCHEMA);
 
 describe('ipc-helpers', () => {
   describe('safeSend', () => {


### PR DESCRIPTION
## Refactoring

Remove unused exports from `main/ipc-helpers.js`:
- `FORWARD_TABLE` and `SPREAD_TABLE` removed from `module.exports` (kept as module-internal variables)
- Tests updated to derive tables via the public `buildTablesFromSchema(API_SCHEMA)` API

The other files listed in #60 already had no dead exports — the symbols were already local-only:
- `preload-helpers.js`: `_onIpc`, `_fwd`, `_pack` were already not in `module.exports`
- `main/fs-manager.js`: `unwatchAll` was already not in `module.exports`
- `main/session-helpers.js`: `MAX_SESSIONS` was already not in `module.exports`
- `main/fs-manager-helpers.js`: `safeAsync` was already not in `module.exports`

Closes #60

## Fichier(s) modifie(s)

- `main/ipc-helpers.js`
- `tests/main/ipc-helpers.test.js`

## Verifications

- [x] Build OK
- [x] Tests OK (326 tests, 21 files)

---

PR creee automatiquement par l'Agent Refactor