### PR TITLE
refactor: reduce long files and functions

### DIFF
--- a/src/components/flow-view.js
+++ b/src/components/flow-view.js
@@ -97,24 +97,9 @@ export class FlowView {
     this.container.appendChild(wrapper);
   }
 
-  _renderList() {
-    if (!this.listEl) return;
-
-    this._termManager.cleanupStaleLiveTerminals(this._runningMap);
-    this._termManager.disposeAllLogTerminals();
-
-    this.listEl.replaceChildren();
-
-    const hasCats = this.catData.categories.length > 0;
-    const uncatFlows = getUncategorizedFlows(this.flows, this.catData.order);
-    const totalFlows = this.flows.length;
-
-    if (totalFlows === 0 && !hasCats) {
-      this.listEl.appendChild(_el('div', 'flow-empty', EMPTY_LIST_MESSAGE));
-      return;
-    }
-
-    const groupParams = (cat, flows, isUncat = false) => ({
+  /** Build the shared groupParams object for a category section. */
+  _buildGroupParams(cat, flows, isUncat = false) {
+    return {
       cat,
       flows,
       isUncategorized: isUncat,
@@ -131,26 +116,49 @@ export class FlowView {
         getDragFlowId: () => this._drag.flowId,
         clearDrag: () => { this._drag.flowId = null; this._drag.catId = null; },
       },
-    });
+    };
+  }
 
-    // Render categorized groups
+  /** Render named category groups into the list element. */
+  _renderCategorizedGroups() {
     for (const cat of this.catData.categories) {
       const flows = getFlowsForCategory(this.flows, this.catData.order, cat.id);
-      this.listEl.appendChild(createCategoryGroup(groupParams(cat, flows)));
+      this.listEl.appendChild(createCategoryGroup(this._buildGroupParams(cat, flows)));
     }
+  }
 
-    // Render uncategorized
-    if (uncatFlows.length > 0 || hasCats) {
-      if (hasCats) {
-        this.listEl.appendChild(createCategoryGroup(
-          groupParams({ id: UNCATEGORIZED, name: 'Sans catégorie' }, uncatFlows, true)
-        ));
-      } else {
-        for (const flow of uncatFlows) {
-          this.listEl.appendChild(this._createCard(flow, UNCATEGORIZED));
-        }
+  /** Render the uncategorized section into the list element. */
+  _renderUncategorizedSection(uncatFlows, hasCats) {
+    if (uncatFlows.length === 0 && !hasCats) return;
+    if (hasCats) {
+      this.listEl.appendChild(createCategoryGroup(
+        this._buildGroupParams({ id: UNCATEGORIZED, name: 'Sans catégorie' }, uncatFlows, true)
+      ));
+    } else {
+      for (const flow of uncatFlows) {
+        this.listEl.appendChild(this._createCard(flow, UNCATEGORIZED));
       }
     }
+  }
+
+  _renderList() {
+    if (!this.listEl) return;
+
+    this._termManager.cleanupStaleLiveTerminals(this._runningMap);
+    this._termManager.disposeAllLogTerminals();
+
+    this.listEl.replaceChildren();
+
+    const hasCats = this.catData.categories.length > 0;
+    const uncatFlows = getUncategorizedFlows(this.flows, this.catData.order);
+
+    if (this.flows.length === 0 && !hasCats) {
+      this.listEl.appendChild(_el('div', 'flow-empty', EMPTY_LIST_MESSAGE));
+      return;
+    }
+
+    this._renderCategorizedGroups();
+    this._renderUncategorizedSection(uncatFlows, hasCats);
   }
 
   _toggleCollapse(catId) {

--- a/src/components/tab-manager.js
+++ b/src/components/tab-manager.js
@@ -84,8 +84,12 @@ export class TabManager {
       this.createTab('Workspace 1');
     }
 
-    // Bus event listeners — single declaration drives both registration and cleanup
-    this._busListeners = subscribeBus([
+    this._busListeners = this._setupBusListeners();
+  }
+
+  /** Register bus event listeners. Returns the subscription handle for cleanup. */
+  _setupBusListeners() {
+    return subscribeBus([
       /** @listens terminal:cwdChanged {{ id: string, cwd: string }} */
       ['terminal:cwdChanged', ({ id, cwd }) => {
         this._onTerminalCwdChanged(id, cwd);

--- a/src/utils/tab-lifecycle.js
+++ b/src/utils/tab-lifecycle.js
@@ -100,6 +100,39 @@ export async function closeTab(deps, createTabFn, switchToFn, id) {
   deps.configManager.scheduleAutoSave();
 }
 
+// ── Tab activation — helpers ──
+
+/**
+ * Detach the outgoing tab's layout, capturing panel widths first.
+ * @param {Map<string, WorkspaceTab>} tabs
+ * @param {string|null} activeTabId
+ */
+function _cleanupPreviousTab(tabs, activeTabId) {
+  if (!activeTabId) return;
+  const prev = tabs.get(activeTabId);
+  if (prev && prev.layoutElement) {
+    capturePanelWidths(prev);
+    prev.layoutElement.remove();
+  }
+}
+
+/**
+ * Attach the incoming tab's layout (or render it for the first time).
+ * @param {SwitchToDeps} deps
+ * @param {WorkspaceTab} tab
+ */
+function _activateTab(deps, tab) {
+  if (tab.layoutElement) {
+    reattachLayout({ workspaceContainer: deps.workspaceContainer }, tab);
+    syncFileTree(tab);
+    /** @emits workspace:activated {undefined} — tab switched */
+    bus.emit('workspace:activated');
+  } else {
+    // First time rendering this tab
+    deps.renderWorkspace(tab);
+  }
+}
+
 // ── Tab activation ──
 
 /**
@@ -121,12 +154,7 @@ export function switchTo(deps, id) {
 
     // If this tab is already active, just re-show its layout
     if (id === activeTabId) {
-      if (tab.layoutElement) {
-        reattachLayout({ workspaceContainer: deps.workspaceContainer }, tab);
-        syncFileTree(tab);
-        /** @fires workspace:activated {undefined} — tab re-shown */
-        bus.emit('workspace:activated');
-      }
+      if (tab.layoutElement) _activateTab(deps, tab);
       deps.renderTabBar();
       return;
     }
@@ -134,28 +162,10 @@ export function switchTo(deps, id) {
 
   if (id === activeTabId) return;
 
-  // Detach outgoing tab (keep terminals alive!)
-  if (activeTabId) {
-    const prev = deps.tabs.get(activeTabId);
-    if (prev && prev.layoutElement) {
-      // Capture panel widths before detaching (needs attached DOM)
-      capturePanelWidths(prev);
-      prev.layoutElement.remove();
-    }
-  }
-
+  _cleanupPreviousTab(deps.tabs, activeTabId);
   deps.setActiveTabId(id);
   deps.renderTabBar();
-
-  if (tab.layoutElement) {
-    reattachLayout({ workspaceContainer: deps.workspaceContainer }, tab);
-    syncFileTree(tab);
-    /** @fires workspace:activated {undefined} — tab switched */
-    bus.emit('workspace:activated');
-  } else {
-    // First time rendering this tab
-    deps.renderWorkspace(tab);
-  }
+  _activateTab(deps, tab);
 }
 
 // ── Terminal CWD tracking (decoupled — no ctx dependency) ──

--- a/src/utils/workspace-layout.js
+++ b/src/utils/workspace-layout.js
@@ -1,32 +1,15 @@
 /**
  * Workspace Layout Manager — extracted from tab-manager.js.
  *
- * Handles workspace panel building, resize, serialization, and restoration.
- * All functions receive explicit dependency objects instead of the full
- * TabManager instance — see typedefs below.
- *
- * @typedef {Object} PanelInteractionDeps
- * @property {Function} getActiveTab      - () => WorkspaceTab|null
- * @property {Function} scheduleAutoSave  - () => void
+ * Handles workspace rendering, layout helpers, and tab disposal.
+ * Resize logic lives in workspace-resize.js.
+ * Serialization logic lives in workspace-serializer.js.
  *
  * @typedef {Object} RenderWorkspaceDeps
  * @property {HTMLElement} workspaceContainer
  * @property {Function} getActiveTabId    - () => string|null
  * @property {Function} getActiveTab      - () => WorkspaceTab|null
  * @property {Function} scheduleAutoSave  - () => void
- *
- * @typedef {Object} SerializeDeps
- * @property {Map<string, WorkspaceTab>} tabs
- * @property {string|null} activeTabId
- *
- * @typedef {Object} RestoreConfigDeps
- * @property {Map<string, WorkspaceTab>} tabs
- * @property {Function} setActiveTabId    - (id) => void
- * @property {string} defaultCwd
- * @property {Function} renderTabBar      - () => void
- * @property {Function} switchTo          - (id) => void
- * @property {{ isRestoring: boolean }} configManager
- * @property {import('./sidebar-manager.js').SideViewStore} viewStore
  *
  * @typedef {Object} DisposeAllTabsDeps
  * @property {Map<string, WorkspaceTab>} tabs
@@ -36,161 +19,28 @@
 import { getComponent } from './component-registry.js';
 import { bus } from './events.js';
 import { _el } from './dom.js';
-import { trackMouse } from './drag-helpers.js';
-import { generateId } from './id.js';
+import { WORKSPACE_PANELS, TAB_DISPOSABLES } from './tab-manager-helpers.js';
 import {
-  PANEL_MIN_WIDTH, FIT_DELAY_MS,
-  WORKSPACE_PANELS, WorkspaceTab, TAB_DISPOSABLES,
-  clampPanelWidth, panelArrowState,
-} from './tab-manager-helpers.js';
-import { disposeAllSideViews } from './sidebar-manager.js';
+  buildSidePanel, buildCenterPanel,
+  capturePanelWidths, restorePanelSizes,
+} from './workspace-resize.js';
 
-// ── Panel building ──
+// Re-export from workspace-resize.js for backward compatibility
+export {
+  buildSidePanel, buildCenterPanel,
+  setupPanelResize, togglePanel,
+  capturePanelWidths, restorePanelSizes,
+} from './workspace-resize.js';
 
-/**
- * Build a collapsible side panel (left or right).
- * @param {PanelInteractionDeps} deps
- * @param {{ side: string, contentCls: string, title?: string }} panelDef
- */
-export function buildSidePanel(deps, { side, contentCls, title }) {
-  const panel = _el('div', `panel panel-${side}`);
-  if (title) {
-    const header = _el('div', 'panel-header');
-    header.appendChild(_el('span', 'panel-title', title));
-    panel.appendChild(header);
-  }
-  const content = _el('div', contentCls);
-  panel.appendChild(content);
-  const handle = _el('div', 'panel-resize-handle');
-  setupPanelResize(deps, handle, panel, side);
-  return { panel, handle, content };
-}
-
-/**
- * Build the center panel with path info, branch badge, and terminal area.
- * @param {PanelInteractionDeps} deps
- * @param {WorkspaceTab} tab
- * @param {HTMLElement} leftPanel
- * @param {HTMLElement} rightPanel
- */
-export function buildCenterPanel(deps, tab, leftPanel, rightPanel) {
-  const panel = _el('div', 'panel panel-center');
-  const header = _el('div', 'panel-header');
-
-  const pathInfo = _el('div', 'path-info');
-
-  const pathArrowLeft = _el('span', 'path-arrow', '\u2190');
-  pathArrowLeft.title = 'Collapse left panel';
-  pathArrowLeft.addEventListener('click', () => togglePanel(deps, leftPanel, 'left', pathArrowLeft));
-
-  const pathText = _el('span', 'path-text', tab.cwd);
-  const branchBadge = _el('span', 'branch-badge', '');
-
-  const pathArrowRight = _el('span', 'path-arrow', '\u2192');
-  pathArrowRight.title = 'Collapse right panel';
-  pathArrowRight.addEventListener('click', () => togglePanel(deps, rightPanel, 'right', pathArrowRight));
-
-  pathInfo.append(pathArrowLeft, pathText, branchBadge, pathArrowRight);
-  header.appendChild(pathInfo);
-  header.appendChild(_el('div', 'term-label', 'Terminal'));
-  panel.appendChild(header);
-
-  const termContainer = _el('div', 'terminal-area');
-  panel.appendChild(termContainer);
-
-  tab.pathTextEl = pathText;
-  tab.branchBadgeEl = branchBadge;
-
-  return { panel, termContainer };
-}
-
-// ── Panel resize / toggle ──
-
-/**
- * Attach mousedown resize handler to a panel handle.
- * @param {PanelInteractionDeps} deps
- * @param {HTMLElement} handle
- * @param {HTMLElement} panel
- * @param {string} side
- */
-export function setupPanelResize({ getActiveTab, scheduleAutoSave }, handle, panel, side) {
-  let startX = 0;
-  let startWidth = 0;
-
-  handle.addEventListener('mousedown', (e) => {
-    e.preventDefault();
-    startX = e.clientX;
-    startWidth = panel.getBoundingClientRect().width;
-    trackMouse('col-resize',
-      (ev) => {
-        const dx = ev.clientX - startX;
-        const newWidth = side === 'left' ? startWidth + dx : startWidth - dx;
-        panel.style.width = `${clampPanelWidth(newWidth, side)}px`;
-        panel.style.flex = 'none';
-        getActiveTab()?.terminalPanel?.fitAll();
-      },
-      () => scheduleAutoSave(),
-    );
-  });
-}
-
-/**
- * Toggle a panel's collapsed state and re-fit terminals.
- * @param {PanelInteractionDeps} deps
- * @param {HTMLElement} panel
- * @param {string} side
- * @param {HTMLElement} [arrowEl]
- */
-export function togglePanel({ getActiveTab, scheduleAutoSave }, panel, side, arrowEl) {
-  panel.classList.add('animating');
-  panel.classList.toggle('collapsed');
-  const isCollapsed = panel.classList.contains('collapsed');
-
-  if (arrowEl) {
-    const arrow = panelArrowState(side, isCollapsed);
-    arrowEl.textContent = arrow.text;
-    arrowEl.title = arrow.title;
-  }
-
-  setTimeout(() => {
-    panel.classList.remove('animating');
-    getActiveTab()?.terminalPanel?.fitAll();
-  }, FIT_DELAY_MS);
-  scheduleAutoSave();
-}
-
-// ── Panel width capture / restore ──
-
-export function capturePanelWidths(tab) {
-  if (!tab.layoutElement) return;
-  tab._panelWidths = {};
-  for (const { side, widthKey, collapsedKey } of WORKSPACE_PANELS) {
-    const el = tab.layoutElement.querySelector(`.panel-${side}`);
-    if (!el) continue;
-    tab._panelWidths[widthKey] = el.getBoundingClientRect().width;
-    tab._panelWidths[collapsedKey] = el.classList.contains('collapsed');
-  }
-}
-
-export function restorePanelSizes(panels, panelEls) {
-  if (!panels) return;
-  for (const { widthKey, collapsedKey, side } of WORKSPACE_PANELS) {
-    const el = panelEls[side];
-    if (!el) continue;
-    if (panels[widthKey] && !panels[collapsedKey]) {
-      el.style.width = `${panels[widthKey]}px`;
-      el.style.flex = 'none';
-    }
-    if (panels[collapsedKey]) el.classList.add('collapsed');
-  }
-}
+// Re-export from workspace-serializer.js for backward compatibility
+export { serialize, restoreConfig } from './workspace-serializer.js';
 
 // ── Workspace rendering ──
 
 /**
  * Render the full workspace layout for a tab.
  * @param {RenderWorkspaceDeps} deps
- * @param {WorkspaceTab} tab
+ * @param {import('./tab-manager-helpers.js').WorkspaceTab} tab
  * @param {{ gitBranch: Function }} api - injected API methods
  */
 export async function renderWorkspace({ workspaceContainer, getActiveTabId, getActiveTab, scheduleAutoSave }, tab, { gitBranch }) {
@@ -249,7 +99,7 @@ export async function renderWorkspace({ workspaceContainer, getActiveTabId, getA
 /**
  * Re-attach a tab's existing layout element to the workspace container.
  * @param {{ workspaceContainer: HTMLElement }} deps
- * @param {WorkspaceTab} tab
+ * @param {import('./tab-manager-helpers.js').WorkspaceTab} tab
  */
 export function reattachLayout({ workspaceContainer }, tab) {
   workspaceContainer.replaceChildren();
@@ -275,87 +125,6 @@ export function syncFileTree(tab) {
       tab.fileTree.setTerminalRoot(termId, node.terminal.cwd);
     }
   }
-}
-
-// ── Serialization ──
-
-/**
- * Serialize all tabs into a config object.
- * @param {SerializeDeps} deps
- * @returns {{ tabs: Array, activeTabIndex: number }}
- */
-export function serialize({ tabs, activeTabId }) {
-  const serializedTabs = [];
-  let activeTabIndex = 0;
-  let i = 0;
-
-  for (const [id, tab] of tabs) {
-    if (id === activeTabId) activeTabIndex = i;
-
-    const tabData = {
-      name: tab.name,
-      cwd: tab.cwd,
-      noShortcut: tab.noShortcut || false,
-      colorGroup: tab.colorGroup || null,
-      splitTree: null,
-      panels: {},
-    };
-
-    // Serialize terminal tree (works for both active and detached layouts)
-    if (tab.terminalPanel) {
-      tabData.splitTree = tab.terminalPanel.serialize();
-    }
-
-    // Serialize webview tabs
-    if (tab.fileViewer) {
-      tabData.webviewTabs = tab.fileViewer.getWebviewTabs();
-    }
-
-    // Panel widths — active tab: snapshot from live DOM; inactive: use cached
-    if (id === activeTabId) capturePanelWidths(tab);
-    if (tab._panelWidths) tabData.panels = { ...tab._panelWidths };
-
-    serializedTabs.push(tabData);
-    i++;
-  }
-
-  return { tabs: serializedTabs, activeTabIndex };
-}
-
-// ── Restore ──
-
-/**
- * Restore workspace from a saved config.
- * @param {RestoreConfigDeps} deps
- * @param {Object} config
- */
-export async function restoreConfig({ tabs, setActiveTabId, defaultCwd, renderTabBar, switchTo, configManager, viewStore }, config) {
-  if (!config || !config.tabs || config.tabs.length === 0) return;
-
-  configManager.isRestoring = true;
-
-  // Reset side views (old terminal IDs will be invalid)
-  disposeAllSideViews(viewStore);
-  disposeAllTabs({ tabs, setActiveTabId });
-
-  // Create tabs from config
-  for (const tabData of config.tabs) {
-    const id = generateId('tab');
-    const tab = new WorkspaceTab(id, tabData.name, tabData.cwd || defaultCwd || '/');
-    tab.noShortcut = tabData.noShortcut || false;
-    tab.colorGroup = tabData.colorGroup || null;
-    tab._restoreData = tabData;
-    tabs.set(id, tab);
-  }
-
-  renderTabBar();
-
-  // Switch to the active tab
-  const tabIds = Array.from(tabs.keys());
-  const activeIdx = Math.min(config.activeTabIndex || 0, tabIds.length - 1);
-  switchTo(tabIds[activeIdx]);
-
-  configManager.isRestoring = false;
 }
 
 // ── Tab disposal ──

--- a/src/utils/workspace-resize.js
+++ b/src/utils/workspace-resize.js
@@ -1,0 +1,157 @@
+/**
+ * Workspace Resize — extracted from workspace-layout.js.
+ *
+ * Handles panel resize interactions and panel toggle (collapse/expand).
+ *
+ * @typedef {Object} PanelInteractionDeps
+ * @property {Function} getActiveTab      - () => WorkspaceTab|null
+ * @property {Function} scheduleAutoSave  - () => void
+ */
+
+import { _el } from './dom.js';
+import { trackMouse } from './drag-helpers.js';
+import {
+  PANEL_MIN_WIDTH, FIT_DELAY_MS,
+  WORKSPACE_PANELS,
+  clampPanelWidth, panelArrowState,
+} from './tab-manager-helpers.js';
+
+// ── Panel building ──
+
+/**
+ * Build a collapsible side panel (left or right).
+ * @param {PanelInteractionDeps} deps
+ * @param {{ side: string, contentCls: string, title?: string }} panelDef
+ */
+export function buildSidePanel(deps, { side, contentCls, title }) {
+  const panel = _el('div', `panel panel-${side}`);
+  if (title) {
+    const header = _el('div', 'panel-header');
+    header.appendChild(_el('span', 'panel-title', title));
+    panel.appendChild(header);
+  }
+  const content = _el('div', contentCls);
+  panel.appendChild(content);
+  const handle = _el('div', 'panel-resize-handle');
+  setupPanelResize(deps, handle, panel, side);
+  return { panel, handle, content };
+}
+
+/**
+ * Build the center panel with path info, branch badge, and terminal area.
+ * @param {PanelInteractionDeps} deps
+ * @param {import('./tab-manager-helpers.js').WorkspaceTab} tab
+ * @param {HTMLElement} leftPanel
+ * @param {HTMLElement} rightPanel
+ */
+export function buildCenterPanel(deps, tab, leftPanel, rightPanel) {
+  const panel = _el('div', 'panel panel-center');
+  const header = _el('div', 'panel-header');
+
+  const pathInfo = _el('div', 'path-info');
+
+  const pathArrowLeft = _el('span', 'path-arrow', '\u2190');
+  pathArrowLeft.title = 'Collapse left panel';
+  pathArrowLeft.addEventListener('click', () => togglePanel(deps, leftPanel, 'left', pathArrowLeft));
+
+  const pathText = _el('span', 'path-text', tab.cwd);
+  const branchBadge = _el('span', 'branch-badge', '');
+
+  const pathArrowRight = _el('span', 'path-arrow', '\u2192');
+  pathArrowRight.title = 'Collapse right panel';
+  pathArrowRight.addEventListener('click', () => togglePanel(deps, rightPanel, 'right', pathArrowRight));
+
+  pathInfo.append(pathArrowLeft, pathText, branchBadge, pathArrowRight);
+  header.appendChild(pathInfo);
+  header.appendChild(_el('div', 'term-label', 'Terminal'));
+  panel.appendChild(header);
+
+  const termContainer = _el('div', 'terminal-area');
+  panel.appendChild(termContainer);
+
+  tab.pathTextEl = pathText;
+  tab.branchBadgeEl = branchBadge;
+
+  return { panel, termContainer };
+}
+
+// ── Panel resize / toggle ──
+
+/**
+ * Attach mousedown resize handler to a panel handle.
+ * @param {PanelInteractionDeps} deps
+ * @param {HTMLElement} handle
+ * @param {HTMLElement} panel
+ * @param {string} side
+ */
+export function setupPanelResize({ getActiveTab, scheduleAutoSave }, handle, panel, side) {
+  let startX = 0;
+  let startWidth = 0;
+
+  handle.addEventListener('mousedown', (e) => {
+    e.preventDefault();
+    startX = e.clientX;
+    startWidth = panel.getBoundingClientRect().width;
+    trackMouse('col-resize',
+      (ev) => {
+        const dx = ev.clientX - startX;
+        const newWidth = side === 'left' ? startWidth + dx : startWidth - dx;
+        panel.style.width = `${clampPanelWidth(newWidth, side)}px`;
+        panel.style.flex = 'none';
+        getActiveTab()?.terminalPanel?.fitAll();
+      },
+      () => scheduleAutoSave(),
+    );
+  });
+}
+
+/**
+ * Toggle a panel's collapsed state and re-fit terminals.
+ * @param {PanelInteractionDeps} deps
+ * @param {HTMLElement} panel
+ * @param {string} side
+ * @param {HTMLElement} [arrowEl]
+ */
+export function togglePanel({ getActiveTab, scheduleAutoSave }, panel, side, arrowEl) {
+  panel.classList.add('animating');
+  panel.classList.toggle('collapsed');
+  const isCollapsed = panel.classList.contains('collapsed');
+
+  if (arrowEl) {
+    const arrow = panelArrowState(side, isCollapsed);
+    arrowEl.textContent = arrow.text;
+    arrowEl.title = arrow.title;
+  }
+
+  setTimeout(() => {
+    panel.classList.remove('animating');
+    getActiveTab()?.terminalPanel?.fitAll();
+  }, FIT_DELAY_MS);
+  scheduleAutoSave();
+}
+
+// ── Panel width capture / restore ──
+
+export function capturePanelWidths(tab) {
+  if (!tab.layoutElement) return;
+  tab._panelWidths = {};
+  for (const { side, widthKey, collapsedKey } of WORKSPACE_PANELS) {
+    const el = tab.layoutElement.querySelector(`.panel-${side}`);
+    if (!el) continue;
+    tab._panelWidths[widthKey] = el.getBoundingClientRect().width;
+    tab._panelWidths[collapsedKey] = el.classList.contains('collapsed');
+  }
+}
+
+export function restorePanelSizes(panels, panelEls) {
+  if (!panels) return;
+  for (const { widthKey, collapsedKey, side } of WORKSPACE_PANELS) {
+    const el = panelEls[side];
+    if (!el) continue;
+    if (panels[widthKey] && !panels[collapsedKey]) {
+      el.style.width = `${panels[widthKey]}px`;
+      el.style.flex = 'none';
+    }
+    if (panels[collapsedKey]) el.classList.add('collapsed');
+  }
+}

--- a/src/utils/workspace-serializer.js
+++ b/src/utils/workspace-serializer.js
@@ -1,0 +1,105 @@
+/**
+ * Workspace Serializer — extracted from workspace-layout.js.
+ *
+ * Handles tab serialization and config restoration.
+ *
+ * @typedef {Object} SerializeDeps
+ * @property {Map<string, WorkspaceTab>} tabs
+ * @property {string|null} activeTabId
+ *
+ * @typedef {Object} RestoreConfigDeps
+ * @property {Map<string, WorkspaceTab>} tabs
+ * @property {Function} setActiveTabId    - (id) => void
+ * @property {string} defaultCwd
+ * @property {Function} renderTabBar      - () => void
+ * @property {Function} switchTo          - (id) => void
+ * @property {{ isRestoring: boolean }} configManager
+ * @property {import('./sidebar-manager.js').SideViewStore} viewStore
+ */
+
+import { generateId } from './id.js';
+import { WorkspaceTab } from './tab-manager-helpers.js';
+import { disposeAllSideViews } from './sidebar-manager.js';
+import { capturePanelWidths } from './workspace-resize.js';
+import { disposeAllTabs } from './workspace-layout.js';
+
+// ── Serialization ──
+
+/**
+ * Serialize all tabs into a config object.
+ * @param {SerializeDeps} deps
+ * @returns {{ tabs: Array, activeTabIndex: number }}
+ */
+export function serialize({ tabs, activeTabId }) {
+  const serializedTabs = [];
+  let activeTabIndex = 0;
+  let i = 0;
+
+  for (const [id, tab] of tabs) {
+    if (id === activeTabId) activeTabIndex = i;
+
+    const tabData = {
+      name: tab.name,
+      cwd: tab.cwd,
+      noShortcut: tab.noShortcut || false,
+      colorGroup: tab.colorGroup || null,
+      splitTree: null,
+      panels: {},
+    };
+
+    // Serialize terminal tree (works for both active and detached layouts)
+    if (tab.terminalPanel) {
+      tabData.splitTree = tab.terminalPanel.serialize();
+    }
+
+    // Serialize webview tabs
+    if (tab.fileViewer) {
+      tabData.webviewTabs = tab.fileViewer.getWebviewTabs();
+    }
+
+    // Panel widths — active tab: snapshot from live DOM; inactive: use cached
+    if (id === activeTabId) capturePanelWidths(tab);
+    if (tab._panelWidths) tabData.panels = { ...tab._panelWidths };
+
+    serializedTabs.push(tabData);
+    i++;
+  }
+
+  return { tabs: serializedTabs, activeTabIndex };
+}
+
+// ── Restore ──
+
+/**
+ * Restore workspace from a saved config.
+ * @param {RestoreConfigDeps} deps
+ * @param {Object} config
+ */
+export async function restoreConfig({ tabs, setActiveTabId, defaultCwd, renderTabBar, switchTo, configManager, viewStore }, config) {
+  if (!config || !config.tabs || config.tabs.length === 0) return;
+
+  configManager.isRestoring = true;
+
+  // Reset side views (old terminal IDs will be invalid)
+  disposeAllSideViews(viewStore);
+  disposeAllTabs({ tabs, setActiveTabId });
+
+  // Create tabs from config
+  for (const tabData of config.tabs) {
+    const id = generateId('tab');
+    const tab = new WorkspaceTab(id, tabData.name, tabData.cwd || defaultCwd || '/');
+    tab.noShortcut = tabData.noShortcut || false;
+    tab.colorGroup = tabData.colorGroup || null;
+    tab._restoreData = tabData;
+    tabs.set(id, tab);
+  }
+
+  renderTabBar();
+
+  // Switch to the active tab
+  const tabIds = Array.from(tabs.keys());
+  const activeIdx = Math.min(config.activeTabIndex || 0, tabIds.length - 1);
+  switchTo(tabIds[activeIdx]);
+
+  configManager.isRestoring = false;
+}


### PR DESCRIPTION
## Refactoring

Split long functions into smaller helpers and extract modules from oversized files:

- `tab-lifecycle.js`: split `switchTo()` into `_cleanupPreviousTab()` and `_activateTab()`
- `flow-view.js`: split `_renderList()` into `_buildGroupParams()`, `_renderCategorizedGroups()`, `_renderUncategorizedSection()`
- `tab-manager.js`: extract `_setupBusListeners()` from `init()`
- `workspace-layout.js`: extract resize and serialization into separate modules

Closes #83

## Fichier(s) modifié(s)

- `src/utils/tab-lifecycle.js`
- `src/utils/workspace-layout.js`
- `src/utils/workspace-resize.js` (new)
- `src/utils/workspace-serializer.js` (new)
- `src/components/tab-manager.js`
- `src/components/flow-view.js`

## Vérifications

- [x] Build OK
- [x] Tests OK (328/328 passed)

---

📂 Path local : `/Users/rekta/projet/coding/refactor-pikagent`
🤖 PR créée automatiquement par l'Agent Refactor