### PR TITLE
refactor: factorize 4 code duplications

### DIFF
--- a/main/flow-helpers.js
+++ b/main/flow-helpers.js
@@ -1,6 +1,7 @@
 const path = require('path');
 const { FLOWS_DIR, LOGS_DIR } = require('./paths');
 const { createStreamParser } = require('./flow-stream-parser');
+const { getLastRun } = require('../shared/flow-utils');
 
 const MS_PER_HOUR = 3_600_000;
 const SCHEDULER_INTERVAL_MS = 60_000;
@@ -44,10 +45,7 @@ function _buildAgentCmd(agent, prompt, opts = {}) {
   return parts.join(' ');
 }
 
-// Shared logic — keep in sync with src/utils/flow-view-helpers.js::getLastRun
-function getLastRun(flow) {
-  return flow.runs?.at(-1) ?? null;
-}
+// getLastRun imported from shared/flow-utils.js
 
 /* ── Schedule day filters (single source of truth) ─────────────── */
 

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
       "main.js",
       "preload.js",
       "main/**/*",
+      "shared/**/*",
       "src/**/*",
       "dist/**/*",
       "package.json"

--- a/shared/flow-utils.js
+++ b/shared/flow-utils.js
@@ -1,0 +1,16 @@
+/**
+ * Shared flow utilities used by both main and renderer processes.
+ * CommonJS format so main/ can require() it directly;
+ * esbuild resolves it for the renderer bundle.
+ */
+
+/**
+ * Return the last run from a flow's runs array, or null if none.
+ * @param {{ runs?: Array }} flow
+ * @returns {Object|null}
+ */
+function getLastRun(flow) {
+  return flow.runs?.at(-1) ?? null;
+}
+
+module.exports = { getLastRun };

--- a/src/utils/flow-view-helpers.js
+++ b/src/utils/flow-view-helpers.js
@@ -4,6 +4,7 @@
  */
 
 import { formatDateTime } from './date-utils.js';
+import { getLastRun } from '../../shared/flow-utils.js';
 
 export const FIT_DELAY_MS = 50;
 export const LOG_SCROLLBACK = 50000;
@@ -144,13 +145,8 @@ export function deleteCategoryData(catData, catId) {
   return true;
 }
 
-/**
- * Return the last run from a flow's runs array, or null if none.
- * Shared logic — keep in sync with main/flow-helpers.js::getLastRun
- */
-export function getLastRun(flow) {
-  return flow.runs?.at(-1) ?? null;
-}
+// getLastRun imported from shared/flow-utils.js and re-exported
+export { getLastRun };
 
 /**
  * Build the list of card action descriptors for a given flow state.


### PR DESCRIPTION
## Refactoring

Eliminate 4 patterns of code duplication identified in #72:

1. **findTabForTerminal**: already unified into single function in `tab-lifecycle.js` returning `{ tabId, tab }`; `board-helpers.js` imports and re-exports it (done in prior commit)
2. **getLastRun**: extracted to `shared/flow-utils.js` (CJS module importable by both Electron processes); `main/flow-helpers.js` and `src/utils/flow-view-helpers.js` now import from it
3. **disposeTerminalMap**: `_disposeAllFromMap` already removed from `flow-card-terminal.js`, uses `disposeTerminalMap` from `terminal-factory.js` (done in prior commit)
4. **BoardView polling**: already replaced manual `setInterval`/`clearInterval` with `RendererPollingTimer` from `src/utils/polling.js` (done in prior commit)

This PR addresses the one remaining duplication (#2) by creating a shared module.

Closes #72

## Fichier(s) modifie(s)

- `shared/flow-utils.js` (new)
- `main/flow-helpers.js`
- `src/utils/flow-view-helpers.js`
- `package.json`

## Verifications

- [x] Build OK
- [x] Tests OK (326/326 passing)