### PR TITLE
refactor: centralize DOM builders, modals, and keyboard handlers

### DIFF
--- a/src/utils/flow-card-renderer.js
+++ b/src/utils/flow-card-renderer.js
@@ -27,11 +27,10 @@ function createFlowActionButton(icon, title, onClick, extraClass = '') {
 function createRunDots(flow, onShowLog) {
   const dots = _el('div', 'flow-card-dots');
   for (const run of (flow.runs || []).slice(-MAX_VISIBLE_RUNS)) {
-    const dot = _el('button', `flow-dot flow-dot-${run.status}`);
-    dot.title = buildDotTooltip(run);
-    dot.addEventListener('click', (e) => {
-      e.stopPropagation();
-      onShowLog(flow, run);
+    const dot = createButton({
+      className: `flow-dot flow-dot-${run.status}`,
+      title: buildDotTooltip(run),
+      onClick: (e) => { e.stopPropagation(); onShowLog(flow, run); },
     });
     dots.appendChild(dot);
   }
@@ -67,14 +66,11 @@ export function createCardHeader(flow, isRunning, isExpanded, opts) {
   nameRow.appendChild(_el('span', 'flow-card-name', flow.name));
   if (isRunning) nameRow.appendChild(_el('span', 'flow-running-badge', 'En cours...'));
   if (isRunning) {
-    nameRow.appendChild(_el('button', {
+    nameRow.appendChild(createButton({
+      label: isExpanded ? '▾ Sortie' : '▸ Sortie',
       className: 'flow-output-toggle',
-      textContent: isExpanded ? '▾ Sortie' : '▸ Sortie',
       title: isExpanded ? 'Masquer la sortie' : 'Afficher la sortie',
-      onClick: (e) => {
-        e.stopPropagation();
-        opts.onToggleOutput(flow.id);
-      },
+      onClick: (e) => { e.stopPropagation(); opts.onToggleOutput(flow.id); },
     }));
   }
   info.appendChild(nameRow);


### PR DESCRIPTION
## Refactoring

Complete the DOM builder centralization by replacing the last remaining inline `_el('button', ...)` calls in `flow-card-renderer.js` with the shared `createButton()` factory from `dom.js`.

This finishes the work started in #80, converting:
- `createRunDots()` — run-status dot buttons now use `createButton()`
- `createCardHeader()` — output toggle button now uses `createButton()`

Closes #58

## Fichier(s) modifie(s)

- `src/utils/flow-card-renderer.js`

## Verifications

- [x] Build OK
- [x] Tests OK (326/326 passing)

---

Path local : `/Users/rekta/projet/coding/refactor-pikagent`
PR creee automatiquement par l'Agent Refactor