### PR TITLE
refactor: factorize aggregation patterns and date formatting

### DIFF
--- a/main/aggregation-utils.js
+++ b/main/aggregation-utils.js
@@ -76,4 +76,23 @@ function computeRate(items, categories, field = 'status', rateKey = 'success') {
   return { total, ...counts, rate };
 }
 
-module.exports = { computeRate };
+/**
+ * Compute basic numeric statistics (avg, min, max, count) from an array of values.
+ * Filters out null/undefined/zero/negative values before computing.
+ *
+ * @param {Array<number|null>} values
+ * @returns {{ avg: number, min: number, max: number, count: number }}
+ */
+function computeNumericStats(values) {
+  const valid = values.filter((v) => v != null && v > 0);
+  if (valid.length === 0) return { avg: 0, min: 0, max: 0, count: 0 };
+  const avg = valid.reduce((a, b) => a + b, 0) / valid.length;
+  return {
+    avg: Math.round(avg),
+    min: Math.round(Math.min(...valid)),
+    max: Math.round(Math.max(...valid)),
+    count: valid.length,
+  };
+}
+
+module.exports = { aggregateByKey, groupAndAggregate, computeRate, computeNumericStats };

--- a/main/stats-helpers.js
+++ b/main/stats-helpers.js
@@ -1,4 +1,4 @@
-const { computeRate: genericComputeRate } = require('./aggregation-utils');
+const { computeRate: genericComputeRate, groupAndAggregate, computeNumericStats } = require('./aggregation-utils');
 const { generateDateRange } = require('./date-utils');
 
 const DEFAULT_DAYS = 30;
@@ -20,24 +20,25 @@ function computeRate(items, statusField = 'status') {
   return genericComputeRate(items, STATUS_CATEGORIES, statusField);
 }
 
+/** Delegate to generic computeNumericStats from aggregation-utils. */
 function computeDuration(durations) {
-  const valid = durations.filter((d) => d != null && d > 0);
-  if (valid.length === 0) return { avg: 0, min: 0, max: 0, count: 0 };
-  const avg = valid.reduce((a, b) => a + b, 0) / valid.length;
-  return {
-    avg: Math.round(avg),
-    min: Math.round(Math.min(...valid)),
-    max: Math.round(Math.max(...valid)),
-    count: valid.length,
-  };
+  return computeNumericStats(durations);
 }
 
 function perDay(items, dateExtractor, days = DEFAULT_DAYS) {
   const labels = generateDateRange(days);
-  return labels.map((day) => {
-    const dayItems = items.filter((r) => dateExtractor(r) === day.date);
-    return { ...day, total: dayItems.length, ...countByStatus(dayItems) };
-  });
+  // Group items by date once (O(n)) instead of filtering per label (O(n*d))
+  const grouped = groupAndAggregate(
+    items,
+    (item) => dateExtractor(item),
+    (groupItems) => ({ total: groupItems.length, ...countByStatus(groupItems) }),
+  );
+  return labels.map((day) => ({
+    ...day,
+    total: 0,
+    ...countByStatus([]),
+    ...grouped[day.date],
+  }));
 }
 
 module.exports = { DEFAULT_DAYS, countByStatus, computeRate, computeDuration, perDay };

--- a/src/utils/date-utils.js
+++ b/src/utils/date-utils.js
@@ -1,7 +1,7 @@
 /**
- * Date/time utilities for the renderer process.
- * Mirror of the functions needed from main/date-utils.js,
- * kept here to avoid cross-layer imports (renderer → main).
+ * Centralized date/time utilities for the renderer process.
+ * Parallel to main/date-utils.js — kept separate to avoid
+ * cross-layer imports (renderer → main).
  * Pure functions — no side effects.
  */
 
@@ -14,7 +14,7 @@ const TIME_FORMAT = { hour: '2-digit', minute: '2-digit' };
  * @param {number|string|null} timestamp
  * @returns {string}
  */
-function formatTime(timestamp) {
+export function formatTime(timestamp) {
   return timestamp
     ? new Date(timestamp).toLocaleTimeString(DATE_LOCALE, TIME_FORMAT)
     : '';

--- a/tests/main/aggregation-utils.test.js
+++ b/tests/main/aggregation-utils.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-const { computeRate } = require('../../main/aggregation-utils');
+const { aggregateByKey, groupAndAggregate, computeRate, computeNumericStats } = require('../../main/aggregation-utils');
 
 describe('aggregation-utils', () => {
   describe('computeRate', () => {
@@ -53,6 +53,31 @@ describe('aggregation-utils', () => {
       const items = [{ status: 'success' }];
       const result = computeRate(items, categories, 'status', 'unknown');
       expect(result.rate).toBe(0);
+    });
+  });
+
+  describe('computeNumericStats', () => {
+    it('computes avg, min, max from values', () => {
+      const result = computeNumericStats([10, 20, 30]);
+      expect(result.avg).toBe(20);
+      expect(result.min).toBe(10);
+      expect(result.max).toBe(30);
+      expect(result.count).toBe(3);
+    });
+
+    it('filters out null/zero/negative values', () => {
+      const result = computeNumericStats([null, 0, -5, 100]);
+      expect(result.count).toBe(1);
+      expect(result.avg).toBe(100);
+    });
+
+    it('returns zeros for empty input', () => {
+      expect(computeNumericStats([])).toEqual({ avg: 0, min: 0, max: 0, count: 0 });
+    });
+
+    it('rounds results', () => {
+      const result = computeNumericStats([10, 15]);
+      expect(result.avg).toBe(13); // Math.round(12.5)
     });
   });
 });


### PR DESCRIPTION
## Refactoring

Factorize duplicated aggregation and date formatting patterns:
- Extracted generic `computeNumericStats()` into `aggregation-utils.js` — removes duplicated numeric stats logic from `stats-helpers.js`
- `computeDuration()` now delegates to `computeNumericStats()`
- `perDay()` now uses `groupAndAggregate()` — improves from O(n*d) to O(n+d) and leverages the previously-unused generic utility
- Exported `formatTime` from `src/utils/date-utils.js` for renderer-side reuse
- Added tests for `computeNumericStats`

Closes #59

## Fichier(s) modifié(s)

- `main/aggregation-utils.js` — added `computeNumericStats()`
- `main/stats-helpers.js` — refactored `computeDuration()` and `perDay()`
- `src/utils/date-utils.js` — exported `formatTime`, updated comments
- `tests/main/aggregation-utils.test.js` — added `computeNumericStats` tests

## Vérifications

- [x] Build OK
- [x] Tests OK (330/330 passed)

---

📂 Path local : `/Users/rekta/projet/coding/refactor-pikagent`
🤖 PR créée automatiquement par l'Agent Refactor