### PR TITLE
refactor: replace ctx coupling with explicit interfaces in TabManager utils

### DIFF
--- a/src/components/tab-manager.js
+++ b/src/components/tab-manager.js
@@ -267,9 +267,24 @@ export class TabManager {
 
     this._tabElements = new Map();
 
+    /** @type {import('../utils/tab-renderer.js').TabElementDeps} */
+    const tabElementDeps = {
+      activeTabId: this.activeTabId,
+      tabs: this.tabs,
+      switchTo: (id) => this.switchTo(id),
+      closeTab: (id) => this.closeTab(id),
+      renameTab: (id, nameEl) => this.renameTab(id, nameEl),
+      setTabColorGroup: (id, cg) => this.setTabColorGroup(id, cg),
+      toggleNoShortcut: (id) => this.toggleNoShortcut(id),
+      dragDeps: {
+        getTabElements: () => this._tabElements,
+        reorderTab: (fromId, toId, before) => this.reorderTab(fromId, toId, before),
+      },
+    };
+
     for (const [id, tab] of this.tabs) {
       if (!this._isTabVisible(tab)) continue;
-      const tabEl = buildTabElement(this, id, tab);
+      const tabEl = buildTabElement(tabElementDeps, id, tab);
       this.tabBar.appendChild(tabEl);
       this._tabElements.set(id, tabEl);
     }

--- a/src/utils/tab-drag.js
+++ b/src/utils/tab-drag.js
@@ -3,20 +3,23 @@
  * component file focused on workspace orchestration.
  *
  * Exports a single factory that wires drag behaviour onto tab elements,
- * reading / writing shared state through a thin `ctx` interface.
+ * reading / writing shared state through an explicit dependency interface.
  *
- * ctx shape (provided by TabManager):
- *   _tabElements   : Map<tabId, HTMLElement>   — live tab DOM elements
- *   reorderTab(fromId, toId, before): void      — commit the reorder
+ * @typedef {Object} TabDragDeps
+ * @property {Function} getTabElements  - () => Map<tabId, HTMLElement> — live tab DOM elements
+ * @property {Function} reorderTab      - (fromId, toId, before) => void — commit the reorder
  */
 
 import { DRAG_THRESHOLD } from './tab-manager-helpers.js';
 
 // ── Internal helpers ────────────────────────────────────────────────
 
-/** Reset CSS transforms on every tab element. */
-function clearTabShifts(ctx) {
-  for (const [, el] of ctx._tabElements) {
+/**
+ * Reset CSS transforms on every tab element.
+ * @param {Function} getTabElements - () => Map<tabId, HTMLElement>
+ */
+function clearTabShifts(getTabElements) {
+  for (const [, el] of getTabElements()) {
     el.style.transform = '';
     el.style.transition = '';
   }
@@ -26,9 +29,13 @@ function clearTabShifts(ctx) {
  * Determine where the dragged tab should be inserted based on cursor
  * position relative to tab midpoints.
  *
+ * @param {Function} getTabElements - () => Map<tabId, HTMLElement>
+ * @param {number} mx
+ * @param {string[]} orderedIds
+ * @param {string} dragId
  * @returns {{ dropTargetId: string|null, dropBefore: boolean, insertIdx: number }}
  */
-function computeDropPosition(ctx, mx, orderedIds, dragId) {
+function computeDropPosition(getTabElements, mx, orderedIds, dragId) {
   let dropTargetId = null;
   let dropBefore = true;
   let insertIdx = -1;
@@ -36,7 +43,7 @@ function computeDropPosition(ctx, mx, orderedIds, dragId) {
   for (let i = 0; i < orderedIds.length; i++) {
     const id = orderedIds[i];
     if (id === dragId) continue;
-    const el = ctx._tabElements.get(id);
+    const el = getTabElements().get(id);
     const rect = el.getBoundingClientRect();
     const midX = rect.left + rect.width / 2;
 
@@ -64,12 +71,19 @@ function computeDropPosition(ctx, mx, orderedIds, dragId) {
 /**
  * Shift surrounding tabs with CSS transforms to open a visual gap at the
  * computed insertion position.
+ *
+ * @param {Function} getTabElements - () => Map<tabId, HTMLElement>
+ * @param {string[]} orderedIds
+ * @param {number} dragIdx
+ * @param {number} insertIdx
+ * @param {number} shiftAmount
+ * @param {string} dragId
  */
-function renderDropIndicator(ctx, orderedIds, dragIdx, insertIdx, shiftAmount, dragId) {
+function renderDropIndicator(getTabElements, orderedIds, dragIdx, insertIdx, shiftAmount, dragId) {
   for (let i = 0; i < orderedIds.length; i++) {
     const id = orderedIds[i];
     if (id === dragId) continue;
-    const el = ctx._tabElements.get(id);
+    const el = getTabElements().get(id);
     el.style.transition = 'transform 0.2s ease';
 
     if (dragIdx < insertIdx) {
@@ -87,19 +101,25 @@ function renderDropIndicator(ctx, orderedIds, dragIdx, insertIdx, shiftAmount, d
 /**
  * While dragging, determine which tab the cursor is over and shift
  * surrounding tabs to open a visual gap.
+ *
+ * @param {Function} getTabElements - () => Map<tabId, HTMLElement>
+ * @param {Object} state
+ * @param {number} mx
+ * @param {string} dragId
  */
-function updateTabDropTarget(ctx, state, mx, dragId) {
-  const orderedIds = Array.from(ctx._tabElements.keys());
-  const dragEl = ctx._tabElements.get(dragId);
+function updateTabDropTarget(getTabElements, state, mx, dragId) {
+  const tabElements = getTabElements();
+  const orderedIds = Array.from(tabElements.keys());
+  const dragEl = tabElements.get(dragId);
   const shiftAmount = dragEl ? dragEl.getBoundingClientRect().width : 0;
   const dragIdx = orderedIds.indexOf(dragId);
 
-  const { dropTargetId, dropBefore, insertIdx } = computeDropPosition(ctx, mx, orderedIds, dragId);
+  const { dropTargetId, dropBefore, insertIdx } = computeDropPosition(getTabElements, mx, orderedIds, dragId);
 
   state.dropTargetId = dropTargetId;
   state.dropBefore = dropBefore;
 
-  renderDropIndicator(ctx, orderedIds, dragIdx, insertIdx, shiftAmount, dragId);
+  renderDropIndicator(getTabElements, orderedIds, dragIdx, insertIdx, shiftAmount, dragId);
 }
 
 /** Create initial per-drag transient state. */
@@ -134,16 +154,22 @@ function handleDragStart(tabEl) {
 /**
  * Clean up after a drag operation: remove visual effects, commit the
  * reorder if the tab was dropped on a valid target, and reset state.
+ *
+ * @param {TabDragDeps} deps
+ * @param {HTMLElement} tabEl
+ * @param {HTMLElement|null} ghost
+ * @param {Object} state
+ * @param {string} tabId
  */
-function handleDragEnd(ctx, tabEl, ghost, state, tabId) {
+function handleDragEnd({ getTabElements, reorderTab }, tabEl, ghost, state, tabId) {
   tabEl.classList.remove('tab-dragging');
   document.body.style.cursor = '';
   document.body.style.userSelect = '';
   if (ghost) { ghost.remove(); }
-  clearTabShifts(ctx);
+  clearTabShifts(getTabElements);
 
   if (state.dropTargetId && state.dropTargetId !== tabId) {
-    ctx.reorderTab(tabId, state.dropTargetId, state.dropBefore);
+    reorderTab(tabId, state.dropTargetId, state.dropBefore);
   }
   state.dropTargetId = null;
   state.dropBefore = null;
@@ -154,11 +180,11 @@ function handleDragEnd(ctx, tabEl, ghost, state, tabId) {
 /**
  * Wire drag-to-reorder behaviour on a single tab element.
  *
- * @param {object} ctx       — TabManager instance (provides _tabElements & reorderTab)
+ * @param {TabDragDeps} deps  — explicit dependency interface
  * @param {HTMLElement} tabEl — the tab DOM element
  * @param {string} tabId     — the tab's unique id
  */
-export function setupTabDrag(ctx, tabEl, tabId) {
+export function setupTabDrag({ getTabElements, reorderTab }, tabEl, tabId) {
   let startX = 0;
   let dragging = false;
   let ghost = null;
@@ -180,7 +206,7 @@ export function setupTabDrag(ctx, tabEl, tabId) {
       }
       if (dragging && ghost) {
         ghost.style.left = `${ev.clientX - offsetX}px`;
-        updateTabDropTarget(ctx, state, ev.clientX, tabId);
+        updateTabDropTarget(getTabElements, state, ev.clientX, tabId);
       }
     };
 
@@ -189,7 +215,7 @@ export function setupTabDrag(ctx, tabEl, tabId) {
       document.removeEventListener('mouseup', onMouseUp);
 
       if (dragging) {
-        handleDragEnd(ctx, tabEl, ghost, state, tabId);
+        handleDragEnd({ getTabElements, reorderTab }, tabEl, ghost, state, tabId);
         ghost = null;
       }
     };

--- a/src/utils/tab-renderer.js
+++ b/src/utils/tab-renderer.js
@@ -1,6 +1,19 @@
 /**
  * Tab element rendering helpers.
  * Extracted from tab-manager.js to reduce component size.
+ *
+ * Functions receive explicit dependency objects instead of the full
+ * TabManager instance.
+ *
+ * @typedef {Object} TabElementDeps
+ * @property {string|null} activeTabId            - Currently active tab id
+ * @property {Map<string, Object>} tabs           - Tab map (used for .size)
+ * @property {Function} switchTo                  - (id) => void
+ * @property {Function} closeTab                  - (id) => void
+ * @property {Function} renameTab                 - (id, nameEl) => void
+ * @property {Function} setTabColorGroup          - (id, colorGroupId) => void
+ * @property {Function} toggleNoShortcut          - (id) => void
+ * @property {import('./tab-drag.js').TabDragDeps} dragDeps - Dependencies for tab drag
  */
 import { _el, setupInlineInput } from './dom.js';
 import { COLOR_GROUPS } from './tab-manager-helpers.js';
@@ -9,14 +22,14 @@ import { attachContextMenu } from './context-menu.js';
 
 /**
  * Build a single tab DOM element.
- * @param {Object} ctx - { tabs, activeTabId, switchTo, closeTab, renameTab }
+ * @param {TabElementDeps} deps
  * @param {string} id
  * @param {Object} tab
  */
-export function buildTabElement(ctx, id, tab) {
+export function buildTabElement(deps, id, tab) {
   const tabEl = _el('div', 'tab');
   tabEl.dataset.tabId = id;
-  if (id === ctx.activeTabId) tabEl.classList.add('active');
+  if (id === deps.activeTabId) tabEl.classList.add('active');
   if (tab.noShortcut) tabEl.classList.add('tab-no-shortcut');
 
   if (tab.colorGroup) {
@@ -25,53 +38,58 @@ export function buildTabElement(ctx, id, tab) {
       const dot = _el('span', 'tab-color-dot');
       dot.style.background = cg.color;
       tabEl.appendChild(dot);
-      tabEl.style.borderBottomColor = id === ctx.activeTabId ? cg.color : '';
+      tabEl.style.borderBottomColor = id === deps.activeTabId ? cg.color : '';
     }
   }
 
   const nameEl = _el('span', 'tab-name', tab.name);
-  nameEl.addEventListener('dblclick', () => ctx.renameTab(id, nameEl));
+  nameEl.addEventListener('dblclick', () => deps.renameTab(id, nameEl));
   tabEl.appendChild(nameEl);
 
-  if (ctx.tabs.size > 1) {
+  if (deps.tabs.size > 1) {
     const closeEl = _el('span', 'tab-close', '\u00d7');
     closeEl.addEventListener('click', (e) => {
       e.stopPropagation();
-      ctx.closeTab(id);
+      deps.closeTab(id);
     });
     tabEl.appendChild(closeEl);
   }
 
-  tabEl.addEventListener('click', () => ctx.switchTo(id));
-  setupTabDrag(ctx, tabEl, id);
-  bindTabContextMenu(ctx, tabEl, id, tab, nameEl);
+  tabEl.addEventListener('click', () => deps.switchTo(id));
+  setupTabDrag(deps.dragDeps, tabEl, id);
+  bindTabContextMenu(deps, tabEl, id, tab, nameEl);
 
   return tabEl;
 }
 
 /**
  * Bind context menu to a tab element.
+ * @param {TabElementDeps} deps
+ * @param {HTMLElement} tabEl
+ * @param {string} id
+ * @param {Object} tab
+ * @param {HTMLElement} nameEl
  */
-export function bindTabContextMenu(ctx, tabEl, id, tab, nameEl) {
+export function bindTabContextMenu(deps, tabEl, id, tab, nameEl) {
   attachContextMenu(tabEl, () => {
     const colorItems = COLOR_GROUPS.map((cg) => ({
       label: `${tab.colorGroup === cg.id ? '\u2713 ' : ''}${cg.label}`,
       colorDot: cg.color,
-      action: () => ctx.setTabColorGroup(id, tab.colorGroup === cg.id ? null : cg.id),
+      action: () => deps.setTabColorGroup(id, tab.colorGroup === cg.id ? null : cg.id),
     }));
     if (tab.colorGroup) {
-      colorItems.push({ label: 'Remove color', action: () => ctx.setTabColorGroup(id, null) });
+      colorItems.push({ label: 'Remove color', action: () => deps.setTabColorGroup(id, null) });
     }
     return [
-      { label: 'Rename', action: () => ctx.renameTab(id, nameEl) },
+      { label: 'Rename', action: () => deps.renameTab(id, nameEl) },
       {
         label: tab.noShortcut ? '\u2713 NoShortcut' : 'NoShortcut',
-        action: () => ctx.toggleNoShortcut(id),
+        action: () => deps.toggleNoShortcut(id),
       },
       { separator: true },
       { label: 'Color Group', children: colorItems },
       { separator: true },
-      { label: 'Close', action: () => ctx.closeTab(id) },
+      { label: 'Close', action: () => deps.closeTab(id) },
     ];
   });
 }


### PR DESCRIPTION
## Summary

- Replace implicit `ctx` (full TabManager instance) with explicit, minimal dependency interfaces in `tab-renderer.js` and `tab-drag.js`
- Each function now receives only the properties it actually needs, documented via JSDoc `@typedef` blocks
- TabManager builds explicit context objects in `renderTabBar()` instead of passing `this`

This completes the elimination of `ctx` coupling across all TabManager utility modules. The three files originally listed in the issue (`tab-lifecycle.js`, `workspace-layout.js`, `sidebar-manager.js`) were already refactored in prior PRs (#69, #81). This PR addresses the remaining two files (`tab-renderer.js`, `tab-drag.js`) that still used the pattern.

Closes #47

## Files changed

- `src/components/tab-manager.js` — caller builds explicit deps object
- `src/utils/tab-renderer.js` — `buildTabElement` / `bindTabContextMenu` receive `TabElementDeps`
- `src/utils/tab-drag.js` — `setupTabDrag` and internals receive `TabDragDeps`

## Test plan

- [x] Build OK (`npm run build`)
- [x] Tests OK (326/326 passing via `npm test`)
- [x] Zero remaining `function fn(ctx, ...)` patterns in `src/`

---

PR created automatically by the Refactor Agent