### PR TITLE
refactor: decouple component-to-component imports via registry

### DIFF
--- a/src/components/config-manager.js
+++ b/src/components/config-manager.js
@@ -7,6 +7,7 @@ import {
   configLabel,
   suggestedDuplicateName,
 } from '../utils/config-manager-helpers.js';
+import { registerComponent } from '../utils/component-registry.js';
 
 export class ConfigManager {
   constructor(tabManager) {
@@ -124,3 +125,5 @@ export class ConfigManager {
     if (name) callback(name);
   }
 }
+
+registerComponent('ConfigManager', ConfigManager);

--- a/src/components/file-viewer-webview.js
+++ b/src/components/file-viewer-webview.js
@@ -7,6 +7,7 @@ import { generateId } from '../utils/id.js';
 import { bus } from '../utils/events.js';
 import { parseWebviewUrl } from '../utils/editor-helpers.js';
 import { WebviewInstance } from './webview-panel.js';
+import { registerComponent } from '../utils/component-registry.js';
 
 export class WebviewManager {
   /**
@@ -129,3 +130,5 @@ export class WebviewManager {
     this._webviewEls.clear();
   }
 }
+
+registerComponent('WebviewManager', WebviewManager);

--- a/src/components/file-viewer.js
+++ b/src/components/file-viewer.js
@@ -1,12 +1,10 @@
 import { detectLanguage } from '../utils/file-icons.js';
 import { bus, subscribeBus, unsubscribeBus } from '../utils/events.js';
-import { GitChangesView } from './git-changes-view.js';
 import { _el } from '../utils/dom.js';
 import { EMPTY_MESSAGE, STATIC_MODES, MODE_CONFIG, ALL_STATIC_ELEMENTS, MODE_ACTIVATE, pinnedFiles } from '../utils/editor-helpers.js';
 import { createEditorDOM, bindEditorEvents, updateLineNumbers, updateHighlight, updateStatusBar, saveFile } from '../utils/file-editor-renderer.js';
 import { renderTabs as renderTabsHelper } from '../utils/file-viewer-tabs.js';
-import { registerComponent } from '../utils/component-registry.js';
-import { WebviewManager } from './file-viewer-webview.js';
+import { registerComponent, getComponent } from '../utils/component-registry.js';
 
 export class FileViewer {
   constructor(container, isActive) {
@@ -20,6 +18,7 @@ export class FileViewer {
     this.mode = 'files'; // 'files' | 'git' | webview id
     this.gitChanges = null;
     this.render();
+    const WebviewManager = getComponent('WebviewManager');
     this._webviewMgr = new WebviewManager(
       this.container, this.statusBar,
       (mode) => this.switchMode(mode),
@@ -51,6 +50,7 @@ export class FileViewer {
     this.gitViewEl = _el('div', 'git-changes-view');
     this.gitViewEl.style.display = 'none';
     this.container.appendChild(this.gitViewEl);
+    const GitChangesView = getComponent('GitChangesView');
     this.gitChanges = new GitChangesView(this.gitViewEl);
 
     this.statusBar = _el('div', 'editor-status-bar');

--- a/src/components/flow-card-terminal.js
+++ b/src/components/flow-card-terminal.js
@@ -9,6 +9,7 @@ import {
   STATUS_LABELS, NO_LOG_MESSAGE, NO_LOG_MODAL_MESSAGE,
   formatRunDateTime,
 } from '../utils/flow-view-helpers.js';
+import { registerComponent } from '../utils/component-registry.js';
 
 export class FlowCardTerminalManager {
   constructor() {
@@ -129,3 +130,5 @@ export class FlowCardTerminalManager {
     disposeTerminalMap(this._logTerminals);
   }
 }
+
+registerComponent('FlowCardTerminalManager', FlowCardTerminalManager);

--- a/src/components/flow-modal.js
+++ b/src/components/flow-modal.js
@@ -8,6 +8,7 @@ import {
   AGENT_OPTIONS, DEFAULT_CWD_LABEL, SKIP_PERM_CONFIG,
   _vis, _createSelect, _createChip, _updateScheduleVis,
 } from '../utils/flow-modal-helpers.js';
+import { registerComponent } from '../utils/component-registry.js';
 
 // --- Section builders ---
 
@@ -253,3 +254,5 @@ export function openFlowModal(existing = null, categories = []) {
     fields.nameInput.focus();
   });
 }
+
+registerComponent('openFlowModal', openFlowModal);

--- a/src/components/flow-view.js
+++ b/src/components/flow-view.js
@@ -1,14 +1,12 @@
-import { openFlowModal } from './flow-modal.js';
 import { _el, showPromptDialog, setupInlineInput } from '../utils/dom.js';
 import { generateId } from '../utils/id.js';
-import { registerComponent } from '../utils/component-registry.js';
+import { registerComponent, getComponent } from '../utils/component-registry.js';
 import {
   EMPTY_LIST_MESSAGE, UNCATEGORIZED, HEADER_BUTTONS,
   getFlowsForCategory, getUncategorizedFlows,
   removeFlowFromOrder, moveFlowInOrder, deleteCategoryData,
 } from '../utils/flow-view-helpers.js';
 import { createCardHeader } from '../utils/flow-card-renderer.js';
-import { FlowCardTerminalManager } from './flow-card-terminal.js';
 import { createCategoryGroup } from '../utils/flow-category-renderer.js';
 import { setupCardDrag, buildCardBody, setupCardHeaderClick } from '../utils/flow-card-setup.js';
 
@@ -20,6 +18,7 @@ export class FlowView {
     this.flows = [];
     this.catData = { categories: [], order: {} };
     this.disposed = false;
+    const FlowCardTerminalManager = getComponent('FlowCardTerminalManager');
     this._termManager = new FlowCardTerminalManager();
     this._expandedCards = new Set();
     this._collapsedCategories = new Set();
@@ -267,6 +266,7 @@ export class FlowView {
   // ===== Creation / Edit Modal =====
 
   async _openModal(existing = null) {
+    const openFlowModal = getComponent('openFlowModal');
     const flow = await openFlowModal(existing, this.catData.categories);
     if (flow) {
       const catId = flow._category;

--- a/src/components/git-changes-view.js
+++ b/src/components/git-changes-view.js
@@ -2,6 +2,7 @@ import { bus } from '../utils/events.js';
 import { DiffViewer } from './diff-viewer.js';
 import { _el } from '../utils/dom.js';
 import { STATUS_LABELS, CHEVRON, CHANGE_SECTIONS, computeTotalChanges, buildFileKey } from '../utils/git-changes-helpers.js';
+import { registerComponent } from '../utils/component-registry.js';
 
 export class GitChangesView {
   constructor(container) {
@@ -121,3 +122,5 @@ export class GitChangesView {
     new DiffViewer(container, diff, filePath);
   }
 }
+
+registerComponent('GitChangesView', GitChangesView);

--- a/src/components/settings-appearance.js
+++ b/src/components/settings-appearance.js
@@ -7,6 +7,7 @@ import { getAppTheme, setAppTheme } from '../utils/app-theme.js';
 import { _el, createButton } from '../utils/dom.js';
 import { MODE_BUTTONS, THEME_PREVIEW_LINES, COLOR_DOT_KEYS } from '../utils/settings-helpers.js';
 import { createSettingsSection } from '../utils/settings-section-builder.js';
+import { registerComponent } from '../utils/component-registry.js';
 
 /**
  * Apply the current terminal theme to all terminal panels across tabs.
@@ -107,3 +108,5 @@ export function renderAppearance(contentEl, tabManager, renderAppearanceFn) {
     content: [modeRow, subHeading, grid],
   });
 }
+
+registerComponent('renderAppearance', renderAppearance);

--- a/src/components/settings-configs.js
+++ b/src/components/settings-configs.js
@@ -5,6 +5,7 @@
 import { _el } from '../utils/dom.js';
 import { CONFIG_ACTIONS, BOTTOM_CONFIG_BUTTONS, formatConfigMeta, buildActionBtn } from '../utils/settings-helpers.js';
 import { createSettingsSection } from '../utils/settings-section-builder.js';
+import { registerComponent } from '../utils/component-registry.js';
 
 function _createConfigActions(config, tabManager, renderConfigsFn) {
   const handlers = {
@@ -110,3 +111,5 @@ export async function renderConfigs(contentEl, tabManager, renderConfigsFn) {
     content: [currentBar, list, _createBottomActions(currentName, tabManager, renderConfigsFn)],
   });
 }
+
+registerComponent('renderConfigs', renderConfigs);

--- a/src/components/settings-keybindings.js
+++ b/src/components/settings-keybindings.js
@@ -5,6 +5,7 @@
 import { formatCombo } from '../utils/shortcut-helpers.js';
 import { _el, createButton } from '../utils/dom.js';
 import { createSettingsSection } from '../utils/settings-section-builder.js';
+import { registerComponent } from '../utils/component-registry.js';
 
 /**
  * Create a key badge element for a binding at a given index.
@@ -92,3 +93,5 @@ export function renderKeybindings(contentEl, shortcutManager, startRecordingFn, 
     content: [list],
   });
 }
+
+registerComponent('renderKeybindings', renderKeybindings);

--- a/src/components/settings-modal.js
+++ b/src/components/settings-modal.js
@@ -1,9 +1,7 @@
 import { formatCombo, eventToCombo } from '../utils/shortcut-helpers.js';
 import { _el, createButton, createModalOverlay } from '../utils/dom.js';
 import { MODAL_CLOSE_TRANSITION_MS, MODIFIER_KEYS, NAV_SECTIONS } from '../utils/settings-helpers.js';
-import { renderAppearance } from './settings-appearance.js';
-import { renderKeybindings } from './settings-keybindings.js';
-import { renderConfigs } from './settings-configs.js';
+import { getComponent } from '../utils/component-registry.js';
 
 export class SettingsModal {
   constructor(shortcutManager) {
@@ -93,7 +91,7 @@ export class SettingsModal {
   // ===== Delegated section renderers =====
 
   _renderAppearance() {
-    renderAppearance(
+    getComponent('renderAppearance')(
       this.content,
       this.tabManager,
       () => this._renderAppearance(),
@@ -101,7 +99,7 @@ export class SettingsModal {
   }
 
   _renderKeybindings() {
-    renderKeybindings(
+    getComponent('renderKeybindings')(
       this.content,
       this.shortcutManager,
       (actionId, index, badgeEl) => this.startRecording(actionId, index, badgeEl),
@@ -110,7 +108,7 @@ export class SettingsModal {
   }
 
   _renderConfigs() {
-    renderConfigs(
+    getComponent('renderConfigs')(
       this.content,
       this.tabManager,
       () => this._renderConfigs(),

--- a/src/components/tab-manager.js
+++ b/src/components/tab-manager.js
@@ -1,5 +1,5 @@
 import { bus, subscribeBus, unsubscribeBus } from '../utils/events.js';
-import { ConfigManager } from './config-manager.js';
+import { getComponent } from '../utils/component-registry.js';
 import { extractFolderName } from '../utils/file-tree-helpers.js';
 import {
   reorderEntries, findCycleTarget, findColorGroupTarget,
@@ -32,6 +32,7 @@ export class TabManager {
     this.activeTabId = null;
     this.defaultCwd = null;
     this.onOpenSettings = null;
+    const ConfigManager = getComponent('ConfigManager');
     this.configManager = new ConfigManager(this);
     this.boardView = null;
     this._boardContainerEl = null;

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -4,13 +4,22 @@ import { ShortcutManager } from './components/shortcuts.js';
 import { SettingsModal } from './components/settings-modal.js';
 import { applyAppTheme } from './utils/app-theme.js';
 
-// Side-effect imports: register tab components in the component registry
+// Side-effect imports: register components in the component registry.
+// Sub-components must be registered before their parents resolve them.
+import './components/config-manager.js';
 import './components/terminal-panel.js';
 import './components/file-tree.js';
+import './components/git-changes-view.js';
+import './components/file-viewer-webview.js';
 import './components/file-viewer.js';
 import './components/board-view.js';
+import './components/flow-card-terminal.js';
+import './components/flow-modal.js';
 import './components/flow-view.js';
 import './components/usage-view.js';
+import './components/settings-appearance.js';
+import './components/settings-keybindings.js';
+import './components/settings-configs.js';
 
 // Expose hljs globally for file-viewer
 window.hljs = hljs;


### PR DESCRIPTION
## Refactoring

Decouple direct imports between sibling components using the component registry:
- `tab-manager.js` no longer imports `config-manager.js` directly
- `file-viewer.js` resolves sub-components via registry
- `flow-view.js` resolves sub-components via registry
- `settings-modal.js` resolves settings sections via registry

Components are now loosely coupled and independently testable.

Closes #84

## Fichier(s) modifié(s)

- `src/components/tab-manager.js`
- `src/components/file-viewer.js`
- `src/components/flow-view.js`
- `src/components/settings-modal.js`
- `src/components/config-manager.js`
- `src/components/file-viewer-webview.js`
- `src/components/git-changes-view.js`
- `src/components/flow-card-terminal.js`
- `src/components/flow-modal.js`
- `src/components/settings-appearance.js`
- `src/components/settings-keybindings.js`
- `src/components/settings-configs.js`
- `src/renderer.js`

## Vérifications

- [x] Build OK
- [x] Tests OK (326/326 passing)

---

📂 Path local : `/Users/rekta/projet/coding/refactor-pikagent`
🤖 PR créée automatiquement par l'Agent Refactor