### PR TITLE
refactor: resolve circular dependency workspace-layout ↔ workspace-serializer

### DIFF
--- a/src/components/tab-manager.js
+++ b/src/components/tab-manager.js
@@ -14,9 +14,11 @@ import {
 } from '../utils/sidebar-manager.js';
 import {
   renderWorkspace as doRenderWorkspace, reattachLayout,
-  serialize as doSerialize, restoreConfig as doRestoreConfig,
   capturePanelWidths, disposeAllTabs,
 } from '../utils/workspace-layout.js';
+import {
+  serialize as doSerialize, restoreConfig as doRestoreConfig,
+} from '../utils/workspace-serializer.js';
 import {
   createTab as doCreateTab, closeTab as doCloseTab,
   switchTo as doSwitchTo, findTabForTerminal,

--- a/src/utils/workspace-layout.js
+++ b/src/utils/workspace-layout.js
@@ -32,9 +32,6 @@ export {
   capturePanelWidths, restorePanelSizes,
 } from './workspace-resize.js';
 
-// Re-export from workspace-serializer.js for backward compatibility
-export { serialize, restoreConfig } from './workspace-serializer.js';
-
 // ── Workspace rendering ──
 
 /**


### PR DESCRIPTION
## Refactoring

Resolve the circular dependency between `workspace-layout.js` and `workspace-serializer.js` by removing backward-compat re-exports and updating imports to point directly to `workspace-serializer.js`.

Closes #94

## Fichier(s) modifié(s)

- `src/utils/workspace-layout.js` — removed re-export of `serialize` and `restoreConfig` from `workspace-serializer.js`
- `src/components/tab-manager.js` — updated imports of `serialize` and `restoreConfig` to come from `workspace-serializer.js` directly

## Vérifications

- [x] Build OK
- [x] Tests OK (316/316 passing)

---

📂 Path local : `/Users/rekta/projet/coding/refactor-pikagent`
🤖 PR créée automatiquement par l'Agent Refactor