### PR TITLE
refactor: remove dead exports from preload-helpers and managers

### DIFF
--- a/main/ipc-helpers.js
+++ b/main/ipc-helpers.js
@@ -14,6 +14,7 @@ function safeSend(getWindow, channel, payload) {
 }
 
 /**
+ * @internal Exported for testing only — production code uses registerManagerHandlers().
  * Derive FORWARD_TABLE and SPREAD_TABLE from API_SCHEMA.
  *
  * FORWARD_TABLE entries: [channel, domain]
@@ -42,6 +43,7 @@ function buildTablesFromSchema(schema) {
 const { forward: FORWARD_TABLE, spread: SPREAD_TABLE } = buildTablesFromSchema(API_SCHEMA);
 
 /**
+ * @internal Exported for testing only — production code uses registerManagerHandlers().
  * Register forward-style handlers on ipcMain for a given target.
  * @param {object} ipc - Electron ipcMain
  * @param {object} target - The object whose methods will be called
@@ -54,6 +56,7 @@ function registerForward(ipc, target, entries) {
 }
 
 /**
+ * @internal Exported for testing only — production code uses registerManagerHandlers().
  * Register spread-style handlers on ipcMain for a given target.
  * @param {object} ipc - Electron ipcMain
  * @param {object} target - The object whose methods will be called


### PR DESCRIPTION
## Refactoring

Confirms and finalizes the removal of unused exports from preload-helpers.js, ipc-helpers.js, fs-manager.js, session-helpers.js, and fs-manager-helpers.js as described in #60.

**Verification results** — all 5 dead exports from the issue are already absent from `module.exports`:

| File | Dead export | Status |
|---|---|---|
| `preload-helpers.js` | `_onIpc`, `_fwd`, `_pack` | Already local-only (not exported) |
| `main/ipc-helpers.js` | `FORWARD_TABLE`, `SPREAD_TABLE` | Already local-only (not exported) |
| `main/fs-manager.js` | `unwatchAll` | Already local-only (not exported) |
| `main/session-helpers.js` | `MAX_SESSIONS` | Already local-only (not exported) |
| `main/fs-manager-helpers.js` | `safeAsync` | Already local-only (not exported) |

**Additional cleanup:** Added `@internal` JSDoc annotations to three remaining test-only exports in `ipc-helpers.js` (`buildTablesFromSchema`, `registerForward`, `registerSpread`) — these are exported solely for test coverage while production code uses `registerManagerHandlers()`.

Closes #60

## Fichier(s) modifie(s)

- `main/ipc-helpers.js` — added `@internal` annotations to test-only exports

## Verifications

- [x] Build OK
- [x] Tests OK (21 files, 316 tests)

---

📂 Path local : `/Users/rekta/projet/coding/refactor-pikagent`
🤖 PR créée automatiquement par l'Agent Refactor