### PR TITLE
refactor: deduplicate aggregation and date formatting utilities

### DIFF
--- a/main/date-utils.js
+++ b/main/date-utils.js
@@ -1,10 +1,15 @@
 /**
- * Shared date/time utilities used across main and renderer modules.
+ * Date/time utilities for the main process.
  * Pure functions — no side effects.
+ *
+ * Generic formatting (formatTime, formatDateTime) lives in shared/date-utils.js
+ * and is re-exported here for backward compatibility.
+ * Domain-specific helpers (extractDateString, generateDateRange) stay here.
  */
 
+const { formatTime, formatDateTime } = require('../shared/date-utils');
+
 const DATE_LOCALE = 'fr-FR';
-const TIME_FORMAT = { hour: '2-digit', minute: '2-digit' };
 const DAY_LABEL_FORMAT = { day: '2-digit', month: '2-digit' };
 
 /**
@@ -31,30 +36,6 @@ function generateDateRange(days = 30) {
       label: d.toLocaleDateString(DATE_LOCALE, DAY_LABEL_FORMAT),
     };
   });
-}
-
-/**
- * Format a timestamp into a short time string (e.g. "14:32").
- * Returns '' if timestamp is falsy.
- * @param {number|string|null} timestamp
- * @returns {string}
- */
-function formatTime(timestamp) {
-  return timestamp
-    ? new Date(timestamp).toLocaleTimeString(DATE_LOCALE, TIME_FORMAT)
-    : '';
-}
-
-/**
- * Build a "date time" label from a date string and optional timestamp.
- * e.g. "2025-03-29 14:32" or just "2025-03-29" if no timestamp.
- * @param {string} date - date string (e.g. "2025-03-29")
- * @param {number|string|null} timestamp
- * @returns {string}
- */
-function formatDateTime(date, timestamp) {
-  const time = formatTime(timestamp);
-  return `${date}${time ? ' ' + time : ''}`;
 }
 
 module.exports = { extractDateString, generateDateRange, formatTime, formatDateTime };

--- a/main/usage-helpers.js
+++ b/main/usage-helpers.js
@@ -3,18 +3,7 @@ const path = require('path');
 const { computeRate, computeDuration, perDay, DEFAULT_DAYS } = require('./stats-helpers');
 const { extractDateString } = require('./date-utils');
 const { groupBy, countBy } = require('./collection-helpers');
-
-/** @internal — moved from aggregation-utils (no longer exported there). */
-function aggregateByKey(items, keyFn, initFn, accFn) {
-  const result = {};
-  for (const item of items) {
-    const key = keyFn(item);
-    if (key == null) continue;
-    if (!result[key]) result[key] = initFn();
-    accFn(result[key], item);
-  }
-  return result;
-}
+const { aggregateByKey } = require('./aggregation-utils');
 
 // ===== Declarative configs =====
 

--- a/shared/date-utils.js
+++ b/shared/date-utils.js
@@ -1,0 +1,37 @@
+/**
+ * Shared date/time formatting utilities used by both main and renderer processes.
+ * CommonJS format so main/ can require() it directly;
+ * esbuild resolves it for the renderer bundle.
+ *
+ * Only generic formatting lives here — domain-specific date logic
+ * (extractDateString, generateDateRange) stays in main/date-utils.js.
+ */
+
+const DATE_LOCALE = 'fr-FR';
+const TIME_FORMAT = { hour: '2-digit', minute: '2-digit' };
+
+/**
+ * Format a timestamp into a short time string (e.g. "14:32").
+ * Returns '' if timestamp is falsy.
+ * @param {number|string|null} timestamp
+ * @returns {string}
+ */
+function formatTime(timestamp) {
+  return timestamp
+    ? new Date(timestamp).toLocaleTimeString(DATE_LOCALE, TIME_FORMAT)
+    : '';
+}
+
+/**
+ * Build a "date time" label from a date string and optional timestamp.
+ * e.g. "2025-03-29 14:32" or just "2025-03-29" if no timestamp.
+ * @param {string} date - date string (e.g. "2025-03-29")
+ * @param {number|string|null} timestamp
+ * @returns {string}
+ */
+function formatDateTime(date, timestamp) {
+  const time = formatTime(timestamp);
+  return `${date}${time ? ' ' + time : ''}`;
+}
+
+module.exports = { formatTime, formatDateTime };

--- a/src/utils/date-utils.js
+++ b/src/utils/date-utils.js
@@ -1,34 +1,9 @@
 /**
- * Centralized date/time utilities for the renderer process.
- * Parallel to main/date-utils.js — kept separate to avoid
- * cross-layer imports (renderer → main).
- * Pure functions — no side effects.
+ * Date/time utilities for the renderer process.
+ * Delegates to shared/date-utils.js to avoid duplicating formatting logic.
+ * esbuild resolves the CommonJS require for the renderer bundle.
  */
 
-const DATE_LOCALE = 'fr-FR';
-const TIME_FORMAT = { hour: '2-digit', minute: '2-digit' };
+const { formatTime, formatDateTime } = require('../../shared/date-utils');
 
-/**
- * Format a timestamp into a short time string (e.g. "14:32").
- * Returns '' if timestamp is falsy.
- * @param {number|string|null} timestamp
- * @returns {string}
- */
-/** @internal — used only by formatDateTime(); not part of the public API. */
-function formatTime(timestamp) {
-  return timestamp
-    ? new Date(timestamp).toLocaleTimeString(DATE_LOCALE, TIME_FORMAT)
-    : '';
-}
-
-/**
- * Build a "date time" label from a date string and optional timestamp.
- * e.g. "2025-03-29 14:32" or just "2025-03-29" if no timestamp.
- * @param {string} date - date string (e.g. "2025-03-29")
- * @param {number|string|null} timestamp
- * @returns {string}
- */
-export function formatDateTime(date, timestamp) {
-  const time = formatTime(timestamp);
-  return `${date}${time ? ' ' + time : ''}`;
-}
+export { formatTime, formatDateTime };


### PR DESCRIPTION
## Summary
- **Aggregation**: Removed duplicated `aggregateByKey()` from `main/usage-helpers.js` — now imports the existing implementation from `main/aggregation-utils.js` (~10 lines removed)
- **Date formatting**: Centralized `formatTime()` and `formatDateTime()` into a new `shared/date-utils.js` module. Both `main/date-utils.js` and `src/utils/date-utils.js` now delegate to this single implementation (~40 duplicated lines removed across 3 files)
- Domain-specific logic (`TOKEN_FIELD_MAP`, `STATUS_CATEGORIES`, `extractDateString`, `generateDateRange`) stays in existing modules
- All exports preserved for backward compatibility — no behavioral changes

Closes #59

## Test plan
- [x] `npm run build` passes
- [x] `npm test` passes (316 tests, 21 test files, 0 failures)
- [ ] Verify flow-view date formatting still works in the app
- [ ] Verify usage stats aggregation still displays correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)