### PR TITLE
refactor: centralize DOM builders, modals and keyboard handlers

### DIFF
--- a/src/components/flow-card-terminal.js
+++ b/src/components/flow-card-terminal.js
@@ -2,7 +2,7 @@
  * Terminal management for flow cards: live terminals, inline log terminals, and log modal.
  * Extracted from FlowView to reduce component size.
  */
-import { _el, _safeFit } from '../utils/dom.js';
+import { _el, _safeFit, createModalOverlay, setupKeyboardShortcuts } from '../utils/dom.js';
 import { createReadonlyTerminal, disposeTerminal, disposeTerminalMap } from '../utils/terminal-factory.js';
 import {
   FIT_DELAY_MS, LOG_SCROLLBACK, LIVE_SCROLLBACK,
@@ -95,11 +95,10 @@ export class FlowCardTerminalManager {
   async showRunLog(flow, run) {
     const log = await window.api.flow.getRunLog(flow.id, run.logTimestamp);
 
-    const overlay = _el('div', 'flow-modal-overlay');
-    const modal = _el('div', 'flow-log-modal');
+    const close = () => { resizeObs.disconnect(); term.dispose(); overlay.remove(); };
+    const { overlay, modal } = createModalOverlay('flow-modal-overlay', 'flow-log-modal', close);
     const termContainer = _el('div', 'flow-log-terminal');
     modal.append(this._buildLogModalHeader(flow, run), termContainer);
-    overlay.appendChild(modal);
     document.body.appendChild(overlay);
 
     const { term, resizeObs } = this._createReadonlyTerminal(termContainer, {
@@ -108,9 +107,8 @@ export class FlowCardTerminalManager {
 
     term.write(log || NO_LOG_MODAL_MESSAGE);
 
-    const close = () => { resizeObs.disconnect(); term.dispose(); overlay.remove(); };
     modal.querySelector('.flow-log-close').addEventListener('click', close);
-    overlay.addEventListener('click', (e) => { if (e.target === overlay) close(); });
+    setupKeyboardShortcuts(overlay, { onEscape: close });
   }
 
   // === Cleanup on render / refresh ===

--- a/src/components/settings-configs.js
+++ b/src/components/settings-configs.js
@@ -2,8 +2,8 @@
  * Workspace Configs section renderer for SettingsModal.
  * Extracted from settings-modal.js to reduce component size.
  */
-import { _el } from '../utils/dom.js';
-import { CONFIG_ACTIONS, BOTTOM_CONFIG_BUTTONS, formatConfigMeta, buildActionBtn } from '../utils/settings-helpers.js';
+import { _el, createButton } from '../utils/dom.js';
+import { CONFIG_ACTIONS, BOTTOM_CONFIG_BUTTONS, formatConfigMeta } from '../utils/settings-helpers.js';
 import { createSettingsSection } from '../utils/settings-section-builder.js';
 import { registerComponent } from '../utils/component-registry.js';
 
@@ -22,7 +22,7 @@ function _createConfigActions(config, tabManager, renderConfigsFn) {
   const actions = _el('div', 'config-actions');
   for (const desc of CONFIG_ACTIONS) {
     if (desc.hideWhen && config[desc.hideWhen]) continue;
-    actions.appendChild(buildActionBtn({ ...desc, onClick: handlers[desc.action] }));
+    actions.appendChild(createButton({ ...desc, className: desc.cls, onClick: handlers[desc.action] }));
   }
   return actions;
 }
@@ -80,7 +80,7 @@ function _createBottomActions(currentName, tabManager, renderConfigsFn) {
   };
   const container = _el('div', 'config-bottom-actions');
   for (const { label, action } of BOTTOM_CONFIG_BUTTONS) {
-    container.appendChild(buildActionBtn({ label, cls: 'config-bottom-btn', onClick: handlers[action] }));
+    container.appendChild(createButton({ label, className: 'config-bottom-btn', onClick: handlers[action] }));
   }
   return container;
 }

--- a/src/components/webview-panel.js
+++ b/src/components/webview-panel.js
@@ -1,4 +1,4 @@
-import { _el } from '../utils/dom.js';
+import { _el, setupKeyboardShortcuts } from '../utils/dom.js';
 import { trackMouse } from '../utils/drag-helpers.js';
 import {
   MAX_LOGS,
@@ -44,11 +44,11 @@ export class WebviewInstance {
     this.urlInput.type = 'text';
     this.urlInput.value = this.url;
     this.urlInput.spellcheck = false;
-    this.urlInput.addEventListener('keydown', (e) => {
-      if (e.key === 'Enter') {
+    setupKeyboardShortcuts(this.urlInput, {
+      onEnter: (e) => {
         e.preventDefault();
         this.navigate(this.urlInput.value.trim());
-      }
+      },
     });
 
     this._mobileBtn = _el('button', 'webview-nav-btn', { textContent: '\u{1F4F1}', title: 'Mobile view' });

--- a/src/utils/dom.js
+++ b/src/utils/dom.js
@@ -120,12 +120,45 @@ export function createModalOverlay(overlayClass, modalClass, onClose) {
 }
 
 /**
+ * High-level modal builder: creates overlay + modal with a title bar,
+ * content area, and optional close button. Appends to document.body.
+ *
+ * @param {{ title?: string, content?: Node|Node[], onClose: Function,
+ *           overlayClass?: string, modalClass?: string }} opts
+ * @returns {{ overlay: HTMLElement, modal: HTMLElement, body: HTMLElement, close: Function }}
+ */
+export function createCustomModal({ title, content, onClose, overlayClass = 'modal-overlay', modalClass = 'modal' } = {}) {
+  const close = () => { overlay.remove(); onClose?.(); };
+  const { overlay, modal } = createModalOverlay(overlayClass, modalClass, close);
+
+  if (title) {
+    const header = _el('div', `${modalClass}-header`,
+      _el('span', `${modalClass}-title`, title),
+      createButton({ label: '\u00D7', className: `${modalClass}-close-btn`, onClick: close }),
+    );
+    modal.appendChild(header);
+  }
+
+  const body = _el('div', `${modalClass}-body`);
+  if (content) {
+    const nodes = Array.isArray(content) ? content : [content];
+    for (const node of nodes) {
+      if (node) body.appendChild(node);
+    }
+  }
+  modal.appendChild(body);
+
+  setupKeyboardShortcuts(overlay, { onEscape: close });
+
+  return { overlay, modal, body, close };
+}
+
+/**
  * Show a prompt dialog for a single text value.
  * @returns {Promise<string|null>} trimmed value or null if cancelled
  */
 export function showPromptDialog({ title, placeholder = '', defaultValue = '', confirmLabel = 'Create', cancelLabel = 'Cancel' }) {
   return new Promise((resolve) => {
-    const overlay = _el('div', 'prompt-dialog-overlay');
     const close = (val) => { overlay.remove(); resolve(val); };
     const confirm = () => { const v = input.value.trim(); close(v || null); };
 
@@ -135,7 +168,9 @@ export function showPromptDialog({ title, placeholder = '', defaultValue = '', c
       onEscape: () => close(null),
     });
 
-    const box = _el('div', 'prompt-dialog-box',
+    const { overlay } = createModalOverlay('prompt-dialog-overlay', 'prompt-dialog-box', () => close(null));
+    const box = overlay.firstChild;
+    box.append(
       _el('label', 'prompt-dialog-label', title),
       input,
       _el('div', 'prompt-dialog-btns',
@@ -144,8 +179,6 @@ export function showPromptDialog({ title, placeholder = '', defaultValue = '', c
       ),
     );
 
-    overlay.addEventListener('click', (e) => { if (e.target === overlay) close(null); });
-    overlay.appendChild(box);
     document.body.appendChild(overlay);
     input.focus();
     if (defaultValue) input.select();
@@ -175,8 +208,10 @@ export function positionInViewport(x, y, width, height, padding = 8) {
  */
 export function showConfirmDialog(message, { confirmLabel = 'OK', cancelLabel = 'Cancel' } = {}) {
   return new Promise((resolve) => {
-    const overlay = _el('div', 'confirm-overlay');
-    const box = _el('div', 'confirm-box');
+    const cleanup = (result) => { overlay.remove(); resolve(result); };
+
+    const { overlay } = createModalOverlay('confirm-overlay', 'confirm-box', () => cleanup(false));
+    const box = overlay.firstChild;
 
     if (typeof message === 'string') box.appendChild(_el('p', null, message));
     else box.appendChild(message);
@@ -186,11 +221,13 @@ export function showConfirmDialog(message, { confirmLabel = 'OK', cancelLabel = 
       createButton({ label: confirmLabel, className: 'confirm-ok', onClick: () => cleanup(true) }),
     );
     box.appendChild(btnRow);
-    overlay.appendChild(box);
     document.body.appendChild(overlay);
 
-    const cleanup = (result) => { overlay.remove(); resolve(result); };
-    overlay.addEventListener('click', (e) => { if (e.target === overlay) cleanup(false); });
+    setupKeyboardShortcuts(overlay, {
+      onEscape: () => cleanup(false),
+      onEnter: () => cleanup(true),
+    });
+    overlay.setAttribute('tabindex', '-1');
     btnRow.querySelector('.confirm-ok').focus();
   });
 }

--- a/src/utils/settings-helpers.js
+++ b/src/utils/settings-helpers.js
@@ -2,9 +2,11 @@ import { createButton } from './dom.js';
 
 /**
  * Build a button element from a descriptor.
- * Thin wrapper around the centralized `createButton` factory.
+ * Delegates to the centralized `createButton` factory,
+ * mapping the `cls` field name to `className`.
  * @param {{ label: string, title?: string, cls?: string, onClick: Function }} desc
  * @returns {HTMLButtonElement}
+ * @deprecated Use `createButton` from `dom.js` directly with `className` instead of `cls`.
  */
 export function buildActionBtn({ label, title, cls, onClick }) {
   return createButton({ label, title, className: cls, onClick });


### PR DESCRIPTION
## Summary
- **DOM Builders**: Migrated `settings-configs.js` from the `buildActionBtn()` wrapper to using `createButton()` directly from `dom.js`; marked `buildActionBtn()` as `@deprecated`
- **Modal/Dialog creation**: Added `createCustomModal()` high-level builder in `dom.js`; refactored `showPromptDialog()`, `showConfirmDialog()`, and `flow-card-terminal.showRunLog()` to reuse `createModalOverlay()` instead of duplicating the overlay + click-outside-to-close pattern
- **Keyboard handlers**: Migrated `webview-panel.js` URL input and `flow-card-terminal.js` log modal to use `setupKeyboardShortcuts()`; added Enter/Escape support to `showConfirmDialog()`

## Test plan
- [x] `npm run build` passes
- [x] `npm test` — all 316 tests pass
- [ ] Manual: open settings > Workspace Configs, verify buttons still work
- [ ] Manual: open a flow log modal, verify click-outside and Escape close it
- [ ] Manual: open confirm/prompt dialogs, verify Escape/Enter work
- [ ] Manual: webview URL bar Enter to navigate still works

Closes #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)