### PR TITLE
docs: complete JSDoc typedefs for ctx-decoupled TabManager utils

### DIFF
--- a/src/utils/tab-lifecycle.js
+++ b/src/utils/tab-lifecycle.js
@@ -168,7 +168,7 @@ export function switchTo(deps, id) {
   _activateTab(deps, tab);
 }
 
-// ── Terminal CWD tracking (decoupled — no ctx dependency) ──
+// ── Terminal CWD tracking (decoupled — receives only data it needs) ──
 
 /**
  * Find which tab owns a given terminal id.

--- a/src/utils/workspace-layout.js
+++ b/src/utils/workspace-layout.js
@@ -109,6 +109,11 @@ export function reattachLayout({ workspaceContainer }, tab) {
   }
 }
 
+/**
+ * Synchronize a tab's file tree with its terminal panel, removing stale
+ * entries and updating roots for all active terminals.
+ * @param {import('./tab-manager-helpers.js').WorkspaceTab} tab
+ */
 export function syncFileTree(tab) {
   if (tab.fileTree && tab.terminalPanel) {
     // Remove stale entries (e.g. ghost terminal from TerminalPanel.init() before restoreFromTree)
@@ -126,6 +131,11 @@ export function syncFileTree(tab) {
 
 // ── Tab disposal ──
 
+/**
+ * Dispose a single tab — call dispose() on all disposable sub-components
+ * and remove the layout element from the DOM.
+ * @param {import('./tab-manager-helpers.js').WorkspaceTab} tab
+ */
 export function disposeTab(tab) {
   for (const key of TAB_DISPOSABLES) if (tab[key]) tab[key].dispose();
   if (tab.layoutElement) tab.layoutElement.remove();

--- a/src/utils/workspace-resize.js
+++ b/src/utils/workspace-resize.js
@@ -132,6 +132,10 @@ export function togglePanel({ getActiveTab, scheduleAutoSave }, panel, side, arr
 
 // ── Panel width capture / restore ──
 
+/**
+ * Snapshot current panel widths and collapsed state into `tab._panelWidths`.
+ * @param {import('./tab-manager-helpers.js').WorkspaceTab} tab
+ */
 export function capturePanelWidths(tab) {
   if (!tab.layoutElement) return;
   tab._panelWidths = {};
@@ -143,6 +147,11 @@ export function capturePanelWidths(tab) {
   }
 }
 
+/**
+ * Restore panel widths and collapsed state from a saved config.
+ * @param {Object} panels                      - Saved panel size data
+ * @param {{ left?: HTMLElement, right?: HTMLElement }} panelEls - Panel DOM elements
+ */
 export function restorePanelSizes(panels, panelEls) {
   if (!panels) return;
   for (const { widthKey, collapsedKey, side } of WORKSPACE_PANELS) {


### PR DESCRIPTION
## Summary

- Add missing `@param` JSDoc to `syncFileTree`, `disposeTab`, `capturePanelWidths`, and `restorePanelSizes` -- the last undocumented exported functions in the files listed in #47
- Update stale "no ctx dependency" comment in `tab-lifecycle.js` to remove the outdated `ctx` terminology

The core refactoring (replacing `ctx` parameter with explicit `deps` objects and JSDoc `@typedef` interfaces) was already completed in prior PRs (#69, #81). This PR fills in the remaining JSDoc gaps so every exported function in the three affected files has documented parameter types.

**Files touched:**
- `src/utils/tab-lifecycle.js` -- comment update only
- `src/utils/workspace-layout.js` -- added JSDoc for `syncFileTree`, `disposeTab`
- `src/utils/workspace-resize.js` -- added JSDoc for `capturePanelWidths`, `restorePanelSizes`

Closes #47

## Test plan

- [x] `npm run build` passes
- [x] `npm test` passes (21 files, 316 tests)
- [x] No runtime changes -- JSDoc and comment updates only

🤖 Generated with [Claude Code](https://claude.com/claude-code)