### PR TITLE
refactor: add typed EVENTS constants for event bus

### DIFF
--- a/src/components/file-viewer-webview.js
+++ b/src/components/file-viewer-webview.js
@@ -4,7 +4,7 @@
  */
 import { _el, setupInlineInput } from '../utils/dom.js';
 import { generateId } from '../utils/id.js';
-import { bus } from '../utils/events.js';
+import { bus, EVENTS } from '../utils/events.js';
 import { parseWebviewUrl } from '../utils/editor-helpers.js';
 import { registerComponent, getComponent } from '../utils/component-registry.js';
 
@@ -30,7 +30,7 @@ export class WebviewManager {
     this._createWebviewContainer(wt);
     this._switchMode(wt.id);
     /** @fires layout:changed {undefined} — webview added */
-    bus.emit('layout:changed');
+    bus.emit(EVENTS.LAYOUT_CHANGED);
   }
 
   removeWebview(webviewId) {
@@ -90,7 +90,7 @@ export class WebviewManager {
       if (currentMode === removedId) this._switchMode('files');
       else this._renderModeBar();
       /** @fires layout:changed {undefined} — webview removed */
-      bus.emit('layout:changed');
+      bus.emit(EVENTS.LAYOUT_CHANGED);
     });
     btn.appendChild(closeBtn);
     btn.addEventListener('click', () => this._switchMode(wt.id));

--- a/src/components/file-viewer.js
+++ b/src/components/file-viewer.js
@@ -1,5 +1,5 @@
 import { detectLanguage } from '../utils/file-icons.js';
-import { bus, subscribeBus, unsubscribeBus } from '../utils/events.js';
+import { bus, subscribeBus, unsubscribeBus, EVENTS } from '../utils/events.js';
 import { _el } from '../utils/dom.js';
 import { EMPTY_MESSAGE, STATIC_MODES, MODE_CONFIG, ALL_STATIC_ELEMENTS, MODE_ACTIVATE, pinnedFiles } from '../utils/editor-helpers.js';
 import { createEditorDOM, bindEditorEvents, updateLineNumbers, updateHighlight, updateStatusBar, saveFile } from '../utils/file-editor-renderer.js';
@@ -63,19 +63,19 @@ export class FileViewer {
     // Bus event listeners — single declaration drives both subscription and cleanup
     this._busListeners = subscribeBus([
       /** @listens file:open {{ path: string, name: string }} */
-      ['file:open', ({ path, name }) => {
+      [EVENTS.FILE_OPEN, ({ path, name }) => {
         if (!this.isActive()) return;
         this.switchMode('files');
         this.openFile(path, name);
       }],
       /** @listens terminal:cwdChanged {{ id: string, cwd: string }} */
-      ['terminal:cwdChanged', ({ cwd }) => {
+      [EVENTS.TERMINAL_CWD_CHANGED, ({ cwd }) => {
         if (!this.isActive()) return;
         this.gitChanges.setCwd(cwd);
         if (this.mode === 'git') this.gitChanges.loadChanges();
       }],
       /** @listens workspace:activated {undefined} */
-      ['workspace:activated', () => {
+      [EVENTS.WORKSPACE_ACTIVATED, () => {
         if (!this.isActive()) return;
         this.loadPinnedFiles();
       }],
@@ -276,7 +276,7 @@ export class FileViewer {
     if (this.mode === removedId) this.switchMode('files');
     else this._renderModeBar();
     /** @fires layout:changed {undefined} — webview removed from file-viewer */
-    bus.emit('layout:changed');
+    bus.emit(EVENTS.LAYOUT_CHANGED);
   }
 
   getWebviewTabs() {

--- a/src/components/git-changes-view.js
+++ b/src/components/git-changes-view.js
@@ -1,4 +1,4 @@
-import { bus } from '../utils/events.js';
+import { bus, EVENTS } from '../utils/events.js';
 import { _el } from '../utils/dom.js';
 import { STATUS_LABELS, CHEVRON, CHANGE_SECTIONS, computeTotalChanges, buildFileKey } from '../utils/git-changes-helpers.js';
 import { registerComponent, getComponent } from '../utils/component-registry.js';
@@ -81,7 +81,7 @@ export class GitChangesView {
       _el('span', { className: 'git-open-btn', textContent: '→', title: 'Open file', onClick: (e) => {
         e.stopPropagation();
         /** @fires file:open {{ path: string, name: string }} */
-        bus.emit('file:open', { path: `${this.gitCwd}/${file.path}`, name: file.path.split('/').pop() });
+        bus.emit(EVENTS.FILE_OPEN, { path: `${this.gitCwd}/${file.path}`, name: file.path.split('/').pop() });
       }}),
     );
 

--- a/src/components/terminal-panel.js
+++ b/src/components/terminal-panel.js
@@ -1,4 +1,4 @@
-import { bus } from '../utils/events.js';
+import { bus, EVENTS } from '../utils/events.js';
 import { _el } from '../utils/dom.js';
 import { trackMouse } from '../utils/drag-helpers.js';
 import {
@@ -189,7 +189,7 @@ export class TerminalPanel {
       trackMouse(RESIZE_CURSOR[direction],
         (ev) => doResize(ev, handle, splitEl, direction, () => this.fitAll()),
         /** @fires layout:changed {undefined} — resize complete */
-        () => bus.emit('layout:changed'),
+        () => bus.emit(EVENTS.LAYOUT_CHANGED),
       );
     });
   }
@@ -211,7 +211,7 @@ export class TerminalPanel {
     node.terminal.dispose();
     this.terminals.delete(termId);
     /** @fires terminal:removed {{ id: string }} */
-    bus.emit('terminal:removed', { id: termId });
+    bus.emit(EVENTS.TERMINAL_REMOVED, { id: termId });
 
     if (this.terminals.size === 0) {
       this.init();

--- a/src/utils/board-helpers.js
+++ b/src/utils/board-helpers.js
@@ -4,6 +4,7 @@
  */
 
 import { findTabForTerminal } from './tab-lifecycle.js';
+import { EVENTS } from './events.js';
 export { findTabForTerminal };
 
 // Minimum bytes of meaningful output per poll interval to consider agent "working".
@@ -23,9 +24,9 @@ export const STATUS_CONFIG = {
 /** All card-level CSS classes derived from STATUS_CONFIG — single source of truth for class removal. */
 export const ALL_CARD_CLASSES = Object.values(STATUS_CONFIG).map(c => c.cardClass);
 
-export const EVT_CREATED = 'terminal:created';
-export const EVT_REMOVED = 'terminal:removed';
-export const EVT_EXITED = 'terminal:exited';
+export const EVT_CREATED = EVENTS.TERMINAL_CREATED;
+export const EVT_REMOVED = EVENTS.TERMINAL_REMOVED;
+export const EVT_EXITED = EVENTS.TERMINAL_EXITED;
 
 /** Terminal options used by board card mini-terminals. */
 export const BOARD_TERMINAL_OPTS = {

--- a/src/utils/events.js
+++ b/src/utils/events.js
@@ -28,8 +28,35 @@
  *
  * @type {Record<string, EventDef>}
  */
-/** @internal — not exported; used only by emitEvent() for dev-time validation. */
-const EVENT_CATALOG = {
+/**
+ * Typed event-name constants.
+ *
+ * Import these instead of using raw strings so that the coupling between
+ * producers and consumers is explicit, traceable, and typo-proof.
+ *
+ * @readonly
+ * @enum {string}
+ */
+export const EVENTS = {
+  /** @see EVENT_CATALOG['terminal:cwdChanged'] */
+  TERMINAL_CWD_CHANGED: 'terminal:cwdChanged',
+  /** @see EVENT_CATALOG['terminal:created'] */
+  TERMINAL_CREATED: 'terminal:created',
+  /** @see EVENT_CATALOG['terminal:removed'] */
+  TERMINAL_REMOVED: 'terminal:removed',
+  /** @see EVENT_CATALOG['terminal:exited'] */
+  TERMINAL_EXITED: 'terminal:exited',
+  /** @see EVENT_CATALOG['layout:changed'] */
+  LAYOUT_CHANGED: 'layout:changed',
+  /** @see EVENT_CATALOG['workspace:activated'] */
+  WORKSPACE_ACTIVATED: 'workspace:activated',
+  /** @see EVENT_CATALOG['workspace:openFromFolder'] */
+  WORKSPACE_OPEN_FROM_FOLDER: 'workspace:openFromFolder',
+  /** @see EVENT_CATALOG['file:open'] */
+  FILE_OPEN: 'file:open',
+};
+
+export const EVENT_CATALOG = {
   // ── Terminal lifecycle events ──
 
   /**

--- a/src/utils/file-tree-context-menu.js
+++ b/src/utils/file-tree-context-menu.js
@@ -2,7 +2,7 @@
  * Context menu builders for the file tree.
  * Extracted from FileTree to reduce component size.
  */
-import { bus } from './events.js';
+import { bus, EVENTS } from './events.js';
 import { getRelativePath } from './file-tree-helpers.js';
 
 /**
@@ -71,7 +71,7 @@ export function buildDirContextItems(dirPath, rootCwd, contentEl, depth, expande
     { separator: true },
     { label: 'Open as Workspace', action: () => {
       /** @fires workspace:openFromFolder {{ cwd: string }} */
-      bus.emit('workspace:openFromFolder', { cwd: dirPath });
+      bus.emit(EVENTS.WORKSPACE_OPEN_FROM_FOLDER, { cwd: dirPath });
     } },
     { separator: true },
     ...buildCommonContextItems(dirPath, nameEl, rootCwd, promptRenameFn, `Delete folder "${dirName}" and all its contents?`, api),

--- a/src/utils/file-tree-drop.js
+++ b/src/utils/file-tree-drop.js
@@ -3,7 +3,7 @@
  * Extracted from file-tree.js to reduce component size.
  */
 
-import { bus } from './events.js';
+import { bus, EVENTS } from './events.js';
 import { _el, setupInlineInput } from './dom.js';
 import { INPUT_BLUR_DELAY, computeIndent } from './file-tree-helpers.js';
 
@@ -121,7 +121,7 @@ export function promptNewEntry(dirPath, parentContentEl, depth, expandedDirs, ty
       } else {
         await writefile(newPath, '');
         /** @fires file:open {{ path: string, name: string }} — newly created file */
-        bus.emit('file:open', { path: newPath, name });
+        bus.emit(EVENTS.FILE_OPEN, { path: newPath, name });
       }
     },
   });

--- a/src/utils/file-tree-renderer.js
+++ b/src/utils/file-tree-renderer.js
@@ -3,7 +3,7 @@
  * Extracted from file-tree.js to reduce component size.
  */
 
-import { bus } from './events.js';
+import { bus, EVENTS } from './events.js';
 import { _el } from './dom.js';
 import { computeIndent, CHEVRON_EXPANDED, CHEVRON_COLLAPSED, SVG_ICONS } from './file-tree-helpers.js';
 import { buildFileContextItems, buildDirContextItems } from './file-tree-context-menu.js';
@@ -119,7 +119,7 @@ export function renderFileEntry(entry, parentEl, depth, callbacks) {
     row.classList.add('active');
     activeRowRef.current = row;
     /** @fires file:open {{ path: string, name: string }} */
-    bus.emit('file:open', { path: entry.path, name: entry.name });
+    bus.emit(EVENTS.FILE_OPEN, { path: entry.path, name: entry.name });
   });
 
   attachContextMenu(row, () => buildFileContextItems(

--- a/src/utils/tab-lifecycle.js
+++ b/src/utils/tab-lifecycle.js
@@ -36,7 +36,7 @@
 
 import { generateId } from './id.js';
 import { showConfirmDialog, _el } from './dom.js';
-import { bus } from './events.js';
+import { bus, EVENTS } from './events.js';
 import { WorkspaceTab } from './tab-manager-helpers.js';
 import {
   reattachLayout, syncFileTree, capturePanelWidths, disposeTab,
@@ -126,7 +126,7 @@ function _activateTab(deps, tab) {
     reattachLayout({ workspaceContainer: deps.workspaceContainer }, tab);
     syncFileTree(tab);
     /** @emits workspace:activated {undefined} — tab switched */
-    bus.emit('workspace:activated');
+    bus.emit(EVENTS.WORKSPACE_ACTIVATED);
   } else {
     // First time rendering this tab
     deps.renderWorkspace(tab);

--- a/src/utils/tab-manager-init.js
+++ b/src/utils/tab-manager-init.js
@@ -4,7 +4,7 @@
  * Handles startup (default config restore) and bus event subscriptions.
  */
 
-import { subscribeBus } from './events.js';
+import { subscribeBus, EVENTS } from './events.js';
 import { extractFolderName } from './file-tree-helpers.js';
 import { findTabForTerminal, onTerminalCwdChanged } from './tab-lifecycle.js';
 
@@ -71,27 +71,27 @@ export async function initTabManager(deps) {
 export function setupBusListeners(deps) {
   return subscribeBus([
     /** @listens terminal:cwdChanged {{ id: string, cwd: string }} */
-    ['terminal:cwdChanged', ({ id, cwd }) => {
+    [EVENTS.TERMINAL_CWD_CHANGED, ({ id, cwd }) => {
       onTerminalCwdChanged(deps.tabs, deps.getActiveTabId(), id, cwd, { gitBranch: deps.api.gitBranch });
       deps.configManager.scheduleAutoSave();
     }],
     /** @listens terminal:created {{ id: string, cwd: string }} */
-    ['terminal:created', ({ id, cwd }) => {
+    [EVENTS.TERMINAL_CREATED, ({ id, cwd }) => {
       const tab = findTabForTerminal(deps.tabs, id)?.tab ?? deps.tabs.get(deps.getActiveTabId());
       if (tab?.fileTree) tab.fileTree.setTerminalRoot(id, cwd);
       deps.configManager.scheduleAutoSave();
     }],
     /** @listens terminal:removed {{ id: string }} */
-    ['terminal:removed', ({ id }) => {
+    [EVENTS.TERMINAL_REMOVED, ({ id }) => {
       for (const [, tab] of deps.tabs) {
         if (tab.fileTree) tab.fileTree.removeTerminal(id);
       }
       deps.configManager.scheduleAutoSave();
     }],
     /** @listens layout:changed {undefined} */
-    ['layout:changed', () => deps.configManager.scheduleAutoSave()],
+    [EVENTS.LAYOUT_CHANGED, () => deps.configManager.scheduleAutoSave()],
     /** @listens workspace:openFromFolder {{ cwd: string }} */
-    ['workspace:openFromFolder', ({ cwd }) => {
+    [EVENTS.WORKSPACE_OPEN_FROM_FOLDER, ({ cwd }) => {
       const folderName = extractFolderName(cwd);
       deps.createTab(folderName, cwd);
     }],

--- a/src/utils/terminal-instance.js
+++ b/src/utils/terminal-instance.js
@@ -1,6 +1,6 @@
 import { WebLinksAddon } from '@xterm/addon-web-links';
 import { generateId } from './id.js';
-import { bus } from './events.js';
+import { bus, EVENTS } from './events.js';
 import { FilePathLinkProvider } from './file-link-provider.js';
 import { createTerminal } from './terminal-factory.js';
 import { CWD_POLL_MS } from './terminal-panel-helpers.js';
@@ -56,7 +56,7 @@ export class TerminalInstance {
 
     this.unsubExit = this._api.ptyOnExit(this.id, () => {
       /** @fires terminal:exited {{ id: string }} — PTY process exited */
-      bus.emit('terminal:exited', { id: this.id });
+      bus.emit(EVENTS.TERMINAL_EXITED, { id: this.id });
     });
 
     this.resizeObserver = new ResizeObserver(() => this.fit());
@@ -79,7 +79,7 @@ export class TerminalInstance {
       if (cwd && cwd !== this.cwd) {
         this.cwd = cwd;
         /** @fires terminal:cwdChanged {{ id: string, cwd: string }} — cwd changed */
-        bus.emit('terminal:cwdChanged', { id: this.id, cwd });
+        bus.emit(EVENTS.TERMINAL_CWD_CHANGED, { id: this.id, cwd });
       }
     }, CWD_POLL_MS);
   }

--- a/src/utils/terminal-node-builder.js
+++ b/src/utils/terminal-node-builder.js
@@ -3,7 +3,7 @@
  * Extracted from terminal-panel.js to reduce component size.
  */
 
-import { bus } from './events.js';
+import { bus, EVENTS } from './events.js';
 import { _el } from './dom.js';
 import { SplitNode, DRAG_GRIP, createSplitContainer } from './terminal-panel-helpers.js';
 import { TerminalInstance } from './terminal-instance.js';
@@ -63,7 +63,7 @@ export function createTerminalNode(cwd, defaultCwd, terminals, { buildTopBar: bu
   terminals.set(node.terminal.id, node);
 
   /** @fires terminal:created {{ id: string, cwd: string }} */
-  bus.emit('terminal:created', { id: node.terminal.id, cwd: spawnCwd });
+  bus.emit(EVENTS.TERMINAL_CREATED, { id: node.terminal.id, cwd: spawnCwd });
 
   wrapper.addEventListener('mousedown', () => onMousedown(node));
 

--- a/src/utils/terminal-split.js
+++ b/src/utils/terminal-split.js
@@ -3,7 +3,7 @@
  * Extracted from terminal-panel.js to reduce component size.
  */
 
-import { bus } from './events.js';
+import { bus, EVENTS } from './events.js';
 import { SplitNode, isSameDirectionSplit, createSplitContainer, equalizeChildren } from './terminal-panel-helpers.js';
 import { directionFromSide, isInsertBefore, findClosestInDirection } from './split-primitives.js';
 import { detachElement, moveToCenter, insertIntoSplit, wrapInNewSplit } from './split-layout.js';
@@ -52,7 +52,7 @@ export function moveTerminal(sourceId, targetId, side, terminals, { createSplitH
   fitAll();
   setActive(sourceNode);
   /** @fires layout:changed {undefined} — split operation complete */
-  bus.emit('layout:changed');
+  bus.emit(EVENTS.LAYOUT_CHANGED);
 }
 
 /**

--- a/src/utils/workspace-layout.js
+++ b/src/utils/workspace-layout.js
@@ -17,7 +17,7 @@
  */
 
 import { getComponent } from './component-registry.js';
-import { bus } from './events.js';
+import { bus, EVENTS } from './events.js';
 import { _el } from './dom.js';
 import { WORKSPACE_PANELS, TAB_DISPOSABLES } from './tab-manager-helpers.js';
 import {
@@ -88,7 +88,7 @@ export async function renderWorkspace({ workspaceContainer, getActiveTabId, getA
   if (branch) tab.branchBadgeEl.textContent = ` ${branch}`;
 
   /** @fires workspace:activated {undefined} — initial workspace render complete */
-  bus.emit('workspace:activated');
+  bus.emit(EVENTS.WORKSPACE_ACTIVATED);
 }
 
 // ── Layout helpers ──


### PR DESCRIPTION
## Summary
- Added a centralized `EVENTS` enum in `src/utils/events.js` with typed constants for all 8 bus events
- Updated all 14 producer/consumer files to import `EVENTS.*` instead of using hardcoded string literals
- Updated `board-helpers.js` local constants (`EVT_CREATED`, `EVT_REMOVED`, `EVT_EXITED`) to derive from `EVENTS`

No behavior changes — event names, payloads, and the bus communication pattern are all preserved. This makes the implicit coupling explicit and traceable.

Closes #49

## Test plan
- [x] `npm run build` passes
- [x] All 316 tests pass (`npm test`)
- [ ] Verify grep for raw event strings finds zero results outside of `events.js` definitions
- [ ] Manual smoke test: open/close terminals, switch tabs, file tree open, git changes view

🤖 Generated with [Claude Code](https://claude.com/claude-code)