### PR TITLE
refactor: remove dead exports (EVENT_CATALOG, formatTime)

### DIFF
--- a/src/utils/date-utils.js
+++ b/src/utils/date-utils.js
@@ -4,6 +4,6 @@
  * esbuild resolves the CommonJS require for the renderer bundle.
  */
 
-const { formatTime, formatDateTime } = require('../../shared/date-utils');
+const { formatDateTime } = require('../../shared/date-utils');
 
-export { formatTime, formatDateTime };
+export { formatDateTime };

--- a/src/utils/events.js
+++ b/src/utils/events.js
@@ -56,7 +56,7 @@ export const EVENTS = {
   FILE_OPEN: 'file:open',
 };
 
-export const EVENT_CATALOG = {
+const EVENT_CATALOG = {
   // ── Terminal lifecycle events ──
 
   /**


### PR DESCRIPTION
## Refactoring

- Suppression de l'export `EVENT_CATALOG` dans `src/utils/events.js` (conservé en interne pour validation dev)
- Suppression de `formatTime` des exports de `src/utils/date-utils.js` (utilisé uniquement en interne par `formatDateTime`)
- La majorité des items de #73 étaient déjà résolus par des refactors précédents

Closes #73

## Fichier(s) modifié(s)

- `src/utils/events.js`
- `src/utils/date-utils.js`

## Vérifications

- [x] Build OK
- [x] Tests OK (318/318)

---

📂 Path local : `/Users/rekta/projet/coding/refactor-pikagent`
🤖 PR créée automatiquement par l'Agent Refactor