### PR TITLE
refactor: extract _initTabComponents from renderWorkspace()

### DIFF
--- a/src/utils/workspace-layout.js
+++ b/src/utils/workspace-layout.js
@@ -35,6 +35,40 @@ export {
 // ── Workspace rendering ──
 
 /**
+ * Instantiate tab sub-components and restore saved state if present.
+ *
+ * @param {import('./tab-manager-helpers.js').WorkspaceTab} tab
+ * @param {HTMLElement} layout
+ * @param {{ left: { content: HTMLElement, panel: HTMLElement }, right: { content: HTMLElement, panel: HTMLElement } }} sides
+ * @param {HTMLElement} termContainer
+ * @param {Function} getActiveTabId - () => string|null
+ */
+function _initTabComponents(tab, layout, sides, termContainer, getActiveTabId) {
+  const FileTree = getComponent('FileTree');
+  const FileViewer = getComponent('FileViewer');
+  const TerminalPanel = getComponent('TerminalPanel');
+
+  tab.layoutElement = layout;
+  tab.fileTree = new FileTree(sides.left.content);
+  tab.fileViewer = new FileViewer(sides.right.content, () => tab.id === getActiveTabId());
+
+  if (tab._restoreData?.splitTree) {
+    tab.terminalPanel = new TerminalPanel(termContainer, tab.cwd);
+    tab.terminalPanel.restoreFromTree(tab._restoreData.splitTree);
+    restorePanelSizes(tab._restoreData.panels, { left: sides.left.panel, right: sides.right.panel });
+    syncFileTree(tab);
+    if (tab._restoreData.webviewTabs && tab.fileViewer) {
+      tab.fileViewer.setWebviewTabs(tab._restoreData.webviewTabs);
+    }
+    delete tab._restoreData;
+  } else {
+    tab.terminalPanel = new TerminalPanel(termContainer, tab.cwd);
+    const firstTermId = tab.terminalPanel.activeTerminal?.terminal?.id;
+    if (firstTermId) tab.fileTree.setTerminalRoot(firstTermId, tab.cwd);
+  }
+}
+
+/**
  * Render the full workspace layout for a tab.
  * @param {RenderWorkspaceDeps} deps
  * @param {import('./tab-manager-helpers.js').WorkspaceTab} tab
@@ -61,28 +95,7 @@ export async function renderWorkspace({ workspaceContainer, getActiveTabId, getA
   );
   workspaceContainer.appendChild(layout);
 
-  const FileTree = getComponent('FileTree');
-  const FileViewer = getComponent('FileViewer');
-  const TerminalPanel = getComponent('TerminalPanel');
-
-  tab.layoutElement = layout;
-  tab.fileTree = new FileTree(sides.left.content);
-  tab.fileViewer = new FileViewer(sides.right.content, () => tab.id === getActiveTabId());
-
-  if (tab._restoreData?.splitTree) {
-    tab.terminalPanel = new TerminalPanel(termContainer, tab.cwd);
-    tab.terminalPanel.restoreFromTree(tab._restoreData.splitTree);
-    restorePanelSizes(tab._restoreData.panels, { left: sides.left.panel, right: sides.right.panel });
-    syncFileTree(tab);
-    if (tab._restoreData.webviewTabs && tab.fileViewer) {
-      tab.fileViewer.setWebviewTabs(tab._restoreData.webviewTabs);
-    }
-    delete tab._restoreData;
-  } else {
-    tab.terminalPanel = new TerminalPanel(termContainer, tab.cwd);
-    const firstTermId = tab.terminalPanel.activeTerminal?.terminal?.id;
-    if (firstTermId) tab.fileTree.setTerminalRoot(firstTermId, tab.cwd);
-  }
+  _initTabComponents(tab, layout, sides, termContainer, getActiveTabId);
 
   const branch = await gitBranch(tab.cwd);
   if (branch) tab.branchBadgeEl.textContent = ` ${branch}`;


### PR DESCRIPTION
## Refactoring

- Extraction de `_initTabComponents()` depuis `renderWorkspace()` dans `workspace-layout.js`
- Réduit `renderWorkspace()` de ~50 à ~28 lignes
- Les autres items de #83 (tab-manager, file-tree, switchTo, createTab, _renderList, init) étaient déjà résolus dans des refactors précédents

Closes #83

## Fichier(s) modifié(s)

- `src/utils/workspace-layout.js`

## Vérifications

- [x] Build OK
- [x] Tests OK (318/318)

---

📂 Path local : `/Users/rekta/projet/coding/refactor-pikagent`
🤖 PR créée automatiquement par l'Agent Refactor