### PR TITLE
refactor: fix missing aggregateByKey export in aggregation-utils

### DIFF
--- a/main/aggregation-utils.js
+++ b/main/aggregation-utils.js
@@ -95,4 +95,4 @@ function computeNumericStats(values) {
   };
 }
 
-module.exports = { groupAndAggregate, computeRate, computeNumericStats };
+module.exports = { aggregateByKey, groupAndAggregate, computeRate, computeNumericStats };


### PR DESCRIPTION
## Refactoring

- Ajout de `aggregateByKey` aux exports de `main/aggregation-utils.js` (défini mais manquant dans `module.exports`)
- La centralisation de l'agrégation et du formatage de dates étaient déjà en place
- `stats-helpers.js` délègue déjà à `aggregation-utils.js`
- Le formatage de dates est déjà centralisé dans `shared/date-utils.js`

Closes #59

## Fichier(s) modifié(s)

- `main/aggregation-utils.js`

## Vérifications

- [x] Build OK
- [x] Tests OK (318/318)

---

📂 Path local : `/Users/rekta/projet/coding/refactor-pikagent`
🤖 PR créée automatiquement par l'Agent Refactor