### PR TITLE
refactor: break circular dependency workspace-layout ↔ workspace-serializer

### DIFF
--- a/src/utils/workspace-cleanup.js
+++ b/src/utils/workspace-cleanup.js
@@ -1,0 +1,36 @@
+/**
+ * Workspace Cleanup — tab disposal utilities.
+ *
+ * Extracted from workspace-layout.js to break the circular dependency
+ * between workspace-layout.js and workspace-serializer.js (issue #94).
+ *
+ * @typedef {Object} DisposeAllTabsDeps
+ * @property {Map<string, WorkspaceTab>} tabs
+ * @property {Function} setActiveTabId    - (id) => void
+ */
+
+import { TAB_DISPOSABLES } from './tab-manager-helpers.js';
+
+// ── Tab disposal ──
+
+/**
+ * Dispose a single tab — call dispose() on all disposable sub-components
+ * and remove the layout element from the DOM.
+ * @param {import('./tab-manager-helpers.js').WorkspaceTab} tab
+ */
+export function disposeTab(tab) {
+  for (const key of TAB_DISPOSABLES) if (tab[key]) tab[key].dispose();
+  if (tab.layoutElement) tab.layoutElement.remove();
+}
+
+/**
+ * Dispose all tabs and clear the tab map.
+ * @param {DisposeAllTabsDeps} deps
+ */
+export function disposeAllTabs({ tabs, setActiveTabId }) {
+  for (const [id, tab] of [...tabs]) {
+    disposeTab(tab);
+    tabs.delete(id);
+  }
+  setActiveTabId(null);
+}

--- a/src/utils/workspace-layout.js
+++ b/src/utils/workspace-layout.js
@@ -11,15 +11,13 @@
  * @property {Function} getActiveTab      - () => WorkspaceTab|null
  * @property {Function} scheduleAutoSave  - () => void
  *
- * @typedef {Object} DisposeAllTabsDeps
- * @property {Map<string, WorkspaceTab>} tabs
- * @property {Function} setActiveTabId    - (id) => void
+ * Tab disposal logic lives in workspace-cleanup.js.
  */
 
 import { getComponent } from './component-registry.js';
 import { bus, EVENTS } from './events.js';
 import { _el } from './dom.js';
-import { WORKSPACE_PANELS, TAB_DISPOSABLES } from './tab-manager-helpers.js';
+import { WORKSPACE_PANELS } from './tab-manager-helpers.js';
 import {
   buildSidePanel, buildCenterPanel,
   capturePanelWidths, restorePanelSizes,
@@ -31,6 +29,9 @@ export {
   setupPanelResize, togglePanel,
   capturePanelWidths, restorePanelSizes,
 } from './workspace-resize.js';
+
+// Re-export from workspace-cleanup.js for backward compatibility
+export { disposeTab, disposeAllTabs } from './workspace-cleanup.js';
 
 // ── Workspace rendering ──
 
@@ -129,26 +130,3 @@ export function syncFileTree(tab) {
   }
 }
 
-// ── Tab disposal ──
-
-/**
- * Dispose a single tab — call dispose() on all disposable sub-components
- * and remove the layout element from the DOM.
- * @param {import('./tab-manager-helpers.js').WorkspaceTab} tab
- */
-export function disposeTab(tab) {
-  for (const key of TAB_DISPOSABLES) if (tab[key]) tab[key].dispose();
-  if (tab.layoutElement) tab.layoutElement.remove();
-}
-
-/**
- * Dispose all tabs and clear the tab map.
- * @param {DisposeAllTabsDeps} deps
- */
-export function disposeAllTabs({ tabs, setActiveTabId }) {
-  for (const [id, tab] of [...tabs]) {
-    disposeTab(tab);
-    tabs.delete(id);
-  }
-  setActiveTabId(null);
-}

--- a/src/utils/workspace-serializer.js
+++ b/src/utils/workspace-serializer.js
@@ -21,7 +21,7 @@ import { generateId } from './id.js';
 import { WorkspaceTab } from './tab-manager-helpers.js';
 import { disposeAllSideViews } from './sidebar-manager.js';
 import { capturePanelWidths } from './workspace-resize.js';
-import { disposeAllTabs } from './workspace-layout.js';
+import { disposeAllTabs } from './workspace-cleanup.js';
 
 // ── Serialization ──
 


### PR DESCRIPTION
## Refactoring

- Extraction de `disposeTab` et `disposeAllTabs` dans un nouveau module `workspace-cleanup.js`
- `workspace-serializer.js` importe désormais depuis `workspace-cleanup.js` au lieu de `workspace-layout.js`
- `workspace-layout.js` re-exporte depuis `workspace-cleanup.js` pour compatibilité ascendante
- La dépendance circulaire est complètement cassée

Closes #94

## Fichier(s) modifié(s)

- `src/utils/workspace-cleanup.js` (nouveau)
- `src/utils/workspace-layout.js`
- `src/utils/workspace-serializer.js`

## Vérifications

- [x] Build OK
- [x] Tests OK (319/319)

---

📂 Path local : `/Users/rekta/projet/coding/refactor-pikagent`
🤖 PR créée automatiquement par l'Agent Refactor