### PR TITLE
refactor: extract shared polling timer implementation

### DIFF
--- a/main/polling-timer.js
+++ b/main/polling-timer.js
@@ -1,30 +1,5 @@
 /**
- * Reusable polling timer with start/stop lifecycle.
- * Shared by FlowManager and SessionManager.
+ * Re-exports the shared PollingTimer for the main process.
+ * Implementation lives in shared/polling-timer.js.
  */
-class PollingTimer {
-  constructor(intervalMs, callback) {
-    this._intervalMs = intervalMs;
-    this._callback = callback;
-    this._timer = null;
-  }
-
-  start() {
-    if (this._timer) return;
-    this._timer = setInterval(() => this._callback(), this._intervalMs);
-    this._callback();
-  }
-
-  stop() {
-    if (this._timer) {
-      clearInterval(this._timer);
-      this._timer = null;
-    }
-  }
-
-  get running() {
-    return this._timer !== null;
-  }
-}
-
-module.exports = { PollingTimer };
+module.exports = require('../shared/polling-timer');

--- a/shared/polling-timer.js
+++ b/shared/polling-timer.js
@@ -1,0 +1,37 @@
+/**
+ * Reusable polling timer with start/stop lifecycle.
+ * Shared by both main process (CommonJS) and renderer process (ES module via esbuild).
+ *
+ * Usage:
+ *   const { PollingTimer } = require('../shared/polling-timer');
+ */
+class PollingTimer {
+  /**
+   * @param {number} intervalMs  - Polling interval in milliseconds
+   * @param {Function} callback  - Called on each tick and immediately on start
+   */
+  constructor(intervalMs, callback) {
+    this._intervalMs = intervalMs;
+    this._callback = callback;
+    this._timer = null;
+  }
+
+  start() {
+    if (this._timer) return;
+    this._timer = setInterval(() => this._callback(), this._intervalMs);
+    this._callback();
+  }
+
+  stop() {
+    if (this._timer) {
+      clearInterval(this._timer);
+      this._timer = null;
+    }
+  }
+
+  get running() {
+    return this._timer !== null;
+  }
+}
+
+module.exports = { PollingTimer };

--- a/src/utils/polling.js
+++ b/src/utils/polling.js
@@ -1,33 +1,10 @@
 /**
- * Reusable polling timer for the renderer process.
- * Mirrors the API of main/polling-timer.js (start/stop/running)
- * but lives in the renderer bundle.
+ * Re-exports the shared PollingTimer for the renderer process.
+ * Implementation lives in shared/polling-timer.js.
+ *
+ * The class is aliased as RendererPollingTimer to preserve the existing
+ * public API used by renderer components.
  */
-export class RendererPollingTimer {
-  /**
-   * @param {number} intervalMs  - Polling interval in milliseconds
-   * @param {Function} callback  - Called on each tick and immediately on start
-   */
-  constructor(intervalMs, callback) {
-    this._intervalMs = intervalMs;
-    this._callback = callback;
-    this._timer = null;
-  }
+import { PollingTimer } from '../../shared/polling-timer.js';
 
-  start() {
-    if (this._timer) return;
-    this._timer = setInterval(() => this._callback(), this._intervalMs);
-    this._callback();
-  }
-
-  stop() {
-    if (this._timer) {
-      clearInterval(this._timer);
-      this._timer = null;
-    }
-  }
-
-  get running() {
-    return this._timer !== null;
-  }
-}
+export { PollingTimer as RendererPollingTimer };


### PR DESCRIPTION
## Summary

- Moved the duplicated polling timer logic to `shared/polling-timer.js` as a single shared implementation
- Updated `main/polling-timer.js` to re-export from shared (CommonJS)
- Updated `src/utils/polling.js` to re-export from shared (ES module, preserving the `RendererPollingTimer` alias)

Closes #111

## Test plan

- [x] Build passes (`npm run build`)
- [x] All 319 tests pass across 21 test files (`npm test`)
- [x] Existing imports in `main/flow-manager.js`, `main/session-manager.js`, and `src/components/board-view.js` remain unchanged

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)