### PR TITLE
refactor: remove dead code and unused exports

### DIFF
--- a/main/date-utils.js
+++ b/main/date-utils.js
@@ -2,12 +2,12 @@
  * Date/time utilities for the main process.
  * Pure functions — no side effects.
  *
- * Generic formatting (formatTime, formatDateTime) lives in shared/date-utils.js
+ * Generic formatting (formatDateTime) lives in shared/date-utils.js
  * and is re-exported here for backward compatibility.
  * Domain-specific helpers (extractDateString, generateDateRange) stay here.
  */
 
-const { formatTime, formatDateTime } = require('../shared/date-utils');
+const { formatDateTime } = require('../shared/date-utils');
 
 const DATE_LOCALE = 'fr-FR';
 const DAY_LABEL_FORMAT = { day: '2-digit', month: '2-digit' };
@@ -38,4 +38,4 @@ function generateDateRange(days = 30) {
   });
 }
 
-module.exports = { extractDateString, generateDateRange, formatTime, formatDateTime };
+module.exports = { extractDateString, generateDateRange, formatDateTime };

--- a/src/utils/file-icons.js
+++ b/src/utils/file-icons.js
@@ -1,5 +1,3 @@
-const DEFAULT_ICON = '📄';
-
 /** Unified file-type config: maps each extension to its icon and/or language.
  *  Single source of truth — add new file types here. */
 const FILE_CONFIG = {
@@ -61,13 +59,6 @@ const FILENAME_LANG = {
 
 function _getExt(filename) {
   return filename.split('.').pop().toLowerCase();
-}
-
-/** @internal */
-function getFileIcon(name, isDirectory) {
-  if (isDirectory) return '📁';
-  const cfg = FILE_CONFIG[_getExt(name)];
-  return (cfg && cfg.icon) || DEFAULT_ICON;
 }
 
 export function detectLanguage(filename) {

--- a/src/utils/tab-manager-helpers.js
+++ b/src/utils/tab-manager-helpers.js
@@ -19,11 +19,6 @@ export const WORKSPACE_PANELS = [
   { side: 'right', contentCls: 'file-viewer',                    widthKey: 'rightWidth', collapsedKey: 'rightCollapsed' },
 ];
 
-/** @internal */
-const LEFT_MAX_WIDTH = SIDE_CONFIG.left.maxWidth;
-/** @internal */
-const RIGHT_MAX_WIDTH = SIDE_CONFIG.right.maxWidth;
-
 // ── Activity bar buttons ──
 export const ACTIVITY_BUTTONS = [
   { label: 'work', mode: 'work' },

--- a/tests/main/date-utils.test.js
+++ b/tests/main/date-utils.test.js
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
-const { extractDateString, generateDateRange, formatTime, formatDateTime } = require('../../main/date-utils');
+const { extractDateString, generateDateRange, formatDateTime } = require('../../main/date-utils');
+const { formatTime } = require('../../shared/date-utils');
 
 describe('date-utils', () => {
   describe('extractDateString', () => {


### PR DESCRIPTION
## Summary

- Removed dead `getFileIcon` function and `DEFAULT_ICON` constant from `src/utils/file-icons.js` (never exported, never used)
- Removed dead `LEFT_MAX_WIDTH` / `RIGHT_MAX_WIDTH` constants from `src/utils/tab-manager-helpers.js` (defined but never used)
- Dropped `formatTime` re-export from `main/date-utils.js` (no internal consumer; kept in `shared/date-utils.js`)
- Updated `tests/main/date-utils.test.js` to import `formatTime` directly from `shared/date-utils`

## Notes on issue scope

Several items listed in #73 were already resolved in prior refactorings:
- `electron-handlers.js` — already deleted (file does not exist)
- `dateStr`, `dayLabels` in stats-helpers.js — not present in current code
- `registerHandlers` in fs-manager.js — not present in current code
- `parseLogTimestamp`, `projectShortName`, `buildFileKey`, `getFlowRunDuration`, `getByAgent` in usage-helpers.js — already not exported (internal-only functions)
- `EVENT_CATALOG`, `EventBus` in events.js — already not exported (local to module)
- `COLOR_GROUPS` re-export from tab-manager.js — no such re-export exists
- `aggregateByKey`, `groupAndAggregate` in aggregation-utils.js — used by sibling modules (`usage-helpers.js`, `stats-helpers.js`) via `require()`, so must stay exported

Closes #73

## Test plan

- [x] `npm run build` passes
- [x] `npm test` passes (21 files, 319 tests)

---
PR created automatically by Agent Refactor