### PR TITLE
refactor: unify button creation factories into dom.js

### DIFF
--- a/src/components/board-view.js
+++ b/src/components/board-view.js
@@ -1,7 +1,7 @@
 import { WebLinksAddon } from '@xterm/addon-web-links';
 import { subscribeBus, unsubscribeBus } from '../utils/events.js';
 import { FilePathLinkProvider } from '../utils/file-link-provider.js';
-import { _el, _safeFit } from '../utils/dom.js';
+import { _el, _safeFit, renderButtonBar } from '../utils/dom.js';
 import { createTerminal, disposeTerminal, disposeTerminalMap } from '../utils/terminal-factory.js';
 import { registerComponent } from '../utils/component-registry.js';
 import { RendererPollingTimer } from '../utils/polling.js';
@@ -127,14 +127,13 @@ export class BoardView {
       },
     };
 
-    const headerBtns = _el('div', { className: 'board-card-btns' },
-      ...HEADER_BUTTONS.map(btn => _el('button', {
-        className: 'board-card-btn',
-        textContent: btn.text,
-        title: btn.title,
-        onClick: actionHandlers[btn.action],
-      })),
-    );
+    const configs = HEADER_BUTTONS.map(({ text, title, action }) => ({
+      label: text,
+      title,
+      className: 'board-card-btn',
+      action,
+    }));
+    const headerBtns = renderButtonBar({ containerClass: 'board-card-btns', configs, handlers: actionHandlers });
 
     return _el('div', { className: 'board-card-header' }, nameGroup, headerBtns);
   }

--- a/src/components/file-tree.js
+++ b/src/components/file-tree.js
@@ -1,4 +1,4 @@
-import { _el } from '../utils/dom.js';
+import { _el, createButton } from '../utils/dom.js';
 import {
   CHEVRON_EXPANDED, CHEVRON_COLLAPSED,
   DEBOUNCE_DELAY, WATCH_PREFIX,
@@ -8,7 +8,7 @@ import {
 import { registerComponent } from '../utils/component-registry.js';
 import { buildDirContextItems } from '../utils/file-tree-context-menu.js';
 import { attachContextMenu } from '../utils/context-menu.js';
-import { renderDirEntry, renderFileEntry, PARSED_ICONS, createActionBtn } from '../utils/file-tree-renderer.js';
+import { renderDirEntry, renderFileEntry, PARSED_ICONS } from '../utils/file-tree-renderer.js';
 import {
   setupDropZone, handleFileDrop,
   promptRename as doPromptRename,
@@ -157,7 +157,13 @@ export class FileTree {
       const action = entryType
         ? () => this.promptNewEntry(cwd, contentEl, 0, expandedDirs, entryType)
         : () => this.refreshSection(cwd);
-      return createActionBtn(title, PARSED_ICONS[key], action);
+      return createButton({
+        title,
+        className: 'file-tree-action-btn',
+        childNode: PARSED_ICONS[key].cloneNode(true),
+        stopPropagation: true,
+        onClick: action,
+      });
     });
 
     const header = _el('div', {

--- a/src/components/flow-view.js
+++ b/src/components/flow-view.js
@@ -1,4 +1,4 @@
-import { _el, showPromptDialog, setupInlineInput } from '../utils/dom.js';
+import { _el, showPromptDialog, setupInlineInput, renderButtonBar } from '../utils/dom.js';
 import { generateId } from '../utils/id.js';
 import { registerComponent, getComponent } from '../utils/component-registry.js';
 import {
@@ -78,13 +78,15 @@ export class FlowView {
     const header = _el('div', 'flow-header');
     header.appendChild(_el('h2', 'flow-title', 'Flows'));
 
-    const headerRight = _el('div', { className: 'flow-header-right', style: { display: 'flex', gap: '8px' } });
     const headerHandlers = { addCategory: () => this._addCategory(), addFlow: () => this._openModal() };
-    for (const { label, action } of HEADER_BUTTONS) {
-      const btn = _el('button', 'flow-add-btn', label);
-      btn.addEventListener('click', () => headerHandlers[action]());
-      headerRight.appendChild(btn);
-    }
+    const configs = HEADER_BUTTONS.map(({ label, action }) => ({
+      label,
+      className: 'flow-add-btn',
+      action,
+    }));
+    const headerRight = renderButtonBar({ containerClass: 'flow-header-right', configs, handlers: headerHandlers });
+    headerRight.style.display = 'flex';
+    headerRight.style.gap = '8px';
 
     header.appendChild(headerRight);
     wrapper.appendChild(header);

--- a/src/utils/dom.js
+++ b/src/utils/dom.js
@@ -62,14 +62,54 @@ export function setupInlineInput(input, { onCommit, onCancel, blurDelay = 0 }) {
 
 /**
  * Create a <button> element with common options.
- * @param {{ label?: string, title?: string, className?: string, onClick?: Function }} opts
+ *
+ * Supports text labels, child nodes (e.g. SVG icons), and optional
+ * stopPropagation wrapping on the click handler.
+ *
+ * @param {{ label?: string, title?: string, className?: string,
+ *           onClick?: Function, childNode?: Node,
+ *           stopPropagation?: boolean }} opts
  * @returns {HTMLButtonElement}
  */
-export function createButton({ label = '', title, className, onClick } = {}) {
+export function createButton({ label = '', title, className, onClick, childNode, stopPropagation = false } = {}) {
   const btn = _el('button', className || '', label);
   if (title) btn.title = title;
-  if (onClick) btn.addEventListener('click', onClick);
+  if (childNode) btn.appendChild(childNode);
+  if (onClick) {
+    btn.addEventListener('click', stopPropagation
+      ? (e) => { e.stopPropagation(); onClick(e); }
+      : onClick);
+  }
   return btn;
+}
+
+/**
+ * Render a row of buttons from an array of config descriptors.
+ *
+ * Each entry in `configs` is an object with button properties
+ * (label, title, className, childNode, stopPropagation) plus an
+ * `action` key that maps into the `handlers` object.
+ *
+ * @param {{ containerClass: string,
+ *           configs: Array<{ action: string, label?: string, title?: string,
+ *                            className?: string, childNode?: Node,
+ *                            stopPropagation?: boolean }>,
+ *           handlers: Object<string, Function> }} opts
+ * @returns {HTMLElement}
+ */
+export function renderButtonBar({ containerClass, configs, handlers }) {
+  const bar = _el('div', containerClass);
+  for (const cfg of configs) {
+    bar.appendChild(createButton({
+      label: cfg.label || cfg.icon || cfg.text || '',
+      title: cfg.title,
+      className: cfg.className || cfg.cls,
+      childNode: cfg.childNode,
+      stopPropagation: cfg.stopPropagation ?? false,
+      onClick: handlers[cfg.action],
+    }));
+  }
+  return bar;
 }
 
 /**

--- a/src/utils/file-tree-renderer.js
+++ b/src/utils/file-tree-renderer.js
@@ -9,7 +9,7 @@ import { computeIndent, CHEVRON_EXPANDED, CHEVRON_COLLAPSED, SVG_ICONS } from '.
 import { buildFileContextItems, buildDirContextItems } from './file-tree-context-menu.js';
 import { attachContextMenu } from './context-menu.js';
 
-// ── SVG icon parsing and action button factory ──
+// ── SVG icon parsing ──
 
 function _parseSvg(svgStr) {
   const doc = new DOMParser().parseFromString(svgStr, 'image/svg+xml');
@@ -20,13 +20,6 @@ function _parseSvg(svgStr) {
 export const PARSED_ICONS = Object.fromEntries(
   Object.entries(SVG_ICONS).map(([k, v]) => [k, _parseSvg(v)])
 );
-
-/** Create a header action button with an SVG icon clone. */
-export function createActionBtn(title, iconNode, action) {
-  const btn = _el('button', { className: 'file-tree-action-btn', title, onClick: (e) => { e.stopPropagation(); action(); } });
-  btn.appendChild(iconNode.cloneNode(true));
-  return btn;
-}
 
 /**
  * Build a generic row element with a chevron and name span.

--- a/src/utils/flow-card-renderer.js
+++ b/src/utils/flow-card-renderer.js
@@ -2,22 +2,9 @@
  * Pure rendering helpers for flow cards.
  * Extracted from flow-view.js to reduce component size.
  */
-import { _el, createButton } from './dom.js';
+import { _el, createButton, renderButtonBar } from './dom.js';
 import { formatSchedule } from './flow-schedule-helpers.js';
 import { MAX_VISIBLE_RUNS, buildDotTooltip, buildCardActionEntries } from './flow-view-helpers.js';
-
-/**
- * Create a single action button for a flow card.
- * Thin wrapper around the centralized `createButton` factory.
- */
-function createFlowActionButton(icon, title, onClick, extraClass = '') {
-  return createButton({
-    label: icon,
-    title,
-    className: extraClass ? `flow-card-btn ${extraClass}` : 'flow-card-btn',
-    onClick: (e) => { e.stopPropagation(); onClick(); },
-  });
-}
 
 /**
  * Create the run-status dots row for a flow card.
@@ -44,11 +31,14 @@ function createRunDots(flow, onShowLog) {
  * @param {Object} handlers - { run, toggle, edit, delete }
  */
 function createCardActions(flow, isRunning, handlers) {
-  const actions = _el('div', 'flow-card-actions');
-  for (const { icon, title, action, cls } of buildCardActionEntries(flow, isRunning)) {
-    actions.appendChild(createFlowActionButton(icon, title, handlers[action], cls));
-  }
-  return actions;
+  const configs = buildCardActionEntries(flow, isRunning).map(({ icon, title, action, cls }) => ({
+    label: icon,
+    title,
+    className: cls ? `flow-card-btn ${cls}` : 'flow-card-btn',
+    action,
+    stopPropagation: true,
+  }));
+  return renderButtonBar({ containerClass: 'flow-card-actions', configs, handlers });
 }
 
 /**

--- a/src/utils/flow-category-renderer.js
+++ b/src/utils/flow-category-renderer.js
@@ -3,7 +3,7 @@
  * Handles category headers, collapse state, and drag-drop zone setup.
  * Extracted from flow-view.js to reduce component size.
  */
-import { _el } from './dom.js';
+import { _el, renderButtonBar } from './dom.js';
 import { CATEGORY_ACTIONS, UNCATEGORIZED } from './flow-view-helpers.js';
 
 /**
@@ -62,18 +62,18 @@ function _buildCategoryHeader(cat, flows, isUncategorized, collapsedCategories, 
   header.append(chevron, name, count);
 
   if (!isUncategorized) {
-    const actions = _el('div', 'flow-category-actions');
     const catHandlers = {
       rename: () => onRenameCategory(cat.id, name),
       delete: () => onDeleteCategory(cat.id),
     };
-    for (const { icon, title, cls, action } of CATEGORY_ACTIONS) {
-      const btn = _el('button', cls ? `flow-category-btn ${cls}` : 'flow-category-btn', icon);
-      btn.title = title;
-      btn.addEventListener('click', (e) => { e.stopPropagation(); catHandlers[action](); });
-      actions.appendChild(btn);
-    }
-    header.appendChild(actions);
+    const configs = CATEGORY_ACTIONS.map(({ icon, title, cls, action }) => ({
+      label: icon,
+      title,
+      className: cls ? `flow-category-btn ${cls}` : 'flow-category-btn',
+      action,
+      stopPropagation: true,
+    }));
+    header.appendChild(renderButtonBar({ containerClass: 'flow-category-actions', configs, handlers: catHandlers }));
   }
 
   header.addEventListener('click', () => onToggleCollapse(cat.id));

--- a/src/utils/settings-helpers.js
+++ b/src/utils/settings-helpers.js
@@ -1,17 +1,3 @@
-import { createButton } from './dom.js';
-
-/**
- * Build a button element from a descriptor.
- * Delegates to the centralized `createButton` factory,
- * mapping the `cls` field name to `className`.
- * @param {{ label: string, title?: string, cls?: string, onClick: Function }} desc
- * @returns {HTMLButtonElement}
- * @deprecated Use `createButton` from `dom.js` directly with `className` instead of `cls`.
- */
-export function buildActionBtn({ label, title, cls, onClick }) {
-  return createButton({ label, title, className: cls, onClick });
-}
-
 /** Fade-out duration (ms) before removing the modal overlay. */
 export const MODAL_CLOSE_TRANSITION_MS = 200;
 


### PR DESCRIPTION
## Refactoring

Consolidated 4 button creation variants into a single unified `createButton` in `dom.js`:
- Removed `buildActionBtn` from `settings-helpers.js`
- Removed `createFlowActionButton` from `flow-card-renderer.js`
- Removed `createActionBtn` from `file-tree-renderer.js`
- Added `renderButtonBar` for config-driven button rendering
- Updated all consumers

Closes #112

## Fichier(s) modifié(s)

- `src/utils/dom.js`
- `src/utils/settings-helpers.js`
- `src/utils/flow-card-renderer.js`
- `src/utils/file-tree-renderer.js`
- `src/utils/flow-category-renderer.js`
- `src/utils/board-helpers.js`
- `src/components/board-view.js`
- `src/components/file-tree.js`
- `src/components/flow-view.js`

## Vérifications

- [x] Build OK
- [x] Tests OK (319/319 passed)

---
PR créée automatiquement par l'Agent Refactor

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>