### PR TITLE
refactor: reduce long functions and files (regression fix)

### DIFF
--- a/src/utils/terminal-instance.js
+++ b/src/utils/terminal-instance.js
@@ -22,6 +22,23 @@ export class TerminalInstance {
     this.disposed = false;
     this._api = { ptyWrite, ptyOnData, ptyOnExit, ptyCreate, ptyGetCwd, ptyResize, ptyKill };
 
+    this._initTerminal(container, { openExternal, homedir, openPath });
+    this._attachPtyBridge();
+
+    this.resizeObserver = new ResizeObserver(() => this.fit());
+    this.resizeObserver.observe(container);
+
+    this.cwdPollingPaused = false;
+    this.spawn();
+    this.startCwdPolling();
+  }
+
+  /**
+   * Create the xterm terminal, load addons, and attach custom key handler.
+   * @param {HTMLElement} container
+   * @param {{ openExternal: Function, homedir: Function, openPath: Function }} linkApi
+   */
+  _initTerminal(container, { openExternal, homedir, openPath }) {
     const { term, fitAddon } = createTerminal(container, {
       fontSize: 13,
       lineHeight: 1.3,
@@ -45,7 +62,12 @@ export class TerminalInstance {
     });
 
     this.fit();
+  }
 
+  /**
+   * Wire up bidirectional data flow between xterm and the PTY process.
+   */
+  _attachPtyBridge() {
     this.terminal.onData((data) => {
       if (!this.disposed) this._api.ptyWrite({ id: this.id, data });
     });
@@ -58,13 +80,6 @@ export class TerminalInstance {
       /** @fires terminal:exited {{ id: string }} — PTY process exited */
       bus.emit(EVENTS.TERMINAL_EXITED, { id: this.id });
     });
-
-    this.resizeObserver = new ResizeObserver(() => this.fit());
-    this.resizeObserver.observe(container);
-
-    this.cwdPollingPaused = false;
-    this.spawn();
-    this.startCwdPolling();
   }
 
   async spawn() {


### PR DESCRIPTION
## Summary

- Extracted `_initTerminal()` and `_attachPtyBridge()` from `TerminalInstance.constructor()` (51 lines -> 17 lines) in `terminal-instance.js`
- This was the last remaining function over the 50-line threshold in `src/`

The other functions and files listed in #83 (`switchTo()`, `createTab()`, `_renderList()`, `init()`, `renderWorkspace()`) were already refactored in prior PRs (#105-#109). This PR addresses the remaining regression.

## Current state after this PR

| Target | Before #83 work | Now |
|--------|-----------------|-----|
| `workspace-layout.js` | 378 lines | 145 lines |
| `tab-manager.js` | 364 lines | 295 lines |
| `file-tree.js` | 304 lines | 287 lines |
| `switchTo()` | 61 lines | 27 lines |
| `createTab()` | 55 lines | 10 lines |
| `_renderList()` | 55 lines | 18 lines |
| `init()` | 52 lines | 16 lines |
| `renderWorkspace()` | 50 lines | 28 lines |
| `TerminalInstance()` | 51 lines | 17 lines |

No function in `src/` exceeds 50 lines. Longest is `buildSideBySideRows()` at 46 lines.

Closes #83

## Fichier(s) modifie(s)

- `src/utils/terminal-instance.js`

## Verifications

- [x] Build OK
- [x] Tests OK (319/319 passed)

---

PR creee automatiquement par l'Agent Refactor