### PR TITLE
refactor: replace loose JSDoc types with precise types (top 10 files)

### DIFF
--- a/main/aggregation-utils.js
+++ b/main/aggregation-utils.js
@@ -9,11 +9,11 @@
  * For each item, calls `accFn(bucket, item)` to merge data into the bucket.
  * Creates new buckets via `initFn()` when a key is first seen.
  *
- * @param {Array} items
- * @param {Function} keyFn    - (item) => string key
- * @param {Function} initFn   - () => initial bucket value
- * @param {Function} accFn    - (bucket, item) => void (mutates bucket)
- * @returns {Object} map of key -> accumulated bucket
+ * @param {Array<unknown>} items
+ * @param {(item: unknown) => string|null} keyFn    - extracts grouping key from item
+ * @param {() => unknown} initFn                    - creates initial bucket value
+ * @param {(bucket: unknown, item: unknown) => void} accFn - mutates bucket with item
+ * @returns {Record<string, unknown>} map of key -> accumulated bucket
  */
 function aggregateByKey(items, keyFn, initFn, accFn) {
   const result = {};
@@ -30,10 +30,10 @@ function aggregateByKey(items, keyFn, initFn, accFn) {
  * @internal
  * Group items by key, then apply an aggregation function to each group.
  *
- * @param {Array} items
- * @param {Function} keyFn  - (item) => string key
- * @param {Function} aggFn  - (groupItems) => aggregated value
- * @returns {Object} map of key -> aggregated value
+ * @param {Array<unknown>} items
+ * @param {(item: unknown) => string|null} keyFn  - extracts grouping key from item
+ * @param {(groupItems: Array<unknown>) => unknown} aggFn  - aggregation function per group
+ * @returns {Record<string, unknown>} map of key -> aggregated value
  */
 function groupAndAggregate(items, keyFn, aggFn) {
   const groups = {};
@@ -53,11 +53,11 @@ function groupAndAggregate(items, keyFn, aggFn) {
  * Compute a category rate from items using a category set map.
  * Generic version that accepts category definitions.
  *
- * @param {Array} items
- * @param {Object} categories - map of categoryName -> Set of matching values
+ * @param {Array<Record<string, unknown>>} items
+ * @param {Record<string, Set<unknown>>} categories - map of categoryName -> Set of matching values
  * @param {string} [field='status'] - field to read from each item
  * @param {string} [rateKey='success'] - category key used to compute the rate
- * @returns {Object} { total, ...counts per category, rate }
+ * @returns {{ total: number, rate: number } & Record<string, number>}
  */
 function computeRate(items, categories, field = 'status', rateKey = 'success') {
   const keys = Object.keys(categories);

--- a/src/utils/file-tree-renderer.js
+++ b/src/utils/file-tree-renderer.js
@@ -31,7 +31,7 @@ export function createActionBtn(title, iconNode, action) {
 /**
  * Build a generic row element with a chevron and name span.
  *
- * @param {Object} entry - { name }
+ * @param {{ name: string }} entry
  * @param {number} depth
  * @returns {{ row: HTMLElement, chevron: HTMLElement, name: HTMLElement }}
  */
@@ -49,18 +49,11 @@ export function buildRow(entry, depth) {
  * Render a single directory entry into `parentEl`, with expand/collapse
  * and context-menu behaviour wired up.
  *
- * @param {Object} entry - { name, path, isDirectory }
+ * @param {{ name: string, path: string, isDirectory: boolean }} entry
  * @param {HTMLElement} parentEl
  * @param {number} depth
  * @param {Set<string>} expandedDirs
- * @param {Object} callbacks
- * @param {Function} callbacks.setupDropZone - (el, targetDir) => void
- * @param {Function} callbacks.expandDir - (dirPath, childContainer, chevron, depth, expandedDirs) => Promise
- * @param {Function} callbacks.collapseDir - (dirPath, childContainer, chevron, expandedDirs) => void
- * @param {Function} callbacks.renderDir - (dirPath, parentEl, depth, expandedDirs) => Promise
- * @param {Function} callbacks.findRootCwd - (entryPath) => string
- * @param {Function} callbacks.promptRename - (path, nameEl) => void
- * @param {Function} callbacks.promptNewEntry - (dirPath, contentEl, depth, expandedDirs, type) => void
+ * @param {{ setupDropZone: (el: HTMLElement, targetDir: string) => void, expandDir: (dirPath: string, childContainer: HTMLElement, chevron: HTMLElement, depth: number, expandedDirs: Set<string>) => Promise<void>, collapseDir: (dirPath: string, childContainer: HTMLElement, chevron: HTMLElement, expandedDirs: Set<string>) => void, renderDir: (dirPath: string, parentEl: HTMLElement, depth: number, expandedDirs: Set<string>) => Promise<void>, findRootCwd: (entryPath: string) => string, promptRename: (path: string, nameEl: HTMLElement) => void, promptNewEntry: (dirPath: string, contentEl: HTMLElement, depth: number, expandedDirs: Set<string>, type: string) => void, contextMenuApi: unknown }} callbacks
  */
 export async function renderDirEntry(entry, parentEl, depth, expandedDirs, callbacks) {
   const { setupDropZone, expandDir, collapseDir, findRootCwd, promptRename, promptNewEntry, contextMenuApi } = callbacks;
@@ -104,10 +97,10 @@ export async function renderDirEntry(entry, parentEl, depth, expandedDirs, callb
  * Render a single file entry into `parentEl`, wiring up click and
  * context-menu listeners.
  *
- * @param {Object} entry - { name, path }
+ * @param {{ name: string, path: string }} entry
  * @param {HTMLElement} parentEl
  * @param {number} depth
- * @param {{ activeRowRef: { current: HTMLElement|null }, findRootCwd: Function, promptRename: Function }} callbacks
+ * @param {{ activeRowRef: { current: HTMLElement|null }, findRootCwd: (entryPath: string) => string, promptRename: (path: string, nameEl: HTMLElement) => void, contextMenuApi: unknown }} callbacks
  */
 export function renderFileEntry(entry, parentEl, depth, callbacks) {
   const { activeRowRef, findRootCwd, promptRename, contextMenuApi } = callbacks;

--- a/src/utils/file-viewer-tabs.js
+++ b/src/utils/file-viewer-tabs.js
@@ -10,14 +10,11 @@ import { attachContextMenu } from './context-menu.js';
  * Build a single tab element for the given file path.
  *
  * @param {string} filePath
- * @param {Object} file - { name }
+ * @param {{ name: string }} file
  * @param {string|null} activeFile - currently active file path
- * @param {Function} isPinned - (filePath) => boolean
- * @param {Function} isModified - (filePath) => boolean
- * @param {Object} callbacks
- * @param {Function} callbacks.onClose - (filePath) => void
- * @param {Function} callbacks.onActivate - (filePath) => void
- * @param {Function} callbacks.onTogglePin - (filePath) => void
+ * @param {(filePath: string) => boolean} isPinned
+ * @param {(filePath: string) => boolean} isModified
+ * @param {{ onClose: (filePath: string) => void, onActivate: (filePath: string) => void, onTogglePin: (filePath: string) => void }} callbacks
  * @returns {HTMLElement}
  */
 export function createTabEl(filePath, file, activeFile, isPinned, isModified, { onClose, onActivate, onTogglePin }) {
@@ -49,11 +46,11 @@ export function createTabEl(filePath, file, activeFile, isPinned, isModified, { 
  * Rebuild the entire tabs bar from the current open-files map.
  *
  * @param {HTMLElement} tabsBar
- * @param {Map<string, Object>} openFiles - path → file object
+ * @param {Map<string, { name: string }>} openFiles - path -> file object
  * @param {string|null} activeFile
- * @param {Function} isPinned
- * @param {Function} isModified
- * @param {Object} callbacks - forwarded to createTabEl
+ * @param {(filePath: string) => boolean} isPinned
+ * @param {(filePath: string) => boolean} isModified
+ * @param {{ onClose: (filePath: string) => void, onActivate: (filePath: string) => void, onTogglePin: (filePath: string) => void }} callbacks
  */
 export function renderTabs(tabsBar, openFiles, activeFile, isPinned, isModified, callbacks) {
   tabsBar.replaceChildren();

--- a/src/utils/flow-card-setup.js
+++ b/src/utils/flow-card-setup.js
@@ -14,9 +14,7 @@ import { createCardHeader } from './flow-card-renderer.js';
  * @param {HTMLElement} card
  * @param {string} flowId
  * @param {string} catId
- * @param {Object} dragState - mutable drag state object
- * @param {string|null} dragState.flowId
- * @param {string|null} dragState.catId
+ * @param {{ flowId: string|null, catId: string|null }} dragState - mutable drag state object
  */
 export function setupCardDrag(card, flowId, catId, dragState) {
   card.addEventListener('dragstart', (e) => {
@@ -39,11 +37,11 @@ export function setupCardDrag(card, flowId, catId, dragState) {
  * Build the collapsible body portion of a flow card (terminal or log view).
  * Returns null when nothing should be rendered.
  *
- * @param {Object} flow
+ * @param {{ id: string, runs?: Array<unknown>, enabled?: boolean }} flow
  * @param {boolean} isRunning
  * @param {boolean} isExpanded
- * @param {Object} termManager - FlowCardTerminalManager instance
- * @param {Object} runningMap - { [flowId]: ptyId }
+ * @param {{ createLiveTerminal: (flowId: string, ptyId: string) => HTMLElement, loadLogIntoContainer: (flowId: string, run: unknown, container: HTMLElement) => void, disposeLogTerminal: (flowId: string) => void }} termManager - FlowCardTerminalManager instance
+ * @param {Record<string, string>} runningMap - { [flowId]: ptyId }
  * @returns {HTMLElement|null}
  */
 export function buildCardBody(flow, isRunning, isExpanded, termManager, runningMap) {
@@ -68,13 +66,9 @@ export function buildCardBody(flow, isRunning, isExpanded, termManager, runningM
  * or opens the flow modal when there are no runs.
  *
  * @param {HTMLElement} headerRow
- * @param {Object} flow
+ * @param {{ id: string, runs?: Array<unknown>, enabled?: boolean }} flow
  * @param {boolean} isRunning
- * @param {Object} callbacks
- * @param {Set<string>} callbacks.expandedCards
- * @param {Function} callbacks.onRenderList
- * @param {Function} callbacks.onOpenModal - (flow) => void
- * @param {Object} callbacks.termManager
+ * @param {{ expandedCards: Set<string>, onRenderList: () => void, onOpenModal: (flow: { id: string, runs?: Array<unknown>, enabled?: boolean }) => void, termManager: { disposeLogTerminal: (flowId: string) => void } }} callbacks
  */
 export function setupCardHeaderClick(headerRow, flow, isRunning, { expandedCards, onRenderList, onOpenModal, termManager }) {
   headerRow.addEventListener('click', () => {
@@ -102,20 +96,20 @@ export function setupCardHeaderClick(headerRow, flow, isRunning, { expandedCards
  * Build a complete flow card element.
  *
  * @typedef {Object} CreateFlowCardDeps
- * @property {Object} runningMap        - { [flowId]: ptyId }
+ * @property {Record<string, string>} runningMap        - { [flowId]: ptyId }
  * @property {Set<string>} expandedCards
- * @property {Object} drag              - mutable drag state { flowId, catId }
- * @property {Object} termManager       - FlowCardTerminalManager instance
- * @property {Function} onRenderList    - () => void
- * @property {Function} onShowLog       - (flow, run) => void
- * @property {Function} onRun           - (flowId) => void
- * @property {Function} onToggle        - (flowId) => Promise
- * @property {Function} onRefresh       - () => void
- * @property {Function} onOpenModal     - (flow) => void
- * @property {Function} onDeleteFlow    - (flowId) => void
+ * @property {{ flowId: string|null, catId: string|null }} drag - mutable drag state
+ * @property {{ createLiveTerminal: (flowId: string, ptyId: string) => HTMLElement, loadLogIntoContainer: (flowId: string, run: unknown, container: HTMLElement) => void, disposeLogTerminal: (flowId: string) => void }} termManager - FlowCardTerminalManager instance
+ * @property {() => void} onRenderList
+ * @property {(flow: { id: string }, run: unknown) => void} onShowLog
+ * @property {(flowId: string) => void} onRun
+ * @property {(flowId: string) => Promise<void>} onToggle
+ * @property {() => void} onRefresh
+ * @property {(flow: { id: string }) => void} onOpenModal
+ * @property {(flowId: string) => void} onDeleteFlow
  *
  * @param {CreateFlowCardDeps} deps
- * @param {Object} flow
+ * @param {{ id: string, runs?: Array<unknown>, enabled?: boolean }} flow
  * @param {string} catId
  * @returns {HTMLElement}
  */

--- a/src/utils/sidebar-manager.js
+++ b/src/utils/sidebar-manager.js
@@ -9,22 +9,22 @@
  *
  * @typedef {Object} ActivityBarDeps
  * @property {string} sidebarMode          - Current sidebar mode ('work', 'board', etc.)
- * @property {Function} setSidebarMode     - Callback to change sidebar mode
- * @property {Function|null} onOpenSettings - Callback for settings button
+ * @property {(mode: string) => void} setSidebarMode     - Callback to change sidebar mode
+ * @property {(() => void)|null} onOpenSettings - Callback for settings button
  *
  * @typedef {Object} SideViewStore
- * @property {Function} getView         - (viewKey) => view instance or null
- * @property {Function} setView         - (viewKey, value) => void
- * @property {Function} getContainer    - (containerKey) => container element or null
- * @property {Function} setContainer    - (containerKey, value) => void
+ * @property {(viewKey: string) => unknown} getView         - view instance or null
+ * @property {(viewKey: string, value: unknown) => void} setView
+ * @property {(containerKey: string) => HTMLElement|null} getContainer
+ * @property {(containerKey: string, value: HTMLElement|null) => void} setContainer
  *
  * @typedef {Object} SideViewDeps
  * @property {HTMLElement} workspaceContainer - Workspace container element
  * @property {SideViewStore} viewStore        - Accessor for view/container instances
  *
  * @typedef {Object} DetachDeps
- * @property {Function} getActiveTab         - () => active WorkspaceTab or null
- * @property {Function} capturePanelWidths   - (tab) => void
+ * @property {() => import('./tab-manager-helpers.js').WorkspaceTab|null} getActiveTab
+ * @property {(tab: import('./tab-manager-helpers.js').WorkspaceTab) => void} capturePanelWidths
  * @property {SideViewStore} viewStore       - Accessor for view/container instances
  */
 
@@ -110,8 +110,8 @@ export function renderActivityBar({ sidebarMode, setSidebarMode, onOpenSettings 
  * @param {SideViewDeps} deps
  * @param {string} viewKey       - Property key for the view instance
  * @param {string} containerKey  - Property key for the container element
- * @param {Function} ViewClass   - Constructor for the view
- * @param {...*} ctorArgs        - Arguments for the ViewClass constructor
+ * @param {new (container: HTMLElement, ...args: unknown[]) => unknown} ViewClass   - Constructor for the view
+ * @param {...unknown} ctorArgs  - Arguments for the ViewClass constructor
  * @returns {boolean}
  */
 export function renderSideView({ workspaceContainer, viewStore }, viewKey, containerKey, ViewClass, ...ctorArgs) {
@@ -134,7 +134,7 @@ export function renderSideView({ workspaceContainer, viewStore }, viewKey, conta
  * Activate a side view by mode using SIDE_VIEW_RENDERERS config.
  * @param {SideViewDeps} deps
  * @param {string} mode         - Side view mode (board, flow, usage)
- * @param {Object} extraArgs    - Additional constructor args per mode
+ * @param {{ boardCtorArgs?: unknown[], flowCtorArgs?: unknown[] }} extraArgs - Additional constructor args per mode
  */
 export function activateSideView(deps, mode, extraArgs = {}) {
   const sideView = SIDE_VIEWS[mode];
@@ -154,13 +154,13 @@ export function activateSideView(deps, mode, extraArgs = {}) {
  * Switch sidebar mode: detach current view, activate new view (or re-attach work layout).
  *
  * @typedef {Object} ChangeSidebarModeDeps
- * @property {Function} getActiveTab         - () => WorkspaceTab|null
- * @property {Function} capturePanelWidths   - (tab) => void
+ * @property {() => import('./tab-manager-helpers.js').WorkspaceTab|null} getActiveTab
+ * @property {(tab: import('./tab-manager-helpers.js').WorkspaceTab) => void} capturePanelWidths
  * @property {SideViewStore} viewStore
  * @property {HTMLElement} workspaceContainer
- * @property {Function} reattachLayout       - (deps, tab) => void
- * @property {Function} renderWorkspace      - (tab) => void
- * @property {Object} tabManager             - Reference for BoardView/FlowView ctor args
+ * @property {(deps: { workspaceContainer: HTMLElement }, tab: import('./tab-manager-helpers.js').WorkspaceTab) => void} reattachLayout
+ * @property {(tab: import('./tab-manager-helpers.js').WorkspaceTab) => void} renderWorkspace
+ * @property {unknown} tabManager             - Reference for BoardView/FlowView ctor args
  */
 
 /**

--- a/src/utils/tab-bar-renderer.js
+++ b/src/utils/tab-bar-renderer.js
@@ -5,21 +5,22 @@
  *
  * @typedef {Object} RenderTabBarDeps
  * @property {HTMLElement} tabBar
- * @property {Map<string, Object>} tabs
+ * @property {Map<string, import('./tab-manager-helpers.js').WorkspaceTab>} tabs
  * @property {string|null} activeTabId
  * @property {string|null} activeColorFilter
  * @property {Set<string>} excludedColors
- * @property {Function} switchTo         - (id) => void
- * @property {Function} closeTab         - (id) => void
- * @property {Function} renameTab        - (id, nameEl) => void
- * @property {Function} setTabColorGroup - (id, colorGroupId) => void
- * @property {Function} toggleNoShortcut - (id) => void
- * @property {Function} setColorFilter   - (colorGroupId) => void
- * @property {Function} toggleExcludeColor - (colorGroupId) => void
- * @property {Function} createTab        - () => void
- * @property {Function} reorderTab       - (fromId, toId, before) => void
- * @property {Function} isTabVisible     - (tab) => boolean
- * @property {Function} renderTabBar     - () => void   — for callbacks that re-render
+ * @property {(id: string) => void} switchTo
+ * @property {(id: string) => void} closeTab
+ * @property {(id: string, nameEl: HTMLElement) => void} renameTab
+ * @property {(id: string, colorGroupId: string|null) => void} setTabColorGroup
+ * @property {(id: string) => void} toggleNoShortcut
+ * @property {(colorGroupId: string) => void} setColorFilter
+ * @property {(colorGroupId: string) => void} toggleExcludeColor
+ * @property {() => void} createTab
+ * @property {(fromId: string, toId: string, before: boolean) => void} reorderTab
+ * @property {(tab: import('./tab-manager-helpers.js').WorkspaceTab) => boolean} isTabVisible
+ * @property {() => void} renderTabBar     - for callbacks that re-render
+ * @property {() => void} clearColorFilters
  */
 
 import { _el } from './dom.js';

--- a/src/utils/tab-drag.js
+++ b/src/utils/tab-drag.js
@@ -6,8 +6,8 @@
  * reading / writing shared state through an explicit dependency interface.
  *
  * @typedef {Object} TabDragDeps
- * @property {Function} getTabElements  - () => Map<tabId, HTMLElement> — live tab DOM elements
- * @property {Function} reorderTab      - (fromId, toId, before) => void — commit the reorder
+ * @property {() => Map<string, HTMLElement>} getTabElements  - live tab DOM elements
+ * @property {(fromId: string, toId: string, before: boolean) => void} reorderTab - commit the reorder
  */
 
 import { DRAG_THRESHOLD } from './tab-manager-helpers.js';
@@ -16,7 +16,7 @@ import { DRAG_THRESHOLD } from './tab-manager-helpers.js';
 
 /**
  * Reset CSS transforms on every tab element.
- * @param {Function} getTabElements - () => Map<tabId, HTMLElement>
+ * @param {() => Map<string, HTMLElement>} getTabElements
  */
 function clearTabShifts(getTabElements) {
   for (const [, el] of getTabElements()) {
@@ -29,7 +29,7 @@ function clearTabShifts(getTabElements) {
  * Determine where the dragged tab should be inserted based on cursor
  * position relative to tab midpoints.
  *
- * @param {Function} getTabElements - () => Map<tabId, HTMLElement>
+ * @param {() => Map<string, HTMLElement>} getTabElements
  * @param {number} mx
  * @param {string[]} orderedIds
  * @param {string} dragId
@@ -72,7 +72,7 @@ function computeDropPosition(getTabElements, mx, orderedIds, dragId) {
  * Shift surrounding tabs with CSS transforms to open a visual gap at the
  * computed insertion position.
  *
- * @param {Function} getTabElements - () => Map<tabId, HTMLElement>
+ * @param {() => Map<string, HTMLElement>} getTabElements
  * @param {string[]} orderedIds
  * @param {number} dragIdx
  * @param {number} insertIdx
@@ -102,8 +102,8 @@ function renderDropIndicator(getTabElements, orderedIds, dragIdx, insertIdx, shi
  * While dragging, determine which tab the cursor is over and shift
  * surrounding tabs to open a visual gap.
  *
- * @param {Function} getTabElements - () => Map<tabId, HTMLElement>
- * @param {Object} state
+ * @param {() => Map<string, HTMLElement>} getTabElements
+ * @param {{ dropTargetId: string|null, dropBefore: boolean }} state
  * @param {number} mx
  * @param {string} dragId
  */
@@ -158,7 +158,7 @@ function handleDragStart(tabEl) {
  * @param {TabDragDeps} deps
  * @param {HTMLElement} tabEl
  * @param {HTMLElement|null} ghost
- * @param {Object} state
+ * @param {{ dropTargetId: string|null, dropBefore: boolean|null }} state
  * @param {string} tabId
  */
 function handleDragEnd({ getTabElements, reorderTab }, tabEl, ghost, state, tabId) {

--- a/src/utils/tab-lifecycle.js
+++ b/src/utils/tab-lifecycle.js
@@ -12,26 +12,26 @@
  * @property {Map<string, WorkspaceTab>} tabs
  * @property {string} defaultCwd
  * @property {string|null} activeColorFilter
- * @property {Function} renderTabBar
- * @property {{ scheduleAutoSave: Function }} configManager
+ * @property {() => void} renderTabBar
+ * @property {{ scheduleAutoSave: () => void }} configManager
  *
  * @typedef {Object} CloseTabDeps
  * @property {Map<string, WorkspaceTab>} tabs
  * @property {string|null} activeTabId
- * @property {Function} renderTabBar
- * @property {{ scheduleAutoSave: Function }} configManager
+ * @property {() => void} renderTabBar
+ * @property {{ scheduleAutoSave: () => void }} configManager
  *
  * @typedef {Object} SwitchToDeps
  * @property {Map<string, WorkspaceTab>} tabs
- * @property {Function} getActiveTabId         - () => string|null
- * @property {Function} setActiveTabId         - (id) => void
- * @property {Function} getSidebarMode         - () => string
- * @property {Function} setSidebarMode         - (mode) => void
+ * @property {() => string|null} getActiveTabId
+ * @property {(id: string) => void} setActiveTabId
+ * @property {() => string} getSidebarMode
+ * @property {(mode: string) => void} setSidebarMode
  * @property {HTMLElement} workspaceContainer
- * @property {Function} renderTabBar
- * @property {Function} renderActivityBar
- * @property {Function} renderWorkspace
- * @property {Function} detachSidebarView      - (mode) => void
+ * @property {() => void} renderTabBar
+ * @property {() => void} renderActivityBar
+ * @property {(tab: WorkspaceTab) => void} renderWorkspace
+ * @property {(mode: string) => void} detachSidebarView
  */
 
 import { generateId } from './id.js';
@@ -47,7 +47,7 @@ import {
 /**
  * Create a new tab and switch to it.
  * @param {CreateTabDeps} deps
- * @param {Function} switchToFn  - Function to switch to a tab by id
+ * @param {(id: string) => void} switchToFn  - Function to switch to a tab by id
  * @param {string|null} name     - Optional tab name
  * @param {string|null} cwd      - Optional working directory
  * @returns {WorkspaceTab}
@@ -69,8 +69,8 @@ export function createTab(deps, switchToFn, name = null, cwd = null) {
 /**
  * Close a tab by id, prompting the user for confirmation.
  * @param {CloseTabDeps} deps
- * @param {Function} createTabFn  - Function to create a new tab (when closing last)
- * @param {Function} switchToFn   - Function to switch to a tab by id
+ * @param {() => WorkspaceTab} createTabFn  - Function to create a new tab (when closing last)
+ * @param {(id: string) => void} switchToFn   - Function to switch to a tab by id
  * @param {string} id             - Tab id to close
  */
 export async function closeTab(deps, createTabFn, switchToFn, id) {
@@ -191,7 +191,7 @@ export function findTabForTerminal(tabs, termId) {
  * @param {string|null} activeTabId
  * @param {string} termId  - Terminal id that changed
  * @param {string} cwd     - New working directory
- * @param {{ gitBranch: Function }} api - injected API methods
+ * @param {{ gitBranch: (cwd: string) => Promise<string|null> }} api - injected API methods
  */
 export function onTerminalCwdChanged(tabs, activeTabId, termId, cwd, { gitBranch }) {
   const match = findTabForTerminal(tabs, termId);

--- a/src/utils/tab-renderer.js
+++ b/src/utils/tab-renderer.js
@@ -7,12 +7,12 @@
  *
  * @typedef {Object} TabElementDeps
  * @property {string|null} activeTabId            - Currently active tab id
- * @property {Map<string, Object>} tabs           - Tab map (used for .size)
- * @property {Function} switchTo                  - (id) => void
- * @property {Function} closeTab                  - (id) => void
- * @property {Function} renameTab                 - (id, nameEl) => void
- * @property {Function} setTabColorGroup          - (id, colorGroupId) => void
- * @property {Function} toggleNoShortcut          - (id) => void
+ * @property {Map<string, import('./tab-manager-helpers.js').WorkspaceTab>} tabs - Tab map (used for .size)
+ * @property {(id: string) => void} switchTo
+ * @property {(id: string) => void} closeTab
+ * @property {(id: string, nameEl: HTMLElement) => void} renameTab
+ * @property {(id: string, colorGroupId: string|null) => void} setTabColorGroup
+ * @property {(id: string) => void} toggleNoShortcut
  * @property {import('./tab-drag.js').TabDragDeps} dragDeps - Dependencies for tab drag
  */
 import { _el, setupInlineInput } from './dom.js';
@@ -24,7 +24,7 @@ import { attachContextMenu } from './context-menu.js';
  * Build a single tab DOM element.
  * @param {TabElementDeps} deps
  * @param {string} id
- * @param {Object} tab
+ * @param {import('./tab-manager-helpers.js').WorkspaceTab} tab
  */
 export function buildTabElement(deps, id, tab) {
   const tabEl = _el('div', 'tab');
@@ -67,7 +67,7 @@ export function buildTabElement(deps, id, tab) {
  * @param {TabElementDeps} deps
  * @param {HTMLElement} tabEl
  * @param {string} id
- * @param {Object} tab
+ * @param {import('./tab-manager-helpers.js').WorkspaceTab} tab
  * @param {HTMLElement} nameEl
  */
 export function bindTabContextMenu(deps, tabEl, id, tab, nameEl) {
@@ -96,10 +96,10 @@ export function bindTabContextMenu(deps, tabEl, id, tab, nameEl) {
 
 /**
  * Inline rename a tab.
- * @param {Object} tab
+ * @param {import('./tab-manager-helpers.js').WorkspaceTab} tab
  * @param {HTMLElement} nameEl
- * @param {function} onCommit - callback after successful rename (re-render + save)
- * @param {function} onCancel - callback on cancel (re-render only, no save)
+ * @param {() => void} onCommit - callback after successful rename (re-render + save)
+ * @param {() => void} onCancel - callback on cancel (re-render only, no save)
  */
 export function inlineRenameTab(tab, nameEl, onCommit, onCancel) {
   const input = _el('input', { className: 'tab-rename-input', value: tab.name });

--- a/src/utils/terminal-split.js
+++ b/src/utils/terminal-split.js
@@ -15,10 +15,7 @@ import { detachElement, moveToCenter, insertIntoSplit, wrapInNewSplit } from './
  * @param {string} targetId
  * @param {string} side - 'center'|'left'|'right'|'top'|'bottom'
  * @param {Map<string, SplitNode>} terminals
- * @param {Object} callbacks
- * @param {Function} callbacks.createSplitHandle - (direction, splitEl) => HTMLElement
- * @param {Function} callbacks.fitAll - () => void
- * @param {Function} callbacks.setActive - (node) => void
+ * @param {{ createSplitHandle: (direction: string, splitEl: HTMLElement) => HTMLElement, fitAll: () => void, setActive: (node: SplitNode) => void }} callbacks
  */
 export function moveTerminal(sourceId, targetId, side, terminals, { createSplitHandle, fitAll, setActive }) {
   const sourceNode = terminals.get(sourceId);
@@ -60,15 +57,8 @@ export function moveTerminal(sourceId, targetId, side, terminals, { createSplitH
  *
  * @param {SplitNode} targetNode
  * @param {string} direction - 'horizontal'|'vertical'
- * @param {Object} state - mutable panel state
- * @param {string} state.cwd - default working directory
- * @param {SplitNode|null} state.root - root split node (may be updated)
- * @param {Object} callbacks
- * @param {Function} callbacks.createTerminalNode - (cwd) => SplitNode
- * @param {Function} callbacks.createSplitHandle - (direction, splitEl) => HTMLElement
- * @param {Function} callbacks.fitAll - () => void
- * @param {Function} callbacks.setActive - (node) => void
- * @param {Function} callbacks.setRoot - (node) => void
+ * @param {{ cwd: string, root: SplitNode|null }} state - mutable panel state
+ * @param {{ createTerminalNode: (cwd: string) => SplitNode, createSplitHandle: (direction: string, splitEl: HTMLElement) => HTMLElement, fitAll: () => void, setActive: (node: SplitNode) => void, setRoot: (node: SplitNode) => void }} callbacks
  */
 export function splitTerminal(targetNode, direction, state, { createTerminalNode, createSplitHandle, fitAll, setActive, setRoot }) {
   const parentEl = targetNode.element.parentElement;
@@ -107,7 +97,7 @@ export function splitTerminal(targetNode, direction, state, { createTerminalNode
  * @param {SplitNode} activeTerminal
  * @param {Map<string, SplitNode>} terminals
  * @param {string} dir - 'left'|'right'|'up'|'down'
- * @param {Function} setActive - (node) => void
+ * @param {(node: SplitNode) => void} setActive
  */
 export function focusDirection(activeTerminal, terminals, dir, setActive) {
   if (!activeTerminal || terminals.size < 2) return;


### PR DESCRIPTION
## Refactoring

Replaced loose JSDoc types (`{Object}`, `{Function}`, `{*}`) with precise inline types and function signatures across the 10 most affected files.

Partially addresses #110

### Changes per file

| File | Before | After |
|------|--------|-------|
| `src/utils/flow-card-setup.js` | 19 loose types | precise types |
| `src/utils/sidebar-manager.js` | 19 loose types | precise types |
| `src/utils/tab-lifecycle.js` | 16 loose types | precise types |
| `src/utils/tab-bar-renderer.js` | 12 loose types | precise types |
| `src/utils/terminal-split.js` | 12 loose types | precise types |
| `src/utils/file-tree-renderer.js` | 11 loose types | precise types |
| `src/utils/file-viewer-tabs.js` | 10 loose types | precise types |
| `main/aggregation-utils.js` | 9 loose types | precise types |
| `src/utils/tab-renderer.js` | 9 loose types | precise types |
| `src/utils/tab-drag.js` | 8 loose types | precise types |

### Type replacements applied

- `{Object}` -> precise inline shapes (e.g. `{{ name: string, path: string }}`) or `Record<K, V>` or referenced `@typedef`
- `{Function}` -> explicit function signatures (e.g. `{(id: string) => void}`)
- `{*}` -> `{unknown}` or the actual type when determinable
- `{Array}` -> `{Array<unknown>}` or specific element types

## Verifications

- [x] Build OK (`npm run build`)
- [x] Tests OK (319/319 passing)