### PR TITLE
refactor: unify button creation patterns in settings-configs

### DIFF
--- a/src/components/settings-configs.js
+++ b/src/components/settings-configs.js
@@ -2,7 +2,7 @@
  * Workspace Configs section renderer for SettingsModal.
  * Extracted from settings-modal.js to reduce component size.
  */
-import { _el, createButton } from '../utils/dom.js';
+import { _el, renderButtonBar } from '../utils/dom.js';
 import { CONFIG_ACTIONS, BOTTOM_CONFIG_BUTTONS, formatConfigMeta } from '../utils/settings-helpers.js';
 import { createSettingsSection } from '../utils/settings-section-builder.js';
 import { registerComponent } from '../utils/component-registry.js';
@@ -19,12 +19,10 @@ function _createConfigActions(config, tabManager, renderConfigsFn) {
     delete: async (e) => { e.stopPropagation(); await window.api.config.delete(config.name); renderConfigsFn(); },
   };
 
-  const actions = _el('div', 'config-actions');
-  for (const desc of CONFIG_ACTIONS) {
-    if (desc.hideWhen && config[desc.hideWhen]) continue;
-    actions.appendChild(createButton({ ...desc, className: desc.cls, onClick: handlers[desc.action] }));
-  }
-  return actions;
+  const configs = CONFIG_ACTIONS
+    .filter(desc => !(desc.hideWhen && config[desc.hideWhen]))
+    .map(desc => ({ ...desc, className: desc.cls }));
+  return renderButtonBar({ containerClass: 'config-actions', configs, handlers });
 }
 
 function _buildConfigRowLeft(config) {
@@ -78,11 +76,8 @@ function _createBottomActions(currentName, tabManager, renderConfigsFn) {
       });
     },
   };
-  const container = _el('div', 'config-bottom-actions');
-  for (const { label, action } of BOTTOM_CONFIG_BUTTONS) {
-    container.appendChild(createButton({ label, className: 'config-bottom-btn', onClick: handlers[action] }));
-  }
-  return container;
+  const configs = BOTTOM_CONFIG_BUTTONS.map(({ label, action }) => ({ label, action, className: 'config-bottom-btn' }));
+  return renderButtonBar({ containerClass: 'config-bottom-actions', configs, handlers });
 }
 
 /**


### PR DESCRIPTION
## Refactoring

Conversion des 2 dernières boucles manuelles de création de boutons dans `settings-configs.js` pour utiliser `renderButtonBar` de `dom.js`.

Les 4 variantes locales de `createButton` avaient déjà été supprimées dans des PRs précédentes. Ce changement finalise l'unification en éliminant les derniers patterns manuels.

### Changements
- `_createConfigActions()` : boucle `for...of` → `renderButtonBar()`
- `_createBottomActions()` : boucle `for...of` → `renderButtonBar()`
- Import mis à jour : `createButton` → `renderButtonBar`

Closes #112

## Fichier(s) modifié(s)

- `src/components/settings-configs.js`

## Vérifications

- [x] Build OK
- [x] Tests OK (319 tests, 21 fichiers)

---

📂 Path local : `/Users/rekta/projet/coding/refactor-pikagent`
🤖 PR créée automatiquement par l'Agent Refactor