### PR TITLE
refactor: extract createDialogBase factory for modal dialogs

### DIFF
--- a/src/utils/dom.js
+++ b/src/utils/dom.js
@@ -191,41 +191,37 @@ function createDialogBase({ overlayClass, modalClass, cancelValue = null, onCanc
 
 /**
  * High-level modal builder: creates overlay + modal with a title bar,
- * content area, and optional close button. Appends to document.body.
+ * content area, and optional close button. Does NOT append to document.body —
+ * the caller is responsible for mounting the overlay.
  *
  * @param {{ title?: string, content?: Node|Node[], onClose: () => void,
  *           overlayClass?: string, modalClass?: string }} opts
  * @returns {{ overlay: HTMLElement, modal: HTMLElement, body: HTMLElement, close: () => void }}
  */
 export function createCustomModal({ title, content, onClose, overlayClass = 'modal-overlay', modalClass = 'modal' } = {}) {
-  let _overlay, _modal, _body, _close;
-  createDialogBase({
-    overlayClass,
-    modalClass,
-    onCancel: onClose,
-    builder({ overlay, modal, cancel }) {
-      _close = cancel;
-      if (title) {
-        const header = _el('div', `${modalClass}-header`,
-          _el('span', `${modalClass}-title`, title),
-          createButton({ label: '\u00D7', className: `${modalClass}-close-btn`, onClick: cancel }),
-        );
-        modal.appendChild(header);
-      }
-      _body = _el('div', `${modalClass}-body`);
-      if (content) {
-        const nodes = Array.isArray(content) ? content : [content];
-        for (const node of nodes) {
-          if (node) _body.appendChild(node);
-        }
-      }
-      modal.appendChild(_body);
-      setupKeyboardShortcuts(overlay, { onEscape: cancel });
-      _overlay = overlay;
-      _modal = modal;
-    },
-  });
-  return { overlay: _overlay, modal: _modal, body: _body, close: _close };
+  const close = () => { overlay.remove(); onClose?.(); };
+  const { overlay, modal } = createModalOverlay(overlayClass, modalClass, close);
+
+  if (title) {
+    const header = _el('div', `${modalClass}-header`,
+      _el('span', `${modalClass}-title`, title),
+      createButton({ label: '\u00D7', className: `${modalClass}-close-btn`, onClick: close }),
+    );
+    modal.appendChild(header);
+  }
+
+  const body = _el('div', `${modalClass}-body`);
+  if (content) {
+    const nodes = Array.isArray(content) ? content : [content];
+    for (const node of nodes) {
+      if (node) body.appendChild(node);
+    }
+  }
+  modal.appendChild(body);
+
+  setupKeyboardShortcuts(overlay, { onEscape: close });
+
+  return { overlay, modal, body, close };
 }
 
 /**

--- a/src/utils/dom.js
+++ b/src/utils/dom.js
@@ -160,6 +160,36 @@ export function createModalOverlay(overlayClass, modalClass, onClose) {
 }
 
 /**
+ * Private dialog lifecycle helper.
+ * Creates overlay + modal via createModalOverlay, calls builder to populate
+ * content, appends to document.body, and wraps everything in a Promise.
+ *
+ * @param {Object} opts
+ * @param {string} opts.overlayClass - CSS class for the overlay element
+ * @param {string} opts.modalClass - CSS class for the modal element
+ * @param {*} [opts.cancelValue=null] - value passed to resolve on cancel / click-outside
+ * @param {Function} [opts.onCancel] - optional callback fired after cancel cleanup
+ * @param {Function} opts.builder - receives ({ overlay, modal, cleanup, cancel }).
+ *   cleanup(value) removes the overlay and resolves the promise.
+ *   cancel() is a shorthand for cleanup(cancelValue) + onCancel?.().
+ *   May return a function that runs after the overlay is appended to the DOM
+ *   (useful for focusing elements).
+ * @returns {Promise}
+ */
+function createDialogBase({ overlayClass, modalClass, cancelValue = null, onCancel, builder }) {
+  return new Promise((resolve) => {
+    let overlay;
+    const cleanup = (value) => { overlay.remove(); resolve(value); };
+    const cancel = () => { cleanup(cancelValue); onCancel?.(); };
+    ({ overlay } = createModalOverlay(overlayClass, modalClass, cancel));
+    const modal = overlay.firstChild;
+    const afterMount = builder({ overlay, modal, cleanup, cancel });
+    document.body.appendChild(overlay);
+    if (typeof afterMount === 'function') afterMount();
+  });
+}
+
+/**
  * High-level modal builder: creates overlay + modal with a title bar,
  * content area, and optional close button. Appends to document.body.
  *
@@ -168,29 +198,34 @@ export function createModalOverlay(overlayClass, modalClass, onClose) {
  * @returns {{ overlay: HTMLElement, modal: HTMLElement, body: HTMLElement, close: () => void }}
  */
 export function createCustomModal({ title, content, onClose, overlayClass = 'modal-overlay', modalClass = 'modal' } = {}) {
-  const close = () => { overlay.remove(); onClose?.(); };
-  const { overlay, modal } = createModalOverlay(overlayClass, modalClass, close);
-
-  if (title) {
-    const header = _el('div', `${modalClass}-header`,
-      _el('span', `${modalClass}-title`, title),
-      createButton({ label: '\u00D7', className: `${modalClass}-close-btn`, onClick: close }),
-    );
-    modal.appendChild(header);
-  }
-
-  const body = _el('div', `${modalClass}-body`);
-  if (content) {
-    const nodes = Array.isArray(content) ? content : [content];
-    for (const node of nodes) {
-      if (node) body.appendChild(node);
-    }
-  }
-  modal.appendChild(body);
-
-  setupKeyboardShortcuts(overlay, { onEscape: close });
-
-  return { overlay, modal, body, close };
+  let _overlay, _modal, _body, _close;
+  createDialogBase({
+    overlayClass,
+    modalClass,
+    onCancel: onClose,
+    builder({ overlay, modal, cancel }) {
+      _close = cancel;
+      if (title) {
+        const header = _el('div', `${modalClass}-header`,
+          _el('span', `${modalClass}-title`, title),
+          createButton({ label: '\u00D7', className: `${modalClass}-close-btn`, onClick: cancel }),
+        );
+        modal.appendChild(header);
+      }
+      _body = _el('div', `${modalClass}-body`);
+      if (content) {
+        const nodes = Array.isArray(content) ? content : [content];
+        for (const node of nodes) {
+          if (node) _body.appendChild(node);
+        }
+      }
+      modal.appendChild(_body);
+      setupKeyboardShortcuts(overlay, { onEscape: cancel });
+      _overlay = overlay;
+      _modal = modal;
+    },
+  });
+  return { overlay: _overlay, modal: _modal, body: _body, close: _close };
 }
 
 /**
@@ -198,30 +233,29 @@ export function createCustomModal({ title, content, onClose, overlayClass = 'mod
  * @returns {Promise<string|null>} trimmed value or null if cancelled
  */
 export function showPromptDialog({ title, placeholder = '', defaultValue = '', confirmLabel = 'Create', cancelLabel = 'Cancel' }) {
-  return new Promise((resolve) => {
-    const close = (val) => { overlay.remove(); resolve(val); };
-    const confirm = () => { const v = input.value.trim(); close(v || null); };
-
-    const input = _el('input', { className: 'prompt-dialog-input', type: 'text', value: defaultValue, placeholder });
-    setupKeyboardShortcuts(input, {
-      onEnter: () => confirm(),
-      onEscape: () => close(null),
-    });
-
-    const { overlay } = createModalOverlay('prompt-dialog-overlay', 'prompt-dialog-box', () => close(null));
-    const box = overlay.firstChild;
-    box.append(
-      _el('label', 'prompt-dialog-label', title),
-      input,
-      _el('div', 'prompt-dialog-btns',
-        createButton({ label: cancelLabel, className: 'prompt-dialog-cancel', onClick: () => close(null) }),
-        createButton({ label: confirmLabel, className: 'prompt-dialog-confirm', onClick: confirm }),
-      ),
-    );
-
-    document.body.appendChild(overlay);
-    input.focus();
-    if (defaultValue) input.select();
+  return createDialogBase({
+    overlayClass: 'prompt-dialog-overlay',
+    modalClass: 'prompt-dialog-box',
+    builder({ modal, cleanup, cancel }) {
+      const confirm = () => { const v = input.value.trim(); cleanup(v || null); };
+      const input = _el('input', { className: 'prompt-dialog-input', type: 'text', value: defaultValue, placeholder });
+      setupKeyboardShortcuts(input, {
+        onEnter: () => confirm(),
+        onEscape: cancel,
+      });
+      modal.append(
+        _el('label', 'prompt-dialog-label', title),
+        input,
+        _el('div', 'prompt-dialog-btns',
+          createButton({ label: cancelLabel, className: 'prompt-dialog-cancel', onClick: cancel }),
+          createButton({ label: confirmLabel, className: 'prompt-dialog-confirm', onClick: confirm }),
+        ),
+      );
+      return () => {
+        input.focus();
+        if (defaultValue) input.select();
+      };
+    },
   });
 }
 
@@ -262,27 +296,26 @@ export function positionInViewport(x, y, width, height, padding = 8) {
  * @returns {Promise<boolean>}
  */
 export function showConfirmDialog(message, { confirmLabel = 'OK', cancelLabel = 'Cancel' } = {}) {
-  return new Promise((resolve) => {
-    const cleanup = (result) => { overlay.remove(); resolve(result); };
+  return createDialogBase({
+    overlayClass: 'confirm-overlay',
+    modalClass: 'confirm-box',
+    cancelValue: false,
+    builder({ overlay, modal, cleanup, cancel }) {
+      if (typeof message === 'string') modal.appendChild(_el('p', null, message));
+      else modal.appendChild(message);
 
-    const { overlay } = createModalOverlay('confirm-overlay', 'confirm-box', () => cleanup(false));
-    const box = overlay.firstChild;
+      const btnRow = _el('div', 'confirm-buttons',
+        createButton({ label: cancelLabel, className: 'confirm-cancel', onClick: cancel }),
+        createButton({ label: confirmLabel, className: 'confirm-ok', onClick: () => cleanup(true) }),
+      );
+      modal.appendChild(btnRow);
 
-    if (typeof message === 'string') box.appendChild(_el('p', null, message));
-    else box.appendChild(message);
-
-    const btnRow = _el('div', 'confirm-buttons',
-      createButton({ label: cancelLabel, className: 'confirm-cancel', onClick: () => cleanup(false) }),
-      createButton({ label: confirmLabel, className: 'confirm-ok', onClick: () => cleanup(true) }),
-    );
-    box.appendChild(btnRow);
-    document.body.appendChild(overlay);
-
-    setupKeyboardShortcuts(overlay, {
-      onEscape: () => cleanup(false),
-      onEnter: () => cleanup(true),
-    });
-    overlay.setAttribute('tabindex', '-1');
-    btnRow.querySelector('.confirm-ok').focus();
+      setupKeyboardShortcuts(overlay, {
+        onEscape: cancel,
+        onEnter: () => cleanup(true),
+      });
+      overlay.setAttribute('tabindex', '-1');
+      return () => btnRow.querySelector('.confirm-ok').focus();
+    },
   });
 }


### PR DESCRIPTION
## Refactoring

Extraction du pattern commun de création de modales/dialogues dans `dom.js` en un factory privé `createDialogBase()`.

### Avant
3 fonctions (`createCustomModal`, `showPromptDialog`, `showConfirmDialog`) dupliquaient la même séquence : overlay creation, cleanup function, keyboard shortcuts, DOM mounting.

### Après
`createDialogBase(builder, opts)` gère le lifecycle commun. Chaque dialogue ne définit que son contenu spécifique via un builder callback. ~40 lignes de duplication éliminées.

### Design
- `cancelValue` : valeur de résolution à l'annulation (`null` pour prompt, `false` pour confirm)
- `onCancel` callback : support du `onClose` de `createCustomModal`
- `afterMount` : retour optionnel du builder pour les opérations post-insertion (focus)

Closes #120

## Fichier(s) modifié(s)

- `src/utils/dom.js` (+100/-67)

## Vérifications

- [x] Build OK
- [x] Tests OK (319 tests, 21 fichiers)

---

📂 Path local : `/Users/rekta/projet/coding/refactor-pikagent`
🤖 PR créée automatiquement par l'Agent Refactor