### PR TITLE
refactor: unify tab and row element creation (3 files)

### DIFF
--- a/src/utils/dom.js
+++ b/src/utils/dom.js
@@ -226,6 +226,21 @@ export function showPromptDialog({ title, placeholder = '', defaultValue = '', c
 }
 
 /**
+ * Build a row containing a chevron span and a name span.
+ *
+ * Used by file-tree rows and flow-category headers — any place that needs
+ * the common "chevron + label" pattern.
+ *
+ * @param {{ chevronClass: string, nameClass: string, name: string, chevronText?: string }} opts
+ * @returns {{ chevron: HTMLElement, name: HTMLElement }}
+ */
+export function buildChevronRow(opts) {
+  const chevron = _el('span', { className: opts.chevronClass, textContent: opts.chevronText || '' });
+  const name = _el('span', { className: opts.nameClass, textContent: opts.name });
+  return { chevron, name };
+}
+
+/**
  * Clamp (x, y) so a box of (width, height) stays within the viewport.
  * @param {number} x
  * @param {number} y

--- a/src/utils/file-tree-renderer.js
+++ b/src/utils/file-tree-renderer.js
@@ -4,7 +4,7 @@
  */
 
 import { bus, EVENTS } from './events.js';
-import { _el } from './dom.js';
+import { _el, buildChevronRow } from './dom.js';
 import { computeIndent, CHEVRON_EXPANDED, CHEVRON_COLLAPSED, SVG_ICONS } from './file-tree-helpers.js';
 import { buildFileContextItems, buildDirContextItems } from './file-tree-context-menu.js';
 import { attachContextMenu } from './context-menu.js';
@@ -29,8 +29,11 @@ export const PARSED_ICONS = Object.fromEntries(
  * @returns {{ row: HTMLElement, chevron: HTMLElement, name: HTMLElement }}
  */
 export function buildRow(entry, depth) {
-  const chevron = _el('span', { className: 'file-tree-chevron' });
-  const name = _el('span', { className: 'file-tree-name', textContent: entry.name });
+  const { chevron, name } = buildChevronRow({
+    chevronClass: 'file-tree-chevron',
+    nameClass: 'file-tree-name',
+    name: entry.name,
+  });
   const row = _el('div', {
     className: 'file-tree-item',
     style: { paddingLeft: `${computeIndent(depth)}px` },

--- a/src/utils/file-viewer-tabs.js
+++ b/src/utils/file-viewer-tabs.js
@@ -5,6 +5,7 @@
 
 import { _el } from './dom.js';
 import { attachContextMenu } from './context-menu.js';
+import { createTabElement } from './tab-renderer.js';
 
 /**
  * Build a single tab element for the given file path.
@@ -18,28 +19,31 @@ import { attachContextMenu } from './context-menu.js';
  * @returns {HTMLElement}
  */
 export function createTabEl(filePath, file, activeFile, isPinned, isModified, { onClose, onActivate, onTogglePin }) {
-  const tab = _el('div', 'file-tab');
-  if (filePath === activeFile) tab.classList.add('active');
-
   const pinned = isPinned(filePath);
   const modified = isModified(filePath);
 
-  if (pinned) tab.appendChild(_el('span', 'file-tab-pin', '\u{1F4CC}'));
-  tab.appendChild(_el('span', 'file-tab-modified', modified ? '\u25CF' : ''));
-  tab.appendChild(_el('span', null, file.name));
+  // Build prefix elements: optional pin icon + modified indicator
+  const prefixEls = [];
+  if (pinned) prefixEls.push(_el('span', 'file-tab-pin', '\u{1F4CC}'));
+  prefixEls.push(_el('span', 'file-tab-modified', modified ? '\u25CF' : ''));
 
-  const close = _el('span', 'file-tab-close', '\u00D7');
-  close.addEventListener('click', (e) => { e.stopPropagation(); onClose(filePath); });
-  tab.appendChild(close);
+  const { tabEl } = createTabElement({
+    className: 'file-tab',
+    isActive: filePath === activeFile,
+    name: file.name,
+    prefixEls,
+    close: { text: '\u00D7', className: 'file-tab-close', onClick: () => onClose(filePath) },
+    onClick: () => onActivate(filePath),
+    setup: (el) => {
+      attachContextMenu(el, () => [
+        { label: pinned ? 'Unpin from all workspaces' : 'Pin across workspaces', action: () => onTogglePin(filePath) },
+        { separator: true },
+        { label: 'Close', action: () => onClose(filePath) },
+      ]);
+    },
+  });
 
-  tab.addEventListener('click', () => onActivate(filePath));
-  attachContextMenu(tab, () => [
-    { label: pinned ? 'Unpin from all workspaces' : 'Pin across workspaces', action: () => onTogglePin(filePath) },
-    { separator: true },
-    { label: 'Close', action: () => onClose(filePath) },
-  ]);
-
-  return tab;
+  return tabEl;
 }
 
 /**

--- a/src/utils/flow-category-renderer.js
+++ b/src/utils/flow-category-renderer.js
@@ -3,7 +3,7 @@
  * Handles category headers, collapse state, and drag-drop zone setup.
  * Extracted from flow-view.js to reduce component size.
  */
-import { _el, renderButtonBar } from './dom.js';
+import { _el, renderButtonBar, buildChevronRow } from './dom.js';
 import { CATEGORY_ACTIONS, UNCATEGORIZED } from './flow-view-helpers.js';
 
 /**
@@ -56,8 +56,12 @@ export function createCategoryGroup(params) {
 function _buildCategoryHeader(cat, flows, isUncategorized, collapsedCategories, onToggleCollapse, onRenameCategory, onDeleteCategory) {
   const header = _el('div', 'flow-category-header');
 
-  const chevron = _el('span', 'flow-category-chevron', '▼');
-  const name = _el('span', 'flow-category-name', cat.name);
+  const { chevron, name } = buildChevronRow({
+    chevronClass: 'flow-category-chevron',
+    nameClass: 'flow-category-name',
+    name: cat.name,
+    chevronText: '▼',
+  });
   const count = _el('span', 'flow-category-count', `${flows.length}`);
   header.append(chevron, name, count);
 

--- a/src/utils/tab-renderer.js
+++ b/src/utils/tab-renderer.js
@@ -21,43 +21,111 @@ import { setupTabDrag } from './tab-drag.js';
 import { attachContextMenu } from './context-menu.js';
 
 /**
+ * Generic tab element factory.
+ *
+ * Both the workspace tab bar and the file-viewer tab bar share the same
+ * structural pattern: base element + optional prefix children + name +
+ * optional close button + click handler.  This factory captures that
+ * pattern while remaining fully configurable.
+ *
+ * @typedef {Object} TabConfig
+ * @property {string}            className     - CSS class for the root element (e.g. 'tab', 'file-tab')
+ * @property {boolean}           isActive      - Whether the tab should get the 'active' class
+ * @property {string}            name          - Display text for the name span
+ * @property {string}            [nameClass]   - CSS class for the name span (default: none)
+ * @property {string[]}          [extraClasses]- Additional CSS classes for the root element
+ * @property {HTMLElement[]}     [prefixEls]   - Elements inserted before the name span (e.g. color dot, pin icon)
+ * @property {{ text: string, className: string, onClick: (e: Event) => void }|null} [close] - Close button config (null to omit)
+ * @property {(tabEl: HTMLElement) => void}   onClick      - Click handler for the whole tab
+ * @property {(tabEl: HTMLElement, nameEl: HTMLElement) => void} [setup] - Post-creation hook (context menu, drag, etc.)
+ * @property {Object<string,string>}          [dataset]    - dataset entries to set on the root element
+ * @property {Object<string,string>}          [style]      - inline styles to set on the root element
+ *
+ * @param {TabConfig} config
+ * @returns {{ tabEl: HTMLElement, nameEl: HTMLElement }}
+ */
+export function createTabElement(config) {
+  const tabEl = _el('div', config.className);
+  if (config.isActive) tabEl.classList.add('active');
+  if (config.extraClasses) {
+    for (const cls of config.extraClasses) tabEl.classList.add(cls);
+  }
+  if (config.dataset) {
+    for (const [k, v] of Object.entries(config.dataset)) tabEl.dataset[k] = v;
+  }
+  if (config.style) {
+    Object.assign(tabEl.style, config.style);
+  }
+
+  if (config.prefixEls) {
+    for (const el of config.prefixEls) tabEl.appendChild(el);
+  }
+
+  const nameEl = _el('span', config.nameClass || null, config.name);
+  tabEl.appendChild(nameEl);
+
+  if (config.close) {
+    const closeEl = _el('span', config.close.className, config.close.text);
+    closeEl.addEventListener('click', (e) => {
+      e.stopPropagation();
+      config.close.onClick(e);
+    });
+    tabEl.appendChild(closeEl);
+  }
+
+  tabEl.addEventListener('click', () => config.onClick(tabEl));
+
+  if (config.setup) {
+    config.setup(tabEl, nameEl);
+  }
+
+  return { tabEl, nameEl };
+}
+
+/**
  * Build a single tab DOM element.
  * @param {TabElementDeps} deps
  * @param {string} id
  * @param {import('./tab-manager-helpers.js').WorkspaceTab} tab
  */
 export function buildTabElement(deps, id, tab) {
-  const tabEl = _el('div', 'tab');
-  tabEl.dataset.tabId = id;
-  if (id === deps.activeTabId) tabEl.classList.add('active');
-  if (tab.noShortcut) tabEl.classList.add('tab-no-shortcut');
+  const isActive = id === deps.activeTabId;
 
+  // Build optional prefix elements
+  const prefixEls = [];
+  let borderColor = '';
   if (tab.colorGroup) {
     const cg = COLOR_GROUPS.find((c) => c.id === tab.colorGroup);
     if (cg) {
       const dot = _el('span', 'tab-color-dot');
       dot.style.background = cg.color;
-      tabEl.appendChild(dot);
-      tabEl.style.borderBottomColor = id === deps.activeTabId ? cg.color : '';
+      prefixEls.push(dot);
+      if (isActive) borderColor = cg.color;
     }
   }
 
-  const nameEl = _el('span', 'tab-name', tab.name);
-  nameEl.addEventListener('dblclick', () => deps.renameTab(id, nameEl));
-  tabEl.appendChild(nameEl);
+  const extraClasses = [];
+  if (tab.noShortcut) extraClasses.push('tab-no-shortcut');
 
-  if (deps.tabs.size > 1) {
-    const closeEl = _el('span', 'tab-close', '\u00d7');
-    closeEl.addEventListener('click', (e) => {
-      e.stopPropagation();
-      deps.closeTab(id);
-    });
-    tabEl.appendChild(closeEl);
-  }
-
-  tabEl.addEventListener('click', () => deps.switchTo(id));
-  setupTabDrag(deps.dragDeps, tabEl, id);
-  bindTabContextMenu(deps, tabEl, id, tab, nameEl);
+  const { tabEl, nameEl } = createTabElement({
+    className: 'tab',
+    isActive,
+    name: tab.name,
+    nameClass: 'tab-name',
+    extraClasses,
+    prefixEls,
+    dataset: { tabId: id },
+    style: borderColor ? { borderBottomColor: borderColor } : undefined,
+    close: deps.tabs.size > 1
+      ? { text: '\u00d7', className: 'tab-close', onClick: () => deps.closeTab(id) }
+      : null,
+    onClick: () => deps.switchTo(id),
+    setup: (el, nEl) => {
+      nEl.addEventListener('dblclick', () => deps.renameTab(id, nEl));
+      setupTabDrag(deps.dragDeps, el, id);
+      bindTabContextMenu(deps, el, id, tab, nEl);
+    },
+  });
 
   return tabEl;
 }


### PR DESCRIPTION
## Refactoring

Unification de la création d'éléments tab et de lignes chevron+nom entre plusieurs composants.

### 1. Tab element factory
- Nouveau `createTabElement(config)` dans `tab-renderer.js` — factory générique pour tabs
- `buildTabElement()` (workspace tabs) délègue à `createTabElement()`
- `createTabEl()` dans `file-viewer-tabs.js` importe et utilise `createTabElement()`

### 2. Chevron row builder
- Nouveau `buildChevronRow()` dans `dom.js` — crée les spans chevron + nom
- `buildRow()` dans `file-tree-renderer.js` utilise `buildChevronRow()`
- `_buildCategoryHeader()` dans `flow-category-renderer.js` utilise `buildChevronRow()`

Closes #121

## Fichier(s) modifié(s)

- `src/utils/tab-renderer.js` (factory principal)
- `src/utils/file-viewer-tabs.js` (utilise le factory)
- `src/utils/dom.js` (nouveau helper `buildChevronRow`)
- `src/utils/file-tree-renderer.js` (utilise le helper)
- `src/utils/flow-category-renderer.js` (utilise le helper)

## Vérifications

- [x] Build OK
- [x] Tests OK (319 tests, 21 fichiers)

---

📂 Path local : `/Users/rekta/projet/coding/refactor-pikagent`
🤖 PR créée automatiquement par l'Agent Refactor