### PR TITLE
refactor: unify groupBy as wrapper of aggregateByKey

### DIFF
--- a/main/collection-helpers.js
+++ b/main/collection-helpers.js
@@ -2,19 +2,17 @@
  * Generic collection utilities shared across helper modules.
  */
 
+const { aggregateByKey } = require('./aggregation-utils');
+
 /**
  * Groups an array of items by a key function.
+ * Delegates to {@link aggregateByKey} with array-push accumulation.
  * @param {Array} items
  * @param {(item: unknown) => string} keyFn - Returns the grouping key for each item
  * @returns {Record<string, Array<unknown>>} map of key -> array of items
  */
 function groupBy(items, keyFn) {
-  const groups = {};
-  for (const item of items) {
-    const key = keyFn(item);
-    (groups[key] ||= []).push(item);
-  }
-  return groups;
+  return aggregateByKey(items, keyFn, () => [], (bucket, item) => bucket.push(item));
 }
 
 /**


### PR DESCRIPTION
## Refactoring

Unified `groupBy` (collection-helpers.js) to delegate to `aggregateByKey` (aggregation-utils.js), eliminating the duplication while maintaining backward compatibility.

Closes #128

## Fichier(s) modifié(s)

- `main/collection-helpers.js`

## Vérifications

- [x] Build OK
- [x] Tests OK

---

📂 Path local : `/Users/rekta/projet/coding/refactor-pikagent`
🤖 PR créée automatiquement par l'Agent Refactor