### PR TITLE
refactor: remove 6 unused exports (git-manager, fs-manager, events)

### DIFF
--- a/main/fs-manager.js
+++ b/main/fs-manager.js
@@ -104,6 +104,6 @@ module.exports = {
   homedir: getHomedir,
   unwatch: unwatchDir,
   // Original names (used internally and by ipc-handlers.js custom handlers)
-  readDirectory, readFile, writeFile, makeDir, copyEntry, copyFileTo,
-  renameEntry, getHomedir, watchDir, unwatchDir, cleanup,
+  readDirectory, readFile, writeFile, makeDir, copyFileTo,
+  getHomedir, watchDir, unwatchDir, cleanup,
 };

--- a/main/git-manager.js
+++ b/main/git-manager.js
@@ -67,6 +67,6 @@ module.exports = {
   remote: getRemoteUrl,
   localChanges: getLocalChanges,
   fileDiff: getFileDiff,
-  // Original names
-  getBranch, getRemoteUrl, getLocalChanges, getFileDiff,
+  // Original names (only getRemoteUrl still imported externally)
+  getRemoteUrl,
 };

--- a/src/utils/events.js
+++ b/src/utils/events.js
@@ -195,20 +195,6 @@ class EventBus {
 export const bus = new EventBus();
 
 /**
- * Type-checked emit — validates event name exists in catalog (dev-time only).
- * Prefer this over raw bus.emit() so that unknown events are caught early.
- *
- * @param {keyof typeof EVENT_CATALOG} event - must be a key in EVENT_CATALOG
- * @param {unknown} data - payload matching the catalog's documented shape
- */
-export function emitEvent(event, data) {
-  if (process.env.NODE_ENV !== 'production' && !EVENT_CATALOG[event]) {
-    console.warn(`[EventBus] Unknown event: "${event}" — register it in EVENT_CATALOG (src/utils/events.js)`);
-  }
-  bus.emit(event, data);
-}
-
-/**
  * Register an array of [event, handler] pairs on the bus.
  * Returns the array for later cleanup with unsubscribeBus().
  */


### PR DESCRIPTION
## Refactoring

Removed 6 dead exports that were never imported in production:
- `git-manager.js`: removed `getBranch`, `getLocalChanges`, `getFileDiff` from exports
- `fs-manager.js`: removed `copyEntry`, `renameEntry` aliases (kept `copy`, `rename`)
- `events.js`: removed unused `emitEvent` function

Closes #129

## Fichier(s) modifié(s)

- `main/git-manager.js`
- `main/fs-manager.js`
- `src/utils/events.js`

## Vérifications

- [x] Build OK
- [x] Tests OK

---

📂 Path local : `/Users/rekta/projet/coding/refactor-pikagent`
🤖 PR créée automatiquement par l'Agent Refactor