### PR TITLE
refactor: replace loose JSDoc types with precise types

### DIFF
--- a/src/utils/dom.js
+++ b/src/utils/dom.js
@@ -164,17 +164,17 @@ export function createModalOverlay(overlayClass, modalClass, onClose) {
  * Creates overlay + modal via createModalOverlay, calls builder to populate
  * content, appends to document.body, and wraps everything in a Promise.
  *
- * @param {Object} opts
+ * @param {{ overlayClass: string, modalClass: string, cancelValue?: unknown, onCancel?: () => void, builder: (ctx: { overlay: HTMLElement, modal: HTMLElement, cleanup: (value: unknown) => void, cancel: () => void }) => (() => void) | void }} opts
  * @param {string} opts.overlayClass - CSS class for the overlay element
  * @param {string} opts.modalClass - CSS class for the modal element
- * @param {*} [opts.cancelValue=null] - value passed to resolve on cancel / click-outside
- * @param {Function} [opts.onCancel] - optional callback fired after cancel cleanup
- * @param {Function} opts.builder - receives ({ overlay, modal, cleanup, cancel }).
+ * @param {unknown} [opts.cancelValue=null] - value passed to resolve on cancel / click-outside
+ * @param {() => void} [opts.onCancel] - optional callback fired after cancel cleanup
+ * @param {(ctx: { overlay: HTMLElement, modal: HTMLElement, cleanup: (value: unknown) => void, cancel: () => void }) => (() => void) | void} opts.builder - receives ({ overlay, modal, cleanup, cancel }).
  *   cleanup(value) removes the overlay and resolves the promise.
  *   cancel() is a shorthand for cleanup(cancelValue) + onCancel?.().
  *   May return a function that runs after the overlay is appended to the DOM
  *   (useful for focusing elements).
- * @returns {Promise}
+ * @returns {Promise<unknown>}
  */
 function createDialogBase({ overlayClass, modalClass, cancelValue = null, onCancel, builder }) {
   return new Promise((resolve) => {

--- a/src/utils/tab-renderer.js
+++ b/src/utils/tab-renderer.js
@@ -30,8 +30,8 @@ import { attachContextMenu } from './context-menu.js';
  * @property {{ text: string, className: string, onClick: (e: Event) => void }|null} [close] - Close button config (null to omit)
  * @property {(tabEl: HTMLElement) => void}   onClick      - Click handler for the whole tab
  * @property {(tabEl: HTMLElement, nameEl: HTMLElement) => void} [setup] - Post-creation hook (context menu, drag, etc.)
- * @property {Object<string,string>}          [dataset]    - dataset entries to set on the root element
- * @property {Object<string,string>}          [style]      - inline styles to set on the root element
+ * @property {Record<string,string>}          [dataset]    - dataset entries to set on the root element
+ * @property {Record<string,string>}          [style]      - inline styles to set on the root element
  *
  * @param {TabConfig} config
  * @returns {{ tabEl: HTMLElement, nameEl: HTMLElement }}


### PR DESCRIPTION
## Refactoring

Replaced remaining loose JSDoc types across 2 files:
- `{Object}` → inline object type with full property signatures
- `{Function}` → proper callback signatures `(args) => returnType`
- `{*}` → `{unknown}`
- `Object<string,string>` → `Record<string,string>`
- `{Promise}` → `{Promise<unknown>}`

JSDoc-only changes, no runtime modifications.

Closes #110

## Vérifications

- [x] Build OK
- [x] Tests OK (319/319 passed)

---

📂 Path local : `/Users/rekta/projet/coding/refactor-pikagent`
🤖 PR créée automatiquement par l'Agent Refactor