### PR TITLE
refactor: remove dead code and unused exports

### DIFF
--- a/shared/date-utils.js
+++ b/shared/date-utils.js
@@ -35,4 +35,4 @@ function formatDateTime(date, timestamp) {
   return `${date}${time ? ' ' + time : ''}`;
 }
 
-module.exports = { formatTime, formatDateTime };
+module.exports = { formatDateTime };

--- a/tests/main/date-utils.test.js
+++ b/tests/main/date-utils.test.js
@@ -1,6 +1,5 @@
 import { describe, it, expect } from 'vitest';
 const { extractDateString, generateDateRange, formatDateTime } = require('../../main/date-utils');
-const { formatTime } = require('../../shared/date-utils');
 
 describe('date-utils', () => {
   describe('extractDateString', () => {
@@ -46,21 +45,6 @@ describe('date-utils', () => {
       const range = generateDateRange(3);
       expect(range[0].date < range[1].date).toBe(true);
       expect(range[1].date < range[2].date).toBe(true);
-    });
-  });
-
-  describe('formatTime', () => {
-    it('formats a timestamp into a short time string', () => {
-      const result = formatTime(new Date('2025-03-15T14:32:00Z').getTime());
-      // The exact output depends on locale/TZ, but it should be a non-empty string
-      expect(typeof result).toBe('string');
-      expect(result.length).toBeGreaterThan(0);
-    });
-
-    it('returns empty string for falsy input', () => {
-      expect(formatTime(null)).toBe('');
-      expect(formatTime(0)).toBe('');
-      expect(formatTime('')).toBe('');
     });
   });
 


### PR DESCRIPTION
## Summary

- Removed `formatTime` from `shared/date-utils.js` exports (kept as internal function used by `formatDateTime`)
- Removed direct `formatTime` test from `tests/main/date-utils.test.js` (behavior covered via `formatDateTime` tests)
- Most items from issue #73 were already cleaned up in prior refactors (electron-handlers.js deleted, registerHandlers/dateStr/dayLabels removed, internal-only functions already not exported, EVENT_CATALOG/EventBus already private, COLOR_GROUPS re-export/LEFT_MAX_WIDTH/RIGHT_MAX_WIDTH/getFileIcon already gone)

Closes #73

## Verifications

- [x] Build OK (`npm run build`)
- [x] Tests OK (22 files, 317 tests passing)
- [x] Grep verified no remaining imports of removed export

---

PR created by Refactor Agent