### PR TITLE
refactor: extract shared setupDropZone helper

### DIFF
--- a/src/utils/dom.js
+++ b/src/utils/dom.js
@@ -200,5 +200,36 @@ export function positionInViewport(x, y, width, height, padding = 8) {
   };
 }
 
+/**
+ * Wire up dragover / dragleave / drop on an element.
+ *
+ * @param {HTMLElement} el
+ * @param {{ hoverClass?: string,
+ *           onDrop: (e: DragEvent) => void,
+ *           onDragOver?: (e: DragEvent) => void,
+ *           onDragLeave?: (e: DragEvent) => void,
+ *           accept?: (e: DragEvent) => boolean }} opts
+ */
+export function setupDropZone(el, { hoverClass = 'drag-over', onDrop, onDragOver, onDragLeave, accept }) {
+  el.addEventListener('dragover', (e) => {
+    if (accept && !accept(e)) return;
+    e.preventDefault();
+    el.classList.add(hoverClass);
+    if (onDragOver) onDragOver(e);
+  });
+  el.addEventListener('dragleave', (e) => {
+    if (onDragLeave) {
+      onDragLeave(e);
+    } else {
+      el.classList.remove(hoverClass);
+    }
+  });
+  el.addEventListener('drop', (e) => {
+    e.preventDefault();
+    el.classList.remove(hoverClass);
+    onDrop(e);
+  });
+}
+
 // Dialog helpers extracted to dom-dialogs.js — re-exported for backward compat.
 export { createCustomModal, showPromptDialog, showConfirmDialog } from './dom-dialogs.js';

--- a/src/utils/file-tree-drop.js
+++ b/src/utils/file-tree-drop.js
@@ -4,7 +4,7 @@
  */
 
 import { bus, EVENTS } from './events.js';
-import { _el, setupInlineInput } from './dom.js';
+import { _el, setupInlineInput, setupDropZone as _setupDropZone } from './dom.js';
 import { INPUT_BLUR_DELAY, computeIndent } from './file-tree-helpers.js';
 
 /**
@@ -17,26 +17,24 @@ import { INPUT_BLUR_DELAY, computeIndent } from './file-tree-helpers.js';
  * @param {string} [className='drop-target'] - CSS class toggled during drag
  */
 export function setupDropZone(el, getTargetDir, handleFileDrop, className = 'drop-target') {
-  el.addEventListener('dragover', (e) => {
-    if (!e.dataTransfer.types.includes('Files')) return;
-    e.preventDefault();
-    e.stopPropagation();
-    e.dataTransfer.dropEffect = 'copy';
-    el.classList.add(className);
-  });
-
-  el.addEventListener('dragleave', (e) => {
-    e.stopPropagation();
-    el.classList.remove(className);
-  });
-
-  el.addEventListener('drop', async (e) => {
-    e.preventDefault();
-    e.stopPropagation();
-    el.classList.remove(className);
-    const targetDir = typeof getTargetDir === 'function' ? getTargetDir() : getTargetDir;
-    if (!targetDir) return;
-    await handleFileDrop(e.dataTransfer.files, targetDir);
+  _setupDropZone(el, {
+    hoverClass: className,
+    accept: (e) => {
+      if (!e.dataTransfer.types.includes('Files')) return false;
+      e.stopPropagation();
+      e.dataTransfer.dropEffect = 'copy';
+      return true;
+    },
+    onDragLeave: (e) => {
+      e.stopPropagation();
+      el.classList.remove(className);
+    },
+    onDrop: async (e) => {
+      e.stopPropagation();
+      const targetDir = typeof getTargetDir === 'function' ? getTargetDir() : getTargetDir;
+      if (!targetDir) return;
+      await handleFileDrop(e.dataTransfer.files, targetDir);
+    },
   });
 }
 

--- a/src/utils/flow-category-renderer.js
+++ b/src/utils/flow-category-renderer.js
@@ -3,7 +3,7 @@
  * Handles category headers, collapse state, and drag-drop zone setup.
  * Extracted from flow-view.js to reduce component size.
  */
-import { _el, renderButtonBar, buildChevronRow } from './dom.js';
+import { _el, renderButtonBar, buildChevronRow, setupDropZone } from './dom.js';
 import { CATEGORY_ACTIONS, UNCATEGORIZED } from './flow-view-helpers.js';
 
 /**
@@ -76,31 +76,28 @@ function _buildCategoryHeader(cat, flows, isUncategorized, collapsedCategories, 
 }
 
 function _setupCategoryDropZone(items, catId, onDropFlow, dragState) {
-  items.addEventListener('dragover', (e) => {
-    e.preventDefault();
-    e.dataTransfer.dropEffect = 'move';
-    items.classList.add('flow-drop-zone-active');
-    _updateDropIndicator(items, e.clientY);
-  });
-
-  items.addEventListener('dragleave', (e) => {
-    if (!items.contains(e.relatedTarget)) {
-      items.classList.remove('flow-drop-zone-active');
+  setupDropZone(items, {
+    hoverClass: 'flow-drop-zone-active',
+    onDragOver: (e) => {
+      e.dataTransfer.dropEffect = 'move';
+      _updateDropIndicator(items, e.clientY);
+    },
+    onDragLeave: (e) => {
+      if (!items.contains(e.relatedTarget)) {
+        items.classList.remove('flow-drop-zone-active');
+        _clearDropIndicators(items);
+      }
+    },
+    onDrop: (e) => {
       _clearDropIndicators(items);
-    }
-  });
 
-  items.addEventListener('drop', (e) => {
-    e.preventDefault();
-    items.classList.remove('flow-drop-zone-active');
-    _clearDropIndicators(items);
+      const dragFlowId = dragState.getDragFlowId();
+      if (!dragFlowId) return;
 
-    const dragFlowId = dragState.getDragFlowId();
-    if (!dragFlowId) return;
-
-    const insertIndex = _getDropIndex(items, e.clientY);
-    dragState.clearDrag();
-    onDropFlow(dragFlowId, catId, insertIndex);
+      const insertIndex = _getDropIndex(items, e.clientY);
+      dragState.clearDrag();
+      onDropFlow(dragFlowId, catId, insertIndex);
+    },
   });
 }
 


### PR DESCRIPTION
## Summary

- Added a generic `setupDropZone()` helper to `src/utils/dom.js` that centralizes dragover/dragleave/drop event wiring with configurable hover class, acceptance filter, and callback hooks
- Refactored `file-tree-drop.js` to delegate to the shared helper (file-drop from OS, with `stopPropagation` and `Files` type check)
- Refactored `flow-category-renderer.js` to delegate to the shared helper (flow card reordering, with drop indicators and `relatedTarget` check)

Note: `terminal-drop-indicator.js` was listed in the issue but uses custom mouse tracking (`trackMouse`) rather than native drag-and-drop events, so it has no dragover/dragleave/drop pattern to refactor.

Closes #139

## Fichier(s) modifie(s)

- `src/utils/dom.js` — new `setupDropZone()` export
- `src/utils/file-tree-drop.js` — now delegates to `setupDropZone`
- `src/utils/flow-category-renderer.js` — now delegates to `setupDropZone`

## Test plan

- [x] `npm run build` passes
- [x] `npm test` passes (320/320 tests)
- [ ] Manual: verify file drag-drop into the file tree still works (OS files)
- [ ] Manual: verify flow card drag-drop between categories still works

---

PR creee automatiquement par l'Agent Refactor