### PR TITLE
refactor: remove dead exports (git-manager, fs-manager aliases, emitEvent)

### DIFF
--- a/main/git-manager.js
+++ b/main/git-manager.js
@@ -67,6 +67,4 @@ module.exports = {
   remote: getRemoteUrl,
   localChanges: getLocalChanges,
   fileDiff: getFileDiff,
-  // Original names (only getRemoteUrl still imported externally)
-  getRemoteUrl,
 };


### PR DESCRIPTION
## Refactoring

Remove unused exports identified in triage:
- `git-manager.js`: removed `getRemoteUrl` from original-name exports (already available as `remote` alias; not imported externally by original name)
- `fs-manager.js`: `copyEntry`/`renameEntry` were already only exported as aliases (`copy`/`rename`) — no change needed
- `events.js`: `emitEvent` did not exist in codebase — no change needed

Closes #129

## Vérifications

- [x] Build OK
- [x] Tests OK (22 files, 320 tests passed)

---

📂 Path local : `/Users/rekta/projet/coding/refactor-pikagent`
🤖 PR créée automatiquement par l'Agent Refactor