### PR TITLE
refactor: remove deprecated createButton alias (closes #112)

### DIFF
--- a/src/utils/dom.js
+++ b/src/utils/dom.js
@@ -90,9 +90,6 @@ export function createActionButton({ text, label = '', title, cls, className, on
   return btn;
 }
 
-/** @deprecated Use {@link createActionButton} instead. */
-export const createButton = createActionButton;
-
 /**
  * Render a row of buttons from an array of config descriptors.
  *


### PR DESCRIPTION
## Summary

- Removed the unused deprecated `createButton` alias from `src/utils/dom.js`
- The bulk unification of button creation patterns was already completed in #135 (commit 1c38b87), which consolidated 3 duplicate button factory functions into the shared `createActionButton()` and `renderButtonBar()` helpers in `dom.js`
- This PR removes the last leftover: the `@deprecated` `createButton` re-export that no longer has any consumers

Closes #112

## Fichier(s) modifie(s)

- `src/utils/dom.js`

## Verifications

- [x] Build OK (`npm run build`)
- [x] Tests OK (22 test files, 320 tests passed)
- [x] No remaining references to `createButton` in the codebase

---

PR creee automatiquement par l'Agent Refactor