### PR TITLE
refactor: centralize component imports via components/index.js

### DIFF
--- a/src/components/index.js
+++ b/src/components/index.js
@@ -1,0 +1,20 @@
+// Component manifest — centralizes all side-effect imports that register
+// components in the component registry.
+// Sub-components must be registered before their parents resolve them.
+
+import './config-manager.js';
+import './terminal-panel.js';
+import './file-tree.js';
+import './diff-viewer.js';
+import './git-changes-view.js';
+import './webview-panel.js';
+import './file-viewer-webview.js';
+import './file-viewer.js';
+import './board-view.js';
+import './flow-card-terminal.js';
+import './flow-modal.js';
+import './flow-view.js';
+import './usage-view.js';
+import './settings-appearance.js';
+import './settings-keybindings.js';
+import './settings-configs.js';

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -4,24 +4,8 @@ import { ShortcutManager } from './components/shortcuts.js';
 import { SettingsModal } from './components/settings-modal.js';
 import { applyAppTheme } from './utils/app-theme.js';
 
-// Side-effect imports: register components in the component registry.
-// Sub-components must be registered before their parents resolve them.
-import './components/config-manager.js';
-import './components/terminal-panel.js';
-import './components/file-tree.js';
-import './components/diff-viewer.js';
-import './components/git-changes-view.js';
-import './components/webview-panel.js';
-import './components/file-viewer-webview.js';
-import './components/file-viewer.js';
-import './components/board-view.js';
-import './components/flow-card-terminal.js';
-import './components/flow-modal.js';
-import './components/flow-view.js';
-import './components/usage-view.js';
-import './components/settings-appearance.js';
-import './components/settings-keybindings.js';
-import './components/settings-configs.js';
+// Register all components via the centralized manifest.
+import './components/index.js';
 
 // Expose hljs globally for file-viewer
 window.hljs = hljs;


### PR DESCRIPTION
## Refactoring

Created `src/components/index.js` as a component manifest that centralizes all side-effect imports for component registration.

`renderer.js` now imports a single `./components/index.js` instead of 16 individual component files, reducing its coupling and making component management easier.

Closes #141

## Fichier(s) modifié(s)

- `src/components/index.js` (new)
- `src/renderer.js` (simplified imports)

## Vérifications

- [x] Build OK
- [x] Tests OK (22 files, 320 tests passed)

---

📂 Path local : `/Users/rekta/projet/coding/refactor-pikagent`
🤖 PR créée automatiquement par l'Agent Refactor