### PR TITLE
refactor: separate manager initialization from IPC dispatching

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,12 +1,20 @@
 const { app } = require('electron');
 const window = require('./main/window');
+const { initManagers } = require('./main/manager-init');
 const ipcHandlers = require('./main/ipc-handlers');
 
 app.setName('Pickagent');
 
+let managerCleanup = null;
+
 app.whenReady().then(() => {
   const win = window.create();
-  ipcHandlers.register(() => window.get());
+  const getWindow = () => window.get();
+
+  const { targets, cleanup, ptyManager, sessionManager } = initManagers(getWindow);
+  managerCleanup = cleanup;
+
+  ipcHandlers.register(getWindow, { targets, ptyManager, sessionManager });
 
   app.on('activate', () => {
     if (!window.get()) window.create();
@@ -14,6 +22,6 @@ app.whenReady().then(() => {
 });
 
 app.on('window-all-closed', () => {
-  ipcHandlers.cleanup();
+  if (managerCleanup) managerCleanup();
   if (process.platform !== 'darwin') app.quit();
 });

--- a/main/ipc-handlers.js
+++ b/main/ipc-handlers.js
@@ -1,41 +1,17 @@
 const { ipcMain } = require('electron');
-const PtyManager = require('./pty-manager');
 const { registerManagerHandlers, safeSend } = require('./ipc-helpers');
 
-const ptyManager = new PtyManager();
-const sessionManager = require('./session-manager');
-const fsManager = require('./fs-manager');
-const gitManager = require('./git-manager');
-const configManager = require('./config-manager');
-const flowManager = require('./flow-manager');
-const usageManager = require('./usage-manager');
-
 /**
- * Modules that need lifecycle hooks (start / cleanup).
- * Custom (non-table) IPC handlers are registered per-module below.
+ * Register all IPC handlers.
+ *
+ * Manager initialization and dependency wiring are handled externally by
+ * `manager-init.js`.  This module only cares about IPC dispatching.
+ *
+ * @param {() => import('electron').BrowserWindow} getWindow
+ * @param {{ targets: Record<string, object>, ptyManager: object, sessionManager: object }} deps
  */
-const LIFECYCLE_MODULES = [
-  sessionManager,
-  ptyManager,
-  fsManager,
-  flowManager,
-  usageManager,
-];
-
-function register(getWindow) {
-  const { shell, clipboard, dialog } = require('electron');
-
-  // -- Build target map used by FORWARD_TABLE / SPREAD_TABLE --
-  const targets = {
-    pty: ptyManager,
-    fs: fsManager,
-    git: gitManager,
-    config: configManager,
-    flow: flowManager,
-    usage: usageManager,
-    shell,
-    clipboard,
-  };
+function register(getWindow, { targets, ptyManager, sessionManager }) {
+  const { shell, dialog } = require('electron');
 
   // Channels with custom handlers (registered below) — skip declarative registration.
   const customChannels = new Set(['pty:create', 'fs:watch', 'fs:trash', 'dialog:openFolder']);
@@ -59,7 +35,7 @@ function register(getWindow) {
 
   // FS: watch needs safeSend callback
   ipcMain.handle('fs:watch', (_, { id, dirPath }) => {
-    fsManager.watchDir(id, dirPath, (change) => {
+    targets.fs.watchDir(id, dirPath, (change) => {
       safeSend(getWindow, 'fs:changed', change);
     });
   });
@@ -83,17 +59,6 @@ function register(getWindow) {
     if (result.canceled || !result.filePaths.length) return null;
     return result.filePaths[0];
   });
-
-  // -- Lifecycle: start managers that need runtime context --
-  flowManager.start(getWindow, ptyManager);
-  sessionManager.start(ptyManager);
-  usageManager.init(sessionManager);
 }
 
-function cleanup() {
-  for (const mod of LIFECYCLE_MODULES) {
-    if (typeof mod.cleanup === 'function') mod.cleanup();
-  }
-}
-
-module.exports = { register, cleanup };
+module.exports = { register };

--- a/main/manager-init.js
+++ b/main/manager-init.js
@@ -1,0 +1,66 @@
+/**
+ * Manager initialization and dependency wiring.
+ *
+ * Centralises the creation of every manager singleton and the inter-manager
+ * dependencies that used to live inside ipc-handlers.js.  The main entry
+ * point calls `initManagers()` once and passes the result to the IPC layer.
+ */
+
+const PtyManager = require('./pty-manager');
+const sessionManager = require('./session-manager');
+const fsManager = require('./fs-manager');
+const gitManager = require('./git-manager');
+const configManager = require('./config-manager');
+const flowManager = require('./flow-manager');
+const usageManager = require('./usage-manager');
+
+const ptyManager = new PtyManager();
+
+/**
+ * Modules that expose a `cleanup()` method and should be torn down when
+ * the application closes.
+ */
+const LIFECYCLE_MODULES = [
+  sessionManager,
+  ptyManager,
+  fsManager,
+  flowManager,
+  usageManager,
+];
+
+/**
+ * Wire inter-manager dependencies and start runtime services.
+ *
+ * @param {() => import('electron').BrowserWindow} getWindow
+ * @returns {{ targets: Record<string, object>, cleanup: () => void }}
+ */
+function initManagers(getWindow) {
+  // -- Lifecycle: start managers that need runtime context --
+  flowManager.start(getWindow, ptyManager);
+  sessionManager.start(ptyManager);
+  usageManager.init(sessionManager);
+
+  // -- Build target map consumed by IPC dispatching --
+  const { shell, clipboard } = require('electron');
+
+  const targets = {
+    pty: ptyManager,
+    fs: fsManager,
+    git: gitManager,
+    config: configManager,
+    flow: flowManager,
+    usage: usageManager,
+    shell,
+    clipboard,
+  };
+
+  function cleanup() {
+    for (const mod of LIFECYCLE_MODULES) {
+      if (typeof mod.cleanup === 'function') mod.cleanup();
+    }
+  }
+
+  return { targets, cleanup, ptyManager, sessionManager };
+}
+
+module.exports = { initManagers };


### PR DESCRIPTION
## Refactoring

Separated manager initialization from IPC dispatching in the main process:
- Extracted `manager-init.js` to handle inter-manager dependency wiring
- `ipc-handlers.js` now receives a pre-built targets object instead of importing all managers directly
- Reduces coupling and makes initialization order explicit

Closes #140

## Fichier(s) modifié(s)

- `main/ipc-handlers.js`
- `main/manager-init.js` (new)
- `main/main.js` (updated initialization)

## Vérifications

- [x] Build OK
- [x] Tests OK

---

📂 Path local : `/Users/rekta/projet/coding/refactor-pikagent`
🤖 PR créée automatiquement par l'Agent Refactor