### PR TITLE
refactor: replace loose JSDoc types ({Object}, {Function}, {*}) with precise types

### DIFF
--- a/main/ipc-helpers.js
+++ b/main/ipc-helpers.js
@@ -74,7 +74,7 @@ function registerSpread(ipc, target, entries) {
  * Method name is derived from the channel (domain:method).
  *
  * @param {object} ipc - Electron ipcMain
- * @param {Object<string, object>} targets - Map of domain -> target object
+ * @param {Record<string, object>} targets - Map of domain -> target object
  * @param {Set<string>} [skip] - Channels to skip (registered as custom handlers elsewhere)
  */
 function registerManagerHandlers(ipc, targets, skip = new Set()) {

--- a/preload-helpers.js
+++ b/preload-helpers.js
@@ -22,8 +22,8 @@ const _pack = (ch, keys) => (...args) =>
  * pattern with a single factory.
  *
  * @param {string} channel   IPC channel name (e.g. 'pty:data')
- * @param {function} extract transforms the raw payload into { id, value }
- * @returns {(id: string, cb: function) => () => void} subscribe function
+ * @param {(payload: unknown) => { id: string, value: unknown }} extract transforms the raw payload into { id, value }
+ * @returns {(id: string, cb: (value: unknown) => void) => () => void} subscribe function
  */
 function _createTargetedChannel(channel, extract) {
   const listeners = new Map();

--- a/shared/flow-utils.js
+++ b/shared/flow-utils.js
@@ -7,7 +7,7 @@
 /**
  * Return the last run from a flow's runs array, or null if none.
  * @param {{ runs?: Array }} flow
- * @returns {Object|null}
+ * @returns {{ date: string, timestamp: string, logTimestamp?: string, status: string }|null}
  */
 function getLastRun(flow) {
   return flow.runs?.at(-1) ?? null;

--- a/src/components/file-viewer-webview.js
+++ b/src/components/file-viewer-webview.js
@@ -12,8 +12,8 @@ export class WebviewManager {
   /**
    * @param {HTMLElement} container - the file-viewer container element
    * @param {HTMLElement} statusBar - the status bar element (webview containers insert before it)
-   * @param {function} switchModeFn - callback to switch the viewer mode
-   * @param {function} renderModeBarFn - callback to re-render the mode bar
+   * @param {(modeId: string) => void} switchModeFn - callback to switch the viewer mode
+   * @param {() => void} renderModeBarFn - callback to re-render the mode bar
    */
   constructor(container, statusBar, switchModeFn, renderModeBarFn) {
     this._container = container;

--- a/src/components/settings-appearance.js
+++ b/src/components/settings-appearance.js
@@ -11,7 +11,7 @@ import { registerComponent } from '../utils/component-registry.js';
 
 /**
  * Apply the current terminal theme to all terminal panels across tabs.
- * @param {Object|null} tabManager
+ * @param {import('../components/tab-manager.js').TabManager|null} tabManager
  */
 export function applyThemeToTerminals(tabManager) {
   if (!tabManager) return;
@@ -67,8 +67,8 @@ function _createThemeCard(name, theme, isActive, tabManager, renderAppearanceFn)
 /**
  * Render the Appearance section into the given content element.
  * @param {HTMLElement} contentEl - the settings content container
- * @param {Object|null} tabManager
- * @param {function} renderAppearanceFn - callback to re-render this section
+ * @param {import('../components/tab-manager.js').TabManager|null} tabManager
+ * @param {() => void} renderAppearanceFn - callback to re-render this section
  */
 export function renderAppearance(contentEl, tabManager, renderAppearanceFn) {
   // Day/Night mode toggle

--- a/src/components/settings-configs.js
+++ b/src/components/settings-configs.js
@@ -82,8 +82,8 @@ function _createBottomActions(currentName, tabManager, renderConfigsFn) {
 /**
  * Render the Workspace Configs section into the given content element.
  * @param {HTMLElement} contentEl - the settings content container
- * @param {Object|null} tabManager
- * @param {function} renderConfigsFn - callback to re-render this section
+ * @param {import('../components/tab-manager.js').TabManager|null} tabManager
+ * @param {() => void} renderConfigsFn - callback to re-render this section
  */
 export async function renderConfigs(contentEl, tabManager, renderConfigsFn) {
   const currentName = tabManager?.configManager?.currentConfigName || 'Default';

--- a/src/components/settings-keybindings.js
+++ b/src/components/settings-keybindings.js
@@ -12,8 +12,8 @@ import { registerComponent } from '../utils/component-registry.js';
  * @param {{ id: string, label: string, keys: string[] }} binding
  * @param {number} index
  * @param {{ updateBinding: (id: string, keys: string[]) => void, getBindingsList: () => Array<{ id: string, label: string, keys: string[] }>, resetToDefaults: () => void }} shortcutManager
- * @param {function} startRecordingFn - (actionId, index, badgeEl) => void
- * @param {function} renderKeybindingsFn - callback to re-render
+ * @param {(actionId: string, index: number, badgeEl: HTMLElement) => void} startRecordingFn
+ * @param {() => void} renderKeybindingsFn - callback to re-render
  * @returns {HTMLElement}
  */
 export function createKeyBadge(binding, index, shortcutManager, startRecordingFn, renderKeybindingsFn) {

--- a/src/utils/dom.js
+++ b/src/utils/dom.js
@@ -6,7 +6,7 @@
  *   _el('div', 'className', 'text' | { prop: v } | child…)               — positional
  *
  * @param {string} tag
- * @param {Object|string|null} [attrsOrClass]
+ * @param {Record<string, unknown>|string|null} [attrsOrClass]
  * @param {...(Node|string|Object|null|false)} children
  */
 export function _el(tag, attrsOrClass, ...children) {

--- a/src/utils/file-link-provider.js
+++ b/src/utils/file-link-provider.js
@@ -17,7 +17,7 @@ export class FilePathLinkProvider {
   /**
    * @param {import('@xterm/xterm').Terminal} terminal
    * @param {() => string|null} getCwd  returns the shell's current working directory
-   * @param {{ homedir: Function, openPath: Function }} api - injected API methods
+   * @param {{ homedir: () => Promise<string>, openPath: (path: string) => void }} api - injected API methods
    */
   constructor(terminal, getCwd, { homedir, openPath }) {
     this._terminal = terminal;

--- a/src/utils/file-tree-context-menu.js
+++ b/src/utils/file-tree-context-menu.js
@@ -10,10 +10,10 @@ import { getRelativePath } from './file-tree-helpers.js';
  * @param {string} entryPath
  * @param {HTMLElement} nameEl - the name span for inline rename
  * @param {string} rootCwd - workspace root for relative path
- * @param {function} promptRenameFn - (entryPath, nameEl) => void
+ * @param {(entryPath: string, nameEl: HTMLElement) => void} promptRenameFn
  * @param {string} [deleteLabel] - custom delete confirmation text
- * @param {{ clipboardWrite: Function, fsCopy: Function, showInFolder: Function, fsTrash: Function }} api - injected API methods
- * @returns {Array} menu items
+ * @param {{ clipboardWrite: (text: string) => void, fsCopy: (path: string) => void, showInFolder: (path: string) => void, fsTrash: (path: string) => void }} api - injected API methods
+ * @returns {Array<{ label?: string, separator?: boolean, action?: () => void }>} menu items
  */
 export function buildCommonContextItems(entryPath, nameEl, rootCwd, promptRenameFn, deleteLabel, { clipboardWrite, fsCopy, showInFolder, fsTrash }) {
   const displayName = entryPath.split('/').pop();
@@ -42,9 +42,9 @@ export function buildCommonContextItems(entryPath, nameEl, rootCwd, promptRename
  * @param {string} entryPath
  * @param {HTMLElement} nameEl
  * @param {string} rootCwd
- * @param {function} promptRenameFn
- * @param {{ clipboardWrite: Function, fsCopy: Function, showInFolder: Function, fsTrash: Function }} api - injected API methods
- * @returns {Array} menu items
+ * @param {(entryPath: string, nameEl: HTMLElement) => void} promptRenameFn
+ * @param {{ clipboardWrite: (text: string) => void, fsCopy: (path: string) => void, showInFolder: (path: string) => void, fsTrash: (path: string) => void }} api - injected API methods
+ * @returns {Array<{ label?: string, separator?: boolean, action?: () => void }>} menu items
  */
 export function buildFileContextItems(entryPath, nameEl, rootCwd, promptRenameFn, api) {
   return buildCommonContextItems(entryPath, nameEl, rootCwd, promptRenameFn, undefined, api);
@@ -58,10 +58,10 @@ export function buildFileContextItems(entryPath, nameEl, rootCwd, promptRenameFn
  * @param {number} depth
  * @param {Set<string>} expandedDirs
  * @param {HTMLElement} nameEl
- * @param {function} promptRenameFn
- * @param {function} promptNewEntryFn
- * @param {{ clipboardWrite: Function, fsCopy: Function, showInFolder: Function, fsTrash: Function }} api - injected API methods
- * @returns {Array} menu items
+ * @param {(entryPath: string, nameEl: HTMLElement) => void} promptRenameFn
+ * @param {(dirPath: string, contentEl: HTMLElement, depth: number, expandedDirs: Set<string>, type: 'file'|'folder') => void} promptNewEntryFn
+ * @param {{ clipboardWrite: (text: string) => void, fsCopy: (path: string) => void, showInFolder: (path: string) => void, fsTrash: (path: string) => void }} api - injected API methods
+ * @returns {Array<{ label?: string, separator?: boolean, action?: () => void }>} menu items
  */
 export function buildDirContextItems(dirPath, rootCwd, contentEl, depth, expandedDirs, nameEl, promptRenameFn, promptNewEntryFn, api) {
   const dirName = dirPath.split('/').pop();

--- a/src/utils/split-layout.js
+++ b/src/utils/split-layout.js
@@ -83,8 +83,8 @@ export function moveToCenter(sourceEl, targetEl) {
  * @param {string} direction
  * @param {boolean} before - insert before target?
  * @param {HTMLElement} parentEl - the split container
- * @param {function} createHandle - (direction, splitEl) => handle element
- * @param {function} equalize - (splitEl) => void
+ * @param {(direction: string, splitEl: HTMLElement) => HTMLElement} createHandle - creates a split handle element
+ * @param {(splitEl: HTMLElement) => void} equalize - equalizes flex on children
  */
 export function insertIntoSplit(sourceEl, targetEl, direction, before, parentEl, createHandle, equalize) {
   const handle = createHandle(direction, parentEl);
@@ -105,8 +105,8 @@ export function insertIntoSplit(sourceEl, targetEl, direction, before, parentEl,
  * @param {string} direction
  * @param {boolean} before - insert source before target?
  * @param {HTMLElement} parentEl - current parent of targetEl
- * @param {function} createSplitContainer - (direction, flex) => split element
- * @param {function} createHandle - (direction, splitEl) => handle element
+ * @param {(direction: string, flex: string) => HTMLElement} createSplitContainer - creates a new split container element
+ * @param {(direction: string, splitEl: HTMLElement) => HTMLElement} createHandle - creates a split handle element
  */
 export function wrapInNewSplit(sourceEl, targetEl, direction, before, parentEl, createSplitContainer, createHandle) {
   const splitEl = createSplitContainer(direction, targetEl.style.flex || '1');

--- a/src/utils/tab-renderer.js
+++ b/src/utils/tab-renderer.js
@@ -20,18 +20,7 @@ import { attachContextMenu } from './context-menu.js';
  * optional close button + click handler.  This factory captures that
  * pattern while remaining fully configurable.
  *
- * @typedef {Object} TabConfig
- * @property {string}            className     - CSS class for the root element (e.g. 'tab', 'file-tab')
- * @property {boolean}           isActive      - Whether the tab should get the 'active' class
- * @property {string}            name          - Display text for the name span
- * @property {string}            [nameClass]   - CSS class for the name span (default: none)
- * @property {string[]}          [extraClasses]- Additional CSS classes for the root element
- * @property {HTMLElement[]}     [prefixEls]   - Elements inserted before the name span (e.g. color dot, pin icon)
- * @property {{ text: string, className: string, onClick: (e: Event) => void }|null} [close] - Close button config (null to omit)
- * @property {(tabEl: HTMLElement) => void}   onClick      - Click handler for the whole tab
- * @property {(tabEl: HTMLElement, nameEl: HTMLElement) => void} [setup] - Post-creation hook (context menu, drag, etc.)
- * @property {Record<string,string>}          [dataset]    - dataset entries to set on the root element
- * @property {Record<string,string>}          [style]      - inline styles to set on the root element
+ * @typedef {{ className: string, isActive: boolean, name: string, nameClass?: string, extraClasses?: string[], prefixEls?: HTMLElement[], close?: { text: string, className: string, onClick: (e: Event) => void }|null, onClick: (tabEl: HTMLElement) => void, setup?: (tabEl: HTMLElement, nameEl: HTMLElement) => void, dataset?: Record<string,string>, style?: Record<string,string> }} TabConfig
  *
  * @param {TabConfig} config
  * @returns {{ tabEl: HTMLElement, nameEl: HTMLElement }}

--- a/src/utils/terminal-instance.js
+++ b/src/utils/terminal-instance.js
@@ -13,7 +13,7 @@ export class TerminalInstance {
   /**
    * @param {HTMLElement} container
    * @param {string} cwd
-   * @param {{ openExternal: Function, homedir: Function, openPath: Function, ptyWrite: Function, ptyOnData: Function, ptyOnExit: Function, ptyCreate: Function, ptyGetCwd: Function, ptyResize: Function, ptyKill: Function }} api - injected API methods
+   * @param {{ openExternal: (url: string) => void, homedir: () => Promise<string>, openPath: (path: string) => void, ptyWrite: (id: string, data: string) => void, ptyOnData: (id: string, cb: (data: string) => void) => () => void, ptyOnExit: (id: string, cb: (code: number) => void) => () => void, ptyCreate: (opts: { cols: number, rows: number, cwd: string }) => Promise<string>, ptyGetCwd: (id: string) => Promise<string>, ptyResize: (id: string, cols: number, rows: number) => void, ptyKill: (id: string) => void }} api - injected API methods
    */
   constructor(container, cwd, { openExternal, homedir, openPath, ptyWrite, ptyOnData, ptyOnExit, ptyCreate, ptyGetCwd, ptyResize, ptyKill }) {
     this.id = generateId('term');
@@ -36,7 +36,7 @@ export class TerminalInstance {
   /**
    * Create the xterm terminal, load addons, and attach custom key handler.
    * @param {HTMLElement} container
-   * @param {{ openExternal: Function, homedir: Function, openPath: Function }} linkApi
+   * @param {{ openExternal: (url: string) => void, homedir: () => Promise<string>, openPath: (path: string) => void }} linkApi
    */
   _initTerminal(container, { openExternal, homedir, openPath }) {
     const { term, fitAddon } = createTerminal(container, {

--- a/src/utils/terminal-serializer.js
+++ b/src/utils/terminal-serializer.js
@@ -7,7 +7,7 @@
 /**
  * Serialize a single DOM element into a layout tree descriptor.
  * @param {HTMLElement} el - either a split-container or terminal-wrapper
- * @param {function} findTerminalCwd - (el) => cwd string
+ * @param {(el: HTMLElement) => string} findTerminalCwd - returns the terminal cwd for a given wrapper element
  * @param {string} fallbackCwd - default cwd if terminal not found
  * @returns {{ type: string, direction?: string, flex: number, cwd?: string, children?: Array<unknown> }} tree descriptor
  */
@@ -43,7 +43,7 @@ export function serializeElement(el, findTerminalCwd, fallbackCwd) {
 /**
  * Serialize the entire terminal panel layout.
  * @param {HTMLElement} container - the terminal-panel container
- * @param {function} findTerminalCwd - (el) => cwd string
+ * @param {(el: HTMLElement) => string} findTerminalCwd - returns the terminal cwd for a given wrapper element
  * @param {string} fallbackCwd - default cwd
  * @returns {{ type: string, direction?: string, flex: number, cwd?: string, children?: Array<unknown> }} tree descriptor
  */

--- a/src/utils/workspace-layout.js
+++ b/src/utils/workspace-layout.js
@@ -62,7 +62,7 @@ function _initTabComponents(tab, layout, sides, termContainer, getActiveTabId) {
  * Render the full workspace layout for a tab.
  * @param {RenderWorkspaceDeps} deps
  * @param {import('./tab-manager-helpers.js').WorkspaceTab} tab
- * @param {{ gitBranch: Function }} api - injected API methods
+ * @param {{ gitBranch: (cwd: string) => Promise<string> }} api - injected API methods
  */
 export async function renderWorkspace({ workspaceContainer, getActiveTabId, getActiveTab, scheduleAutoSave }, tab, { gitBranch }) {
   workspaceContainer.replaceChildren();


### PR DESCRIPTION
## Refactoring

Replaced loose JSDoc type annotations with precise types across 15 files:
- `{Object}` → specific shape types, `Record<>`, or typed imports
- `{Function}` → typed function signatures `(param: type) => returnType`
- `{function}` → typed function signatures
- `{Object|null} tabManager` → `{import(...).TabManager|null}`

### Files modified

- `main/ipc-helpers.js` — `{Object<string, object>}` → `{Record<string, object>}`
- `preload-helpers.js` — `{function}` extract/subscribe → typed callbacks
- `shared/flow-utils.js` — `{Object|null}` → precise run shape
- `src/components/file-viewer-webview.js` — `{function}` → typed signatures
- `src/components/settings-appearance.js` — `{Object|null}` tabManager → import type, `{function}` → `{() => void}`
- `src/components/settings-configs.js` — `{Object|null}` tabManager → import type, `{function}` → `{() => void}`
- `src/components/settings-keybindings.js` — `{function}` → typed signatures
- `src/utils/dom.js` — `{Object|string|null}` → `{Record<string, unknown>|string|null}`
- `src/utils/file-link-provider.js` — `{Function}` in api shape → typed signatures
- `src/utils/file-tree-context-menu.js` — `{function}` and `{Function}` → typed signatures, `{Array}` → typed arrays
- `src/utils/split-layout.js` — `{function}` → typed signatures
- `src/utils/tab-renderer.js` — `{Object}` typedef → inline shape type
- `src/utils/terminal-instance.js` — `{Function}` in api shapes → typed signatures
- `src/utils/terminal-serializer.js` — `{function}` → typed signatures
- `src/utils/workspace-layout.js` — `{Function}` in api shape → typed signature

Closes #110

## Vérifications

- [x] Build OK
- [x] Tests OK (320/320 passed)

---

📂 Path local : `/Users/rekta/projet/coding/refactor-pikagent`
🤖 PR créée automatiquement par l'Agent Refactor