### PR TITLE
refactor: remove dead original-name exports from fs-manager.js

### DIFF
--- a/main/fs-manager.js
+++ b/main/fs-manager.js
@@ -103,7 +103,6 @@ module.exports = {
   rename: renameEntry,
   homedir: getHomedir,
   unwatch: unwatchDir,
-  // Original names (used internally and by ipc-handlers.js custom handlers)
-  readDirectory, readFile, writeFile, makeDir, copyFileTo,
-  getHomedir, watchDir, unwatchDir, cleanup,
+  // Used directly by ipc-handlers.js (custom fs:watch handler) and manager-init.js (cleanup)
+  watchDir, cleanup,
 };


### PR DESCRIPTION
## Refactoring

Suppression de 7 exports redondants dans `fs-manager.js` : les noms originaux des fonctions (`readDirectory`, `readFile`, `writeFile`, `makeDir`, `copyFileTo`, `getHomedir`, `unwatchDir`) étaient exportés en double aux côtés de leurs alias (`readdir`, `readfile`, `writefile`, `mkdir`, `copyTo`, `homedir`, `unwatch`). Seuls les alias sont utilisés via IPC.

Les exports `watchDir` et `cleanup` sont conservés car utilisés directement par `ipc-handlers.js` et `manager-init.js`.

> Note: Les parties git-manager.js et emitEvent mentionnées dans l'issue originale ont déjà été corrigées dans des PRs précédentes.

Closes #129

## Fichier(s) modifié(s)

- `main/fs-manager.js`

## Vérifications

- [x] Build OK
- [x] Tests OK (320/320)

---

📂 Path local : `/Users/rekta/projet/coding/refactor-pikagent`
🤖 PR créée automatiquement par l'Agent Refactor