### PR TITLE
refactor: remove dead remote/getRemoteUrl export

### DIFF
--- a/api-schema.js
+++ b/api-schema.js
@@ -50,7 +50,6 @@ const API_SCHEMA = {
   },
   git: {
     branch:       { type: 'fwd' },
-    remote:       { type: 'fwd' },
     localChanges: { type: 'fwd' },
     fileDiff:     { type: 'pack', keys: ['cwd', 'filePath', 'isStaged'] },
   },

--- a/main/git-manager.js
+++ b/main/git-manager.js
@@ -31,10 +31,6 @@ async function getBranch(cwd) {
   return runGit(cwd, ['rev-parse', '--abbrev-ref', 'HEAD']);
 }
 
-async function getRemoteUrl(cwd) {
-  return runGit(cwd, ['config', '--get', 'remote.origin.url']);
-}
-
 async function getLocalChanges(cwd) {
   return trySafe(
     async () => {
@@ -64,7 +60,6 @@ async function getFileDiff(cwd, filePath, isStaged) {
 module.exports = {
   // Method aliases matching channel suffixes (git:branch → branch, etc.)
   branch: getBranch,
-  remote: getRemoteUrl,
   localChanges: getLocalChanges,
   fileDiff: getFileDiff,
 };


### PR DESCRIPTION
## Refactoring

Supprime l'export mort `remote` (`getRemoteUrl`) de `git-manager.js` et son entrée dans `api-schema.js`. Cette fonction était déclarée dans l'API IPC mais jamais appelée côté renderer.

Les 3 autres exports mentionnés dans l'issue originale (`getBranch`, `getLocalChanges`, `getFileDiff`) sont tous activement utilisés via leurs aliases IPC. Les exports aliasés de `fs-manager.js` et `emitEvent` dans `events.js` ont déjà été nettoyés par des refactorings précédents.

Closes #129

## Fichier(s) modifié(s)

- `main/git-manager.js` — suppression de `getRemoteUrl` et de l'export `remote`
- `api-schema.js` — suppression de l'entrée `remote` dans le domaine `git`

## Vérifications

- [x] Build OK
- [x] Tests OK (320/320)

---

📂 Path local : `/Users/rekta/projet/coding/refactor-pikagent`
🤖 PR créée automatiquement par l'Agent Refactor