### PR TITLE
refactor: consolidate near-duplicate patterns

### DIFF
--- a/main/usage-helpers.js
+++ b/main/usage-helpers.js
@@ -43,6 +43,10 @@ function addTokens(target, source) {
   for (const k of TOKEN_KEYS) target[k] += source[k] || 0;
 }
 
+function addPerDay(target, source) {
+  for (const k of PERDAY_KEYS) target[k] += source[k] || 0;
+}
+
 /** @internal */
 function parseLogTimestamp(logTs) {
   const parts = logTs.split('T');
@@ -96,9 +100,7 @@ function aggregateTokenData(labels, projectResults) {
     perDayEntries,
     ({ dateKey }) => dateKey,
     () => newPerDayTotals(),
-    (bucket, { dayData }) => {
-      for (const k of PERDAY_KEYS) bucket[k] += dayData[k];
-    },
+    (bucket, { dayData }) => addPerDay(bucket, dayData),
   );
 
   // Accumulate overall totals across all projects
@@ -111,7 +113,7 @@ function aggregateTokenData(labels, projectResults) {
     ({ proj }) => projectShortName(proj),
     () => ({ ...Object.fromEntries(PERDAY_KEYS.map(k => [k, 0])), total: 0 }),
     (bucket, { totals: pt }) => {
-      for (const k of PERDAY_KEYS) bucket[k] += pt[k];
+      addPerDay(bucket, pt);
       bucket.total += PERDAY_KEYS.reduce((sum, k) => sum + pt[k], 0);
     },
   );
@@ -215,7 +217,7 @@ function buildAgentMetrics(sessions, activeSessions) {
 function accumulatePerDay(perDayMap, usage) {
   if (!usage.dateKey) return;
   if (!perDayMap[usage.dateKey]) perDayMap[usage.dateKey] = newPerDayTotals();
-  for (const k of PERDAY_KEYS) perDayMap[usage.dateKey][k] += usage[k];
+  addPerDay(perDayMap[usage.dateKey], usage);
 }
 
 /** @internal */

--- a/src/utils/flow-card-setup.js
+++ b/src/utils/flow-card-setup.js
@@ -4,7 +4,7 @@
  */
 
 import { _el } from './dom.js';
-import { getLastRun } from './flow-view-helpers.js';
+import { getLastRun, toggleInSet } from './flow-view-helpers.js';
 import { cleanupAllDragState } from './flow-category-renderer.js';
 import { createCardHeader } from './flow-card-renderer.js';
 
@@ -73,8 +73,7 @@ export function buildCardBody(flow, isRunning, isExpanded, termManager, runningM
 export function setupCardHeaderClick(headerRow, flow, isRunning, { expandedCards, onRenderList, onOpenModal, termManager }) {
   headerRow.addEventListener('click', () => {
     if (isRunning) {
-      if (expandedCards.has(flow.id)) expandedCards.delete(flow.id);
-      else expandedCards.add(flow.id);
+      toggleInSet(expandedCards, flow.id);
       onRenderList();
       return;
     }
@@ -82,11 +81,8 @@ export function setupCardHeaderClick(headerRow, flow, isRunning, { expandedCards
       onOpenModal(flow);
       return;
     }
-    if (expandedCards.has(flow.id)) {
-      expandedCards.delete(flow.id);
+    if (!toggleInSet(expandedCards, flow.id)) {
       termManager.disposeLogTerminal(flow.id);
-    } else {
-      expandedCards.add(flow.id);
     }
     onRenderList();
   });
@@ -129,8 +125,7 @@ export function createFlowCard(deps, flow, catId) {
 
   const headerRow = createCardHeader(flow, isRunning, isExpanded, {
     onToggleOutput: (flowId) => {
-      if (deps.expandedCards.has(flowId)) deps.expandedCards.delete(flowId);
-      else deps.expandedCards.add(flowId);
+      toggleInSet(deps.expandedCards, flowId);
       deps.onRenderList();
     },
     onShowLog: (f, run) => deps.onShowLog(f, run),

--- a/src/utils/flow-category-renderer.js
+++ b/src/utils/flow-category-renderer.js
@@ -147,7 +147,7 @@ function _getDropIndex(container, clientY) {
  * Remove all drag state indicators from the document.
  */
 export function cleanupAllDragState() {
-  for (const el of document.querySelectorAll('.flow-drop-indicator')) el.remove();
+  _clearDropIndicators(document);
   for (const el of document.querySelectorAll('.flow-drop-zone-active')) {
     el.classList.remove('flow-drop-zone-active');
   }

--- a/src/utils/flow-view-helpers.js
+++ b/src/utils/flow-view-helpers.js
@@ -6,6 +6,18 @@
 import { formatDateTime } from './date-utils.js';
 import { getLastRun } from '../../shared/flow-utils.js';
 
+/**
+ * Toggle a value in a Set (add if absent, delete if present).
+ * @param {Set} set
+ * @param {*} value
+ * @returns {boolean} true if the value is now in the set
+ */
+export function toggleInSet(set, value) {
+  if (set.has(value)) { set.delete(value); return false; }
+  set.add(value);
+  return true;
+}
+
 export const FIT_DELAY_MS = 50;
 export const LOG_SCROLLBACK = 50000;
 export const LIVE_SCROLLBACK = 10000;


### PR DESCRIPTION
## Refactoring

Consolide 3 patterns near-duplicate identifiés dans le codebase :

1. **Drop indicator cleanup** : `cleanupAllDragState()` réutilise maintenant `_clearDropIndicators(document)` au lieu de dupliquer la boucle `querySelectorAll().remove()`

2. **Token per-day aggregation** : Nouveau helper `addPerDay(target, source)` dans `usage-helpers.js` qui factorise 3 boucles `for (const k of PERDAY_KEYS)` identiques (symétrique à `addTokens` existant)

3. **Set toggle** : Nouveau helper `toggleInSet(set, value)` dans `flow-view-helpers.js` qui remplace 3 occurrences du pattern `if (set.has(x)) set.delete(x) else set.add(x)` dans `flow-card-setup.js`

Note : le pattern "DOM row building" mentionné dans l'issue n'était pas une vraie duplication — `file-tree-renderer.js` utilise déjà `buildChevronRow()` de `dom.js`.

Closes #151

## Fichier(s) modifié(s)

- `src/utils/flow-category-renderer.js` — `cleanupAllDragState` réutilise `_clearDropIndicators`
- `main/usage-helpers.js` — ajout de `addPerDay`, remplacement de 3 boucles inline
- `src/utils/flow-view-helpers.js` — ajout de `toggleInSet`
- `src/utils/flow-card-setup.js` — utilisation de `toggleInSet`

## Vérifications

- [x] Build OK
- [x] Tests OK (320/320)

---

📂 Path local : `/Users/rekta/projet/coding/refactor-pikagent`
🤖 PR créée automatiquement par l'Agent Refactor