### PR TITLE
refactor: remove unused groupBy export from collection-helpers

### DIFF
--- a/main/collection-helpers.js
+++ b/main/collection-helpers.js
@@ -2,19 +2,6 @@
  * Generic collection utilities shared across helper modules.
  */
 
-const { aggregateByKey } = require('./aggregation-utils');
-
-/**
- * Groups an array of items by a key function.
- * Delegates to {@link aggregateByKey} with array-push accumulation.
- * @param {Array} items
- * @param {(item: unknown) => string} keyFn - Returns the grouping key for each item
- * @returns {Record<string, Array<unknown>>} map of key -> array of items
- */
-function groupBy(items, keyFn) {
-  return aggregateByKey(items, keyFn, () => [], (bucket, item) => bucket.push(item));
-}
-
 /**
  * Counts occurrences of each key produced by keyFn.
  * @param {Array} items
@@ -30,4 +17,4 @@ function countBy(items, keyFn) {
   return counts;
 }
 
-module.exports = { groupBy, countBy };
+module.exports = { countBy };


### PR DESCRIPTION
## Refactoring

Removed the unused `groupBy` function and its export from `main/collection-helpers.js`. This function was exported but never imported anywhere in the project. Also removed the now-unnecessary `aggregateByKey` import that was only used by `groupBy`.

Closes #155

## Fichier(s) modifié(s)

- `main/collection-helpers.js`

## Vérifications

- [x] Build OK
- [x] Tests OK (22 files, 320 tests)

---

📂 Path local : `/Users/rekta/projet/coding/refactor-pikagent`
🤖 PR créée automatiquement par l'Agent Refactor