### PR TITLE
refactor: extract inline rename helper and consolidate drag body state

### DIFF
--- a/src/components/flow-view.js
+++ b/src/components/flow-view.js
@@ -1,4 +1,4 @@
-import { _el, showPromptDialog, setupInlineInput, renderButtonBar } from '../utils/dom.js';
+import { _el, showPromptDialog, startInlineRename, renderButtonBar } from '../utils/dom.js';
 import { generateId } from '../utils/id.js';
 import { registerComponent, getComponent } from '../utils/component-registry.js';
 import {
@@ -216,22 +216,16 @@ export class FlowView {
     const cat = this.catData.categories.find(c => c.id === catId);
     if (!cat) return;
 
-    const input = _el('input', {
-      className: 'flow-category-name-input',
-      value: cat.name,
-    });
-
-    nameEl.parentNode.replaceChild(input, nameEl);
-    input.focus();
-    input.select();
-
     const finish = async (newName) => {
       if (newName && newName !== cat.name) cat.name = newName;
       await this._persistCategories();
       this._renderList();
     };
 
-    setupInlineInput(input, {
+    startInlineRename(nameEl, {
+      className: 'flow-category-name-input',
+      value: cat.name,
+      mode: 'replaceChild',
       onCommit: finish,
       onCancel: () => finish(null),
     });

--- a/src/utils/dom.js
+++ b/src/utils/dom.js
@@ -149,6 +149,51 @@ export function setupKeyboardShortcuts(el, { onEnter, onEscape } = {}) {
   return () => el.removeEventListener('keydown', handler);
 }
 
+/**
+ * Start an inline rename workflow: create an <input>, swap it into the DOM,
+ * focus it, optionally select a range, and wire up commit / cancel via
+ * `setupInlineInput`.
+ *
+ * Covers three common placement strategies through `opts.mode`:
+ *   - 'replace'         — `targetEl.replaceWith(input)` (default)
+ *   - 'replaceChild'    — `targetEl.parentNode.replaceChild(input, targetEl)`
+ *   - 'hideAndAppend'   — hides `targetEl`, appends input to its parent
+ *
+ * @param {HTMLElement} targetEl — the element being renamed (e.g. a <span>)
+ * @param {{ className: string,
+ *           value: string,
+ *           onCommit: (newValue: string) => void,
+ *           onCancel?: () => void,
+ *           selectRange?: [number, number],
+ *           selectAll?: boolean,
+ *           blurDelay?: number,
+ *           mode?: 'replace'|'replaceChild'|'hideAndAppend' }} opts
+ * @returns {HTMLInputElement}
+ */
+export function startInlineRename(targetEl, { className, value, onCommit, onCancel, selectRange, selectAll = true, blurDelay, mode = 'replace' }) {
+  const input = _el('input', { className, value });
+
+  if (mode === 'hideAndAppend') {
+    targetEl.style.display = 'none';
+    targetEl.parentElement.appendChild(input);
+  } else if (mode === 'replaceChild') {
+    targetEl.parentNode.replaceChild(input, targetEl);
+  } else {
+    targetEl.replaceWith(input);
+  }
+
+  input.focus();
+  if (selectRange) {
+    input.setSelectionRange(selectRange[0], selectRange[1]);
+  } else if (selectAll) {
+    input.select();
+  }
+
+  setupInlineInput(input, { onCommit, onCancel, blurDelay });
+
+  return input;
+}
+
 /** Safely call fitAddon.fit(), swallowing errors from detached terminals. */
 export function _safeFit(fitAddon) {
   try { fitAddon.fit(); } catch {}

--- a/src/utils/drag-helpers.js
+++ b/src/utils/drag-helpers.js
@@ -6,6 +6,23 @@
  */
 
 /**
+ * Apply drag-related body styles: cursor + userSelect.
+ * @param {string} cursor - CSS cursor value (e.g. 'grabbing', 'col-resize')
+ */
+export function setDragBodyState(cursor) {
+  document.body.style.cursor = cursor;
+  document.body.style.userSelect = 'none';
+}
+
+/**
+ * Clear drag-related body styles set by `setDragBodyState`.
+ */
+export function clearDragBodyState() {
+  document.body.style.cursor = '';
+  document.body.style.userSelect = '';
+}
+
+/**
  * Start a mouse-drag session: set cursor, throttle moves via RAF, clean up on mouseup.
  * @param {string} cursor - CSS cursor value during the drag (e.g. 'grabbing', 'col-resize')
  * @param {(e: MouseEvent) => void} onMove - called on each mousemove (RAF-throttled)
@@ -21,13 +38,11 @@ export function trackMouse(cursor, onMove, onDone) {
   const up = () => {
     document.removeEventListener('mousemove', move);
     document.removeEventListener('mouseup', up);
-    document.body.style.cursor = '';
-    document.body.style.userSelect = '';
+    clearDragBodyState();
     document.body.classList.remove('resizing');
     onDone();
   };
-  document.body.style.cursor = cursor;
-  document.body.style.userSelect = 'none';
+  setDragBodyState(cursor);
   document.body.classList.add('resizing');
   document.addEventListener('mousemove', move);
   document.addEventListener('mouseup', up);

--- a/src/utils/file-tree-drop.js
+++ b/src/utils/file-tree-drop.js
@@ -4,7 +4,7 @@
  */
 
 import { bus, EVENTS } from './events.js';
-import { _el, setupInlineInput, setupDropZone as _setupDropZone } from './dom.js';
+import { _el, setupInlineInput, startInlineRename, setupDropZone as _setupDropZone } from './dom.js';
 import { INPUT_BLUR_DELAY, computeIndent } from './file-tree-helpers.js';
 
 /**
@@ -63,15 +63,14 @@ export async function handleFileDrop(files, destDir, { copyTo }) {
  */
 export function promptRename(entryPath, nameEl, { rename }) {
   const oldName = entryPath.split('/').pop();
-  const input = _el('input', { className: 'file-tree-rename-input', type: 'text', value: oldName });
-
-  nameEl.style.display = 'none';
-  nameEl.parentElement.appendChild(input);
-  input.focus();
   const dotIndex = oldName.lastIndexOf('.');
-  input.setSelectionRange(0, dotIndex > 0 ? dotIndex : oldName.length);
 
-  setupInlineInput(input, {
+  const input = startInlineRename(nameEl, {
+    className: 'file-tree-rename-input',
+    value: oldName,
+    mode: 'hideAndAppend',
+    selectAll: false,
+    selectRange: [0, dotIndex > 0 ? dotIndex : oldName.length],
     blurDelay: INPUT_BLUR_DELAY,
     onCommit: async (newName) => {
       input.remove();

--- a/src/utils/tab-drag.js
+++ b/src/utils/tab-drag.js
@@ -9,6 +9,7 @@
  */
 
 import { DRAG_THRESHOLD } from './tab-manager-helpers.js';
+import { setDragBodyState, clearDragBodyState } from './drag-helpers.js';
 
 // ── Internal helpers ────────────────────────────────────────────────
 
@@ -133,8 +134,7 @@ function initDragState() {
  */
 function handleDragStart(tabEl) {
   tabEl.classList.add('tab-dragging');
-  document.body.style.cursor = 'grabbing';
-  document.body.style.userSelect = 'none';
+  setDragBodyState('grabbing');
 
   // Create floating ghost clone
   const ghost = tabEl.cloneNode(true);
@@ -161,8 +161,7 @@ function handleDragStart(tabEl) {
  */
 function handleDragEnd({ getTabElements, reorderTab }, tabEl, ghost, state, tabId) {
   tabEl.classList.remove('tab-dragging');
-  document.body.style.cursor = '';
-  document.body.style.userSelect = '';
+  clearDragBodyState();
   if (ghost) { ghost.remove(); }
   clearTabShifts(getTabElements);
 

--- a/src/utils/tab-renderer.js
+++ b/src/utils/tab-renderer.js
@@ -7,7 +7,7 @@
  *
  * @typedef {{ activeTabId: string|null, tabs: Map<string, import('./tab-manager-helpers.js').WorkspaceTab>, switchTo: (id: string) => void, closeTab: (id: string) => void, renameTab: (id: string, nameEl: HTMLElement) => void, setTabColorGroup: (id: string, colorGroupId: string|null) => void, toggleNoShortcut: (id: string) => void, dragDeps: import('./tab-drag.js').TabDragDeps }} TabElementDeps
  */
-import { _el, setupInlineInput } from './dom.js';
+import { _el, startInlineRename } from './dom.js';
 import { COLOR_GROUPS } from './tab-manager-helpers.js';
 import { setupTabDrag } from './tab-drag.js';
 import { attachContextMenu } from './context-menu.js';
@@ -151,12 +151,9 @@ export function bindTabContextMenu(deps, tabEl, id, tab, nameEl) {
  * @param {() => void} onCancel - callback on cancel (re-render only, no save)
  */
 export function inlineRenameTab(tab, nameEl, onCommit, onCancel) {
-  const input = _el('input', { className: 'tab-rename-input', value: tab.name });
-  nameEl.replaceWith(input);
-  input.focus();
-  input.select();
-
-  setupInlineInput(input, {
+  startInlineRename(nameEl, {
+    className: 'tab-rename-input',
+    value: tab.name,
     onCommit: (newName) => {
       tab.name = newName || tab.name;
       onCommit();


### PR DESCRIPTION
## Refactoring

### Inline rename helper
Extracted `startInlineRename()` into `src/utils/dom.js` to eliminate duplicated inline rename workflows across 3 files.

### Drag body state
Consolidated body cursor/userSelect management by making `tab-drag.js` reuse helpers from `drag-helpers.js`.

Closes #154

## Fichier(s) modifié(s)

- `src/utils/dom.js`
- `src/utils/tab-renderer.js`
- `src/utils/file-tree-drop.js`
- `src/components/flow-view.js`
- `src/utils/drag-helpers.js`
- `src/utils/tab-drag.js`

## Vérifications

- [x] Build OK
- [x] Tests OK

---

📂 Path local : `/Users/rekta/projet/coding/refactor-pikagent`
🤖 PR créée automatiquement par l'Agent Refactor