### PR TITLE
refactor: consolider les patterns near-duplicate restants

### DIFF
--- a/main/usage-helpers.js
+++ b/main/usage-helpers.js
@@ -111,7 +111,7 @@ function aggregateTokenData(labels, projectResults) {
   const perProjectAgg = aggregateByKey(
     projectResults.filter(({ totals: pt }) => PERDAY_KEYS.reduce((sum, k) => sum + pt[k], 0) > 0),
     ({ proj }) => projectShortName(proj),
-    () => ({ ...Object.fromEntries(PERDAY_KEYS.map(k => [k, 0])), total: 0 }),
+    () => ({ ...newPerDayTotals(), total: 0 }),
     (bucket, { totals: pt }) => {
       addPerDay(bucket, pt);
       bucket.total += PERDAY_KEYS.reduce((sum, k) => sum + pt[k], 0);


### PR DESCRIPTION
## Refactoring

Consolide le dernier pattern near-duplicate identifié dans l'issue #151.

La majorité des duplications signalées avaient déjà été corrigées dans des passes précédentes :
- ✅ Drop indicators : `cleanupAllDragState` délègue déjà à `_clearDropIndicators`
- ✅ DOM rows : `buildRow` utilise déjà `buildChevronRow`
- ✅ Token aggregation : `addTokens`/`addPerDay` déjà extraits en helpers
- ✅ Set toggle : `toggleInSet` déjà extrait dans `flow-view-helpers.js`

**Seul changement restant** : remplacement de `Object.fromEntries(PERDAY_KEYS.map(k => [k, 0]))` par `newPerDayTotals()` dans `aggregateTokenData()` (ligne 114), éliminant la dernière duplication du pattern de création de totaux.

Closes #151

## Fichier(s) modifié(s)

- `main/usage-helpers.js`

## Vérifications

- [x] Build OK
- [x] Tests OK (320/320)

---

📂 Path local : `/Users/rekta/projet/coding/refactor-pikagent`
🤖 PR créée automatiquement par l'Agent Refactor