### PR TITLE
refactor: factoriser inline rename et drag body state

### DIFF
--- a/src/components/flow-view.js
+++ b/src/components/flow-view.js
@@ -1,4 +1,4 @@
-import { _el, showPromptDialog, setupInlineInput, renderButtonBar } from '../utils/dom.js';
+import { _el, showPromptDialog, startInlineRename, renderButtonBar } from '../utils/dom.js';
 import { generateId } from '../utils/id.js';
 import { registerComponent, getComponent } from '../utils/component-registry.js';
 import {
@@ -216,22 +216,15 @@ export class FlowView {
     const cat = this.catData.categories.find(c => c.id === catId);
     if (!cat) return;
 
-    const input = _el('input', {
-      className: 'flow-category-name-input',
-      value: cat.name,
-    });
-
-    nameEl.parentNode.replaceChild(input, nameEl);
-    input.focus();
-    input.select();
-
     const finish = async (newName) => {
       if (newName && newName !== cat.name) cat.name = newName;
       await this._persistCategories();
       this._renderList();
     };
 
-    setupInlineInput(input, {
+    startInlineRename(nameEl, {
+      className: 'flow-category-name-input',
+      value: cat.name,
       onCommit: finish,
       onCancel: () => finish(null),
     });

--- a/src/utils/dom.js
+++ b/src/utils/dom.js
@@ -149,6 +149,46 @@ export function setupKeyboardShortcuts(el, { onEnter, onEscape } = {}) {
   return () => el.removeEventListener('keydown', handler);
 }
 
+/**
+ * Start an inline rename workflow: create an input, replace the target element,
+ * focus + select, and wire up commit/cancel via setupInlineInput.
+ *
+ * @param {HTMLElement} targetEl - element to replace with the input
+ * @param {{ className: string, value: string, selectRange?: [number, number],
+ *           blurDelay?: number,
+ *           replaceFn?: (targetEl: HTMLElement, input: HTMLInputElement) => void,
+ *           restoreFn?: (targetEl: HTMLElement, input: HTMLInputElement) => void,
+ *           onCommit: (value: string) => void,
+ *           onCancel?: () => void }} opts
+ * @returns {HTMLInputElement}
+ */
+export function startInlineRename(targetEl, { className, value, selectRange, blurDelay, replaceFn, restoreFn, onCommit, onCancel }) {
+  const input = _el('input', { className, value });
+
+  if (replaceFn) {
+    replaceFn(targetEl, input);
+  } else {
+    targetEl.replaceWith(input);
+  }
+
+  input.focus();
+  if (selectRange) {
+    input.setSelectionRange(selectRange[0], selectRange[1]);
+  } else {
+    input.select();
+  }
+
+  const restore = restoreFn ? () => restoreFn(targetEl, input) : undefined;
+
+  setupInlineInput(input, {
+    blurDelay,
+    onCommit: (val) => { if (restore) restore(); onCommit(val); },
+    onCancel: () => { if (restore) restore(); if (onCancel) onCancel(); },
+  });
+
+  return input;
+}
+
 /** Safely call fitAddon.fit(), swallowing errors from detached terminals. */
 export function _safeFit(fitAddon) {
   try { fitAddon.fit(); } catch {}

--- a/src/utils/drag-helpers.js
+++ b/src/utils/drag-helpers.js
@@ -5,6 +5,18 @@
  * Pure DOM helper — no component dependencies.
  */
 
+/** Set cursor and disable text selection on document.body during a drag. */
+export function setDragBodyState(cursor) {
+  document.body.style.cursor = cursor;
+  document.body.style.userSelect = 'none';
+}
+
+/** Clear cursor and re-enable text selection on document.body after a drag. */
+export function clearDragBodyState() {
+  document.body.style.cursor = '';
+  document.body.style.userSelect = '';
+}
+
 /**
  * Start a mouse-drag session: set cursor, throttle moves via RAF, clean up on mouseup.
  * @param {string} cursor - CSS cursor value during the drag (e.g. 'grabbing', 'col-resize')
@@ -21,13 +33,11 @@ export function trackMouse(cursor, onMove, onDone) {
   const up = () => {
     document.removeEventListener('mousemove', move);
     document.removeEventListener('mouseup', up);
-    document.body.style.cursor = '';
-    document.body.style.userSelect = '';
+    clearDragBodyState();
     document.body.classList.remove('resizing');
     onDone();
   };
-  document.body.style.cursor = cursor;
-  document.body.style.userSelect = 'none';
+  setDragBodyState(cursor);
   document.body.classList.add('resizing');
   document.addEventListener('mousemove', move);
   document.addEventListener('mouseup', up);

--- a/src/utils/file-tree-drop.js
+++ b/src/utils/file-tree-drop.js
@@ -4,7 +4,7 @@
  */
 
 import { bus, EVENTS } from './events.js';
-import { _el, setupInlineInput, setupDropZone as _setupDropZone } from './dom.js';
+import { _el, startInlineRename, setupDropZone as _setupDropZone } from './dom.js';
 import { INPUT_BLUR_DELAY, computeIndent } from './file-tree-helpers.js';
 
 /**
@@ -63,25 +63,18 @@ export async function handleFileDrop(files, destDir, { copyTo }) {
  */
 export function promptRename(entryPath, nameEl, { rename }) {
   const oldName = entryPath.split('/').pop();
-  const input = _el('input', { className: 'file-tree-rename-input', type: 'text', value: oldName });
-
-  nameEl.style.display = 'none';
-  nameEl.parentElement.appendChild(input);
-  input.focus();
   const dotIndex = oldName.lastIndexOf('.');
-  input.setSelectionRange(0, dotIndex > 0 ? dotIndex : oldName.length);
 
-  setupInlineInput(input, {
+  startInlineRename(nameEl, {
+    className: 'file-tree-rename-input',
+    value: oldName,
+    selectRange: [0, dotIndex > 0 ? dotIndex : oldName.length],
     blurDelay: INPUT_BLUR_DELAY,
+    replaceFn: (el, input) => { el.style.display = 'none'; el.parentElement.appendChild(input); },
+    restoreFn: (el, input) => { input.remove(); el.style.display = ''; },
     onCommit: async (newName) => {
-      input.remove();
-      nameEl.style.display = '';
       if (!newName || newName === oldName) return;
       await rename(entryPath, newName);
-    },
-    onCancel: () => {
-      input.remove();
-      nameEl.style.display = '';
     },
   });
 }

--- a/src/utils/tab-drag.js
+++ b/src/utils/tab-drag.js
@@ -9,6 +9,7 @@
  */
 
 import { DRAG_THRESHOLD } from './tab-manager-helpers.js';
+import { setDragBodyState, clearDragBodyState } from './drag-helpers.js';
 
 // ── Internal helpers ────────────────────────────────────────────────
 
@@ -133,8 +134,7 @@ function initDragState() {
  */
 function handleDragStart(tabEl) {
   tabEl.classList.add('tab-dragging');
-  document.body.style.cursor = 'grabbing';
-  document.body.style.userSelect = 'none';
+  setDragBodyState('grabbing');
 
   // Create floating ghost clone
   const ghost = tabEl.cloneNode(true);
@@ -161,8 +161,7 @@ function handleDragStart(tabEl) {
  */
 function handleDragEnd({ getTabElements, reorderTab }, tabEl, ghost, state, tabId) {
   tabEl.classList.remove('tab-dragging');
-  document.body.style.cursor = '';
-  document.body.style.userSelect = '';
+  clearDragBodyState();
   if (ghost) { ghost.remove(); }
   clearTabShifts(getTabElements);
 

--- a/src/utils/tab-renderer.js
+++ b/src/utils/tab-renderer.js
@@ -7,7 +7,7 @@
  *
  * @typedef {{ activeTabId: string|null, tabs: Map<string, import('./tab-manager-helpers.js').WorkspaceTab>, switchTo: (id: string) => void, closeTab: (id: string) => void, renameTab: (id: string, nameEl: HTMLElement) => void, setTabColorGroup: (id: string, colorGroupId: string|null) => void, toggleNoShortcut: (id: string) => void, dragDeps: import('./tab-drag.js').TabDragDeps }} TabElementDeps
  */
-import { _el, setupInlineInput } from './dom.js';
+import { _el, startInlineRename } from './dom.js';
 import { COLOR_GROUPS } from './tab-manager-helpers.js';
 import { setupTabDrag } from './tab-drag.js';
 import { attachContextMenu } from './context-menu.js';
@@ -151,12 +151,9 @@ export function bindTabContextMenu(deps, tabEl, id, tab, nameEl) {
  * @param {() => void} onCancel - callback on cancel (re-render only, no save)
  */
 export function inlineRenameTab(tab, nameEl, onCommit, onCancel) {
-  const input = _el('input', { className: 'tab-rename-input', value: tab.name });
-  nameEl.replaceWith(input);
-  input.focus();
-  input.select();
-
-  setupInlineInput(input, {
+  startInlineRename(nameEl, {
+    className: 'tab-rename-input',
+    value: tab.name,
     onCommit: (newName) => {
       tab.name = newName || tab.name;
       onCommit();


### PR DESCRIPTION
## Refactoring

### 1. Inline rename — helper `startInlineRename` (dom.js)

Extraction du pattern commun de renommage inline (créer input → remplacer l'élément → focus/select → setupInlineInput) en un helper `startInlineRename()` dans `dom.js`.

Les 3 implémentations dupliquées utilisent maintenant ce helper :
- `inlineRenameTab()` dans `tab-renderer.js`
- `promptRename()` dans `file-tree-drop.js`
- `_renameCategoryInline()` dans `flow-view.js`

Le helper supporte des options pour les variantes (sélection partielle, remplacement custom, restauration custom, délai de blur).

### 2. Drag body state — helpers `setDragBodyState` / `clearDragBodyState`

Extraction de la gestion `cursor`/`userSelect` du body pendant un drag en deux helpers dans `drag-helpers.js`.

Utilisé par :
- `trackMouse()` dans `drag-helpers.js` (existant, refactoré)
- `handleDragStart()`/`handleDragEnd()` dans `tab-drag.js` (dédupliqué)

Closes #154

## Fichier(s) modifié(s)

- `src/utils/dom.js` — ajout `startInlineRename`
- `src/utils/tab-renderer.js` — utilise `startInlineRename`
- `src/utils/file-tree-drop.js` — utilise `startInlineRename`
- `src/components/flow-view.js` — utilise `startInlineRename`
- `src/utils/drag-helpers.js` — ajout `setDragBodyState`/`clearDragBodyState`
- `src/utils/tab-drag.js` — utilise les helpers de drag-helpers

## Vérifications

- [x] Build OK
- [x] Tests OK (320/320)

---

📂 Path local : `/Users/rekta/projet/coding/refactor-pikagent`
🤖 PR créée automatiquement par l'Agent Refactor