### PR TITLE
refactor: resolve circular dependency dom.js <-> dom-dialogs.js

### DIFF
--- a/src/components/config-manager.js
+++ b/src/components/config-manager.js
@@ -1,5 +1,5 @@
 import { contextMenu } from '../utils/context-menu.js';
-import { showPromptDialog } from '../utils/dom.js';
+import { showPromptDialog } from '../utils/dom-dialogs.js';
 import {
   AUTO_SAVE_DELAY,
   MENU_OFFSET,

--- a/src/components/flow-view.js
+++ b/src/components/flow-view.js
@@ -1,4 +1,5 @@
-import { _el, showPromptDialog, startInlineRename, renderButtonBar } from '../utils/dom.js';
+import { _el, startInlineRename, renderButtonBar } from '../utils/dom.js';
+import { showPromptDialog } from '../utils/dom-dialogs.js';
 import { generateId } from '../utils/id.js';
 import { registerComponent, getComponent } from '../utils/component-registry.js';
 import {

--- a/src/utils/dom.js
+++ b/src/utils/dom.js
@@ -267,6 +267,3 @@ export function setupDropZone(el, { hoverClass = 'drag-over', onDrop, onDragOver
     onDrop(e);
   });
 }
-
-// Dialog helpers extracted to dom-dialogs.js — re-exported for backward compat.
-export { createCustomModal, showPromptDialog, showConfirmDialog } from './dom-dialogs.js';

--- a/src/utils/tab-lifecycle.js
+++ b/src/utils/tab-lifecycle.js
@@ -16,7 +16,8 @@
  */
 
 import { generateId } from './id.js';
-import { showConfirmDialog, _el } from './dom.js';
+import { _el } from './dom.js';
+import { showConfirmDialog } from './dom-dialogs.js';
 import { bus, EVENTS } from './events.js';
 import { WorkspaceTab } from './tab-manager-helpers.js';
 import { reattachLayout, syncFileTree } from './workspace-layout.js';


### PR DESCRIPTION
## Refactoring

Remove backward-compatibility re-exports from `dom.js` that created a circular dependency with `dom-dialogs.js`. Updated all consumer imports to reference `dom-dialogs.js` directly.

Closes #163

## Vérifications

- [x] Build OK
- [x] Tests OK (22 suites, 320 tests)

---

📂 Path local : `/Users/rekta/projet/coding/refactor-pikagent`
🤖 PR créée automatiquement par l'Agent Refactor