### PR TITLE
refactor: extract shared drop position calculation

### DIFF
--- a/src/utils/drag-helpers.js
+++ b/src/utils/drag-helpers.js
@@ -42,3 +42,26 @@ export function trackMouse(cursor, onMove, onDone) {
   document.addEventListener('mousemove', move);
   document.addEventListener('mouseup', up);
 }
+
+/**
+ * Compute the insertion index for a drag-and-drop operation by comparing
+ * the cursor position to the midpoints of the container's child elements.
+ *
+ * Works on both axes: pass `'y'` for vertical lists, `'x'` for horizontal ones.
+ *
+ * @param {HTMLElement[]} elements  — ordered array of child elements to test against
+ * @param {number} cursorPos       — clientX or clientY depending on axis
+ * @param {'x'|'y'} [axis='y']    — axis to measure
+ * @returns {number} index where the item should be inserted, or -1 to append at end
+ */
+export function computeInsertionIndex(elements, cursorPos, axis = 'y') {
+  const start = axis === 'x' ? 'left' : 'top';
+  const size  = axis === 'x' ? 'width' : 'height';
+
+  for (let i = 0; i < elements.length; i++) {
+    const rect = elements[i].getBoundingClientRect();
+    const mid = rect[start] + rect[size] / 2;
+    if (cursorPos < mid) return i;
+  }
+  return -1; // append at end
+}

--- a/src/utils/flow-category-renderer.js
+++ b/src/utils/flow-category-renderer.js
@@ -5,6 +5,7 @@
  */
 import { _el, renderButtonBar, buildChevronRow, setupDropZone } from './dom.js';
 import { CATEGORY_ACTIONS, UNCATEGORIZED } from './flow-view-helpers.js';
+import { computeInsertionIndex } from './drag-helpers.js';
 
 /**
  * Create a category group DOM element with header and flow items.
@@ -109,15 +110,8 @@ function _updateDropIndicator(container, clientY) {
   const cards = [...container.querySelectorAll(':scope > .flow-card')];
   if (cards.length === 0) return;
 
-  let insertBefore = null;
-  for (const card of cards) {
-    const rect = card.getBoundingClientRect();
-    const midY = rect.top + rect.height / 2;
-    if (clientY < midY) {
-      insertBefore = card;
-      break;
-    }
-  }
+  const idx = computeInsertionIndex(cards, clientY, 'y');
+  const insertBefore = idx === -1 ? null : cards[idx];
 
   const indicator = _el('div', 'flow-drop-indicator flow-drop-active');
   if (insertBefore) {
@@ -139,12 +133,7 @@ function clearIndicators(container, selector) {
 
 function _getDropIndex(container, clientY) {
   const cards = [...container.querySelectorAll(':scope > .flow-card')];
-  for (let i = 0; i < cards.length; i++) {
-    const rect = cards[i].getBoundingClientRect();
-    const midY = rect.top + rect.height / 2;
-    if (clientY < midY) return i;
-  }
-  return -1; // append at end
+  return computeInsertionIndex(cards, clientY, 'y');
 }
 
 /**

--- a/src/utils/tab-drag.js
+++ b/src/utils/tab-drag.js
@@ -9,7 +9,7 @@
  */
 
 import { DRAG_THRESHOLD } from './tab-manager-helpers.js';
-import { setDragBodyState, clearDragBodyState } from './drag-helpers.js';
+import { setDragBodyState, clearDragBodyState, computeInsertionIndex } from './drag-helpers.js';
 
 // ── Internal helpers ────────────────────────────────────────────────
 
@@ -35,36 +35,25 @@ function clearTabShifts(getTabElements) {
  * @returns {{ dropTargetId: string|null, dropBefore: boolean, insertIdx: number }}
  */
 function computeDropPosition(getTabElements, mx, orderedIds, dragId) {
-  let dropTargetId = null;
-  let dropBefore = true;
-  let insertIdx = -1;
+  // Build the list of non-dragged tab elements in order
+  const candidates = orderedIds.filter((id) => id !== dragId);
+  const elements = candidates.map((id) => getTabElements().get(id));
 
-  for (let i = 0; i < orderedIds.length; i++) {
-    const id = orderedIds[i];
-    if (id === dragId) continue;
-    const el = getTabElements().get(id);
-    const rect = el.getBoundingClientRect();
-    const midX = rect.left + rect.width / 2;
+  const rawIdx = computeInsertionIndex(elements, mx, 'x');
 
-    if (mx < midX) {
-      dropTargetId = id;
-      dropBefore = true;
-      insertIdx = i;
-      break;
-    }
+  if (rawIdx !== -1) {
+    // Map back from candidate-space index to orderedIds-space index
+    const dropTargetId = candidates[rawIdx];
+    const insertIdx = orderedIds.indexOf(dropTargetId);
+    return { dropTargetId, dropBefore: true, insertIdx };
   }
 
-  // If no target found, insert after last
-  if (insertIdx === -1) {
-    const lastId = orderedIds.filter((id) => id !== dragId).pop();
-    if (lastId) {
-      dropTargetId = lastId;
-      dropBefore = false;
-      insertIdx = orderedIds.length;
-    }
+  // No target found → insert after last
+  const lastId = candidates[candidates.length - 1] ?? null;
+  if (lastId) {
+    return { dropTargetId: lastId, dropBefore: false, insertIdx: orderedIds.length };
   }
-
-  return { dropTargetId, dropBefore, insertIdx };
+  return { dropTargetId: null, dropBefore: true, insertIdx: -1 };
 }
 
 /**


### PR DESCRIPTION
## Refactoring

Extracted `computeInsertionIndex(elements, cursorPos, axis)` into `drag-helpers.js` to eliminate the duplicated drop position calculation in `flow-category-renderer.js` (Y axis) and `tab-drag.js` (X axis).

Closes #166

## Vérifications

- [x] Build OK
- [x] Tests OK (320/320)

---

📂 Path local : `/Users/rekta/projet/coding/refactor-pikagent`
🤖 PR créée automatiquement par l'Agent Refactor