### PR TITLE
refactor: extract shared dispose helper (3 files)

### DIFF
--- a/src/utils/disposable.js
+++ b/src/utils/disposable.js
@@ -1,0 +1,50 @@
+/**
+ * Shared dispose/cleanup helpers.
+ *
+ * Each "resource descriptor" is an object with:
+ *   - `ref`    : the object (or owner) holding the resource
+ *   - `key`    : the property name on `ref` (e.g. "resizeObserver")
+ *   - `action` : how to clean it up — "dispose" | "disconnect" | "call" | "remove" | "clearInterval"
+ *
+ * After cleanup the property is set to null so it cannot be double-freed.
+ *
+ * `disposeResources` does NOT manage a `disposed` flag — callers that need
+ * guard semantics keep their own flag (e.g. TerminalInstance).
+ */
+
+/**
+ * @typedef {'dispose' | 'disconnect' | 'call' | 'remove' | 'clearInterval'} CleanupAction
+ * @typedef {{ ref: object, key: string, action: CleanupAction }} ResourceDescriptor
+ */
+
+/**
+ * Walk a list of resource descriptors and clean each one up.
+ *
+ * @param {ResourceDescriptor[]} resources
+ */
+export function disposeResources(resources) {
+  for (const { ref, key, action } of resources) {
+    const value = ref[key];
+    if (value == null) continue;
+
+    switch (action) {
+      case 'dispose':
+        value.dispose();
+        break;
+      case 'disconnect':
+        value.disconnect();
+        break;
+      case 'call':
+        value();
+        break;
+      case 'remove':
+        value.remove();
+        break;
+      case 'clearInterval':
+        clearInterval(value);
+        break;
+    }
+
+    ref[key] = null;
+  }
+}

--- a/src/utils/terminal-factory.js
+++ b/src/utils/terminal-factory.js
@@ -2,6 +2,7 @@ import { Terminal } from '@xterm/xterm';
 import { FitAddon } from '@xterm/addon-fit';
 import { getTerminalTheme } from './terminal-themes.js';
 import { _safeFit } from './dom.js';
+import { disposeResources } from './disposable.js';
 
 const BASE_FONT_FAMILY =
   '"JetBrains Mono", "Fira Code", "Cascadia Code", Menlo, monospace';
@@ -38,9 +39,11 @@ export function createTerminal(container, opts = {}) {
  * Dispose a terminal entry: unsub data listener, disconnect observer, dispose terminal.
  */
 export function disposeTerminal(data) {
-  if (data.unsubData) data.unsubData();
-  if (data.resizeObs) data.resizeObs.disconnect();
-  data.term.dispose();
+  disposeResources([
+    { ref: data, key: 'unsubData',  action: 'call' },
+    { ref: data, key: 'resizeObs',  action: 'disconnect' },
+    { ref: data, key: 'term',       action: 'dispose' },
+  ]);
 }
 
 /**

--- a/src/utils/terminal-instance.js
+++ b/src/utils/terminal-instance.js
@@ -4,6 +4,7 @@ import { bus, EVENTS } from './events.js';
 import { FilePathLinkProvider } from './file-link-provider.js';
 import { createTerminal } from './terminal-factory.js';
 import { CWD_POLL_MS } from './terminal-panel-helpers.js';
+import { disposeResources } from './disposable.js';
 
 /**
  * Wraps a single xterm instance with PTY integration, cwd polling, and lifecycle management.
@@ -114,13 +115,12 @@ export class TerminalInstance {
   dispose() {
     if (this.disposed) return;
     this.disposed = true;
-    if (this.cwdPollTimer) {
-      clearInterval(this.cwdPollTimer);
-      this.cwdPollTimer = null;
-    }
-    this.resizeObserver.disconnect();
-    if (this.unsubData) { this.unsubData(); this.unsubData = null; }
-    if (this.unsubExit) { this.unsubExit(); this.unsubExit = null; }
+    disposeResources([
+      { ref: this, key: 'cwdPollTimer',    action: 'clearInterval' },
+      { ref: this, key: 'resizeObserver',   action: 'disconnect' },
+      { ref: this, key: 'unsubData',        action: 'call' },
+      { ref: this, key: 'unsubExit',        action: 'call' },
+    ]);
     this._api.ptyKill({ id: this.id });
     this.terminal.dispose();
   }

--- a/src/utils/workspace-cleanup.js
+++ b/src/utils/workspace-cleanup.js
@@ -8,6 +8,7 @@
  */
 
 import { TAB_DISPOSABLES } from './tab-manager-helpers.js';
+import { disposeResources } from './disposable.js';
 
 // ── Tab disposal ──
 
@@ -17,8 +18,10 @@ import { TAB_DISPOSABLES } from './tab-manager-helpers.js';
  * @param {import('./tab-manager-helpers.js').WorkspaceTab} tab
  */
 export function disposeTab(tab) {
-  for (const key of TAB_DISPOSABLES) if (tab[key]) tab[key].dispose();
-  if (tab.layoutElement) tab.layoutElement.remove();
+  disposeResources([
+    ...TAB_DISPOSABLES.map((key) => ({ ref: tab, key, action: 'dispose' })),
+    { ref: tab, key: 'layoutElement', action: 'remove' },
+  ]);
 }
 
 /**


### PR DESCRIPTION
## Refactoring

Extracted a shared `disposeResources()` helper to eliminate the duplicated dispose/cleanup pattern across `terminal-instance.js`, `terminal-factory.js`, and `workspace-cleanup.js`.

Closes #164

## Vérifications

- [x] Build OK
- [x] Tests OK (321/321 passing)

---

📂 Path local : `/Users/rekta/projet/coding/refactor-pikagent`
🤖 PR créée automatiquement par l'Agent Refactor