### PR TITLE
refactor: extract inline rename helper + reuse drag body state

### DIFF
--- a/src/utils/drag-helpers.js
+++ b/src/utils/drag-helpers.js
@@ -22,8 +22,9 @@ export function clearDragBodyState() {
  * @param {string} cursor - CSS cursor value during the drag (e.g. 'grabbing', 'col-resize')
  * @param {(e: MouseEvent) => void} onMove - called on each mousemove (RAF-throttled)
  * @param {() => void} onDone - called after cleanup on mouseup
+ * @param {{ bodyClass?: string }} [opts] - optional overrides (bodyClass defaults to 'resizing')
  */
-export function trackMouse(cursor, onMove, onDone) {
+export function trackMouse(cursor, onMove, onDone, { bodyClass = 'resizing' } = {}) {
   let rafPending = false;
   const move = (e) => {
     if (rafPending) return;
@@ -34,11 +35,11 @@ export function trackMouse(cursor, onMove, onDone) {
     document.removeEventListener('mousemove', move);
     document.removeEventListener('mouseup', up);
     clearDragBodyState();
-    document.body.classList.remove('resizing');
+    if (bodyClass) document.body.classList.remove(bodyClass);
     onDone();
   };
   setDragBodyState(cursor);
-  document.body.classList.add('resizing');
+  if (bodyClass) document.body.classList.add(bodyClass);
   document.addEventListener('mousemove', move);
   document.addEventListener('mouseup', up);
 }

--- a/src/utils/file-tree-drop.js
+++ b/src/utils/file-tree-drop.js
@@ -4,7 +4,7 @@
  */
 
 import { bus, EVENTS } from './events.js';
-import { _el, startInlineRename, setupDropZone as _setupDropZone } from './dom.js';
+import { _el, setupInlineInput, startInlineRename, setupDropZone as _setupDropZone } from './dom.js';
 import { INPUT_BLUR_DELAY, computeIndent } from './file-tree-helpers.js';
 
 /**

--- a/src/utils/tab-drag.js
+++ b/src/utils/tab-drag.js
@@ -9,7 +9,7 @@
  */
 
 import { DRAG_THRESHOLD } from './tab-manager-helpers.js';
-import { setDragBodyState, clearDragBodyState, computeInsertionIndex } from './drag-helpers.js';
+import { trackMouse, computeInsertionIndex } from './drag-helpers.js';
 
 // ── Internal helpers ────────────────────────────────────────────────
 
@@ -116,14 +116,15 @@ function initDragState() {
 }
 
 /**
- * Apply visual drag-start effects: add CSS class, set cursor, and create
- * a floating ghost clone of the tab element.
+ * Apply visual drag-start effects: add CSS class and create a floating
+ * ghost clone of the tab element.
+ *
+ * Body cursor/userSelect are managed by trackMouse() — not set here.
  *
  * @returns {HTMLElement} the ghost element appended to document.body
  */
 function handleDragStart(tabEl) {
   tabEl.classList.add('tab-dragging');
-  setDragBodyState('grabbing');
 
   // Create floating ghost clone
   const ghost = tabEl.cloneNode(true);
@@ -142,6 +143,8 @@ function handleDragStart(tabEl) {
  * Clean up after a drag operation: remove visual effects, commit the
  * reorder if the tab was dropped on a valid target, and reset state.
  *
+ * Body cursor/userSelect are cleared by trackMouse() — not here.
+ *
  * @param {TabDragDeps} deps
  * @param {HTMLElement} tabEl
  * @param {HTMLElement|null} ghost
@@ -150,7 +153,6 @@ function handleDragStart(tabEl) {
  */
 function handleDragEnd({ getTabElements, reorderTab }, tabEl, ghost, state, tabId) {
   tabEl.classList.remove('tab-dragging');
-  clearDragBodyState();
   if (ghost) { ghost.remove(); }
   clearTabShifts(getTabElements);
 
@@ -172,7 +174,6 @@ function handleDragEnd({ getTabElements, reorderTab }, tabEl, ghost, state, tabI
  */
 export function setupTabDrag({ getTabElements, reorderTab }, tabEl, tabId) {
   let startX = 0;
-  let dragging = false;
   let ghost = null;
   let offsetX = 0;
 
@@ -183,30 +184,42 @@ export function setupTabDrag({ getTabElements, reorderTab }, tabEl, tabId) {
     startX = e.clientX;
     const rect = tabEl.getBoundingClientRect();
     offsetX = e.clientX - rect.left;
-    dragging = false;
 
-    const onMouseMove = (ev) => {
-      if (!dragging && Math.abs(ev.clientX - startX) > DRAG_THRESHOLD) {
-        dragging = true;
-        ghost = handleDragStart(tabEl);
-      }
-      if (dragging && ghost) {
-        ghost.style.left = `${ev.clientX - offsetX}px`;
-        updateTabDropTarget(getTabElements, state, ev.clientX, tabId);
-      }
+    // Phase 1: detect threshold before activating drag.
+    // Once the threshold is exceeded we hand off to trackMouse() which
+    // manages cursor/userSelect, RAF-throttled moves, and mouseup cleanup.
+    const onThresholdMove = (ev) => {
+      if (Math.abs(ev.clientX - startX) <= DRAG_THRESHOLD) return;
+
+      // Threshold crossed — remove these preliminary listeners
+      document.removeEventListener('mousemove', onThresholdMove);
+      document.removeEventListener('mouseup', onThresholdUp);
+
+      // Phase 2: real drag via trackMouse()
+      ghost = handleDragStart(tabEl);
+      // Process the first move immediately so the ghost starts in the right position
+      ghost.style.left = `${ev.clientX - offsetX}px`;
+      updateTabDropTarget(getTabElements, state, ev.clientX, tabId);
+
+      trackMouse('grabbing',
+        (mv) => {
+          ghost.style.left = `${mv.clientX - offsetX}px`;
+          updateTabDropTarget(getTabElements, state, mv.clientX, tabId);
+        },
+        () => {
+          handleDragEnd({ getTabElements, reorderTab }, tabEl, ghost, state, tabId);
+          ghost = null;
+        },
+        { bodyClass: 'dragging' },
+      );
     };
 
-    const onMouseUp = () => {
-      document.removeEventListener('mousemove', onMouseMove);
-      document.removeEventListener('mouseup', onMouseUp);
-
-      if (dragging) {
-        handleDragEnd({ getTabElements, reorderTab }, tabEl, ghost, state, tabId);
-        ghost = null;
-      }
+    const onThresholdUp = () => {
+      document.removeEventListener('mousemove', onThresholdMove);
+      document.removeEventListener('mouseup', onThresholdUp);
     };
 
-    document.addEventListener('mousemove', onMouseMove);
-    document.addEventListener('mouseup', onMouseUp);
+    document.addEventListener('mousemove', onThresholdMove);
+    document.addEventListener('mouseup', onThresholdUp);
   });
 }


### PR DESCRIPTION
## Summary

- **tab-drag.js** now delegates cursor/userSelect and mousemove/mouseup listener management to `trackMouse()` from `drag-helpers.js`, eliminating the duplicated body state handling (`setDragBodyState`/`clearDragBodyState` calls).
- **trackMouse()** gains an optional `bodyClass` parameter (defaults to `'resizing'`) so callers can customise the CSS class toggled on `document.body` during a drag.
- Fixed missing `setupInlineInput` import in `file-tree-drop.js`.

Note: The `startInlineRename` helper extraction (part 1 of #154) was already completed in PR #162. This PR addresses part 2 — making `tab-drag.js` reuse `trackMouse()`.

Closes #154

## Test plan

- [x] Build OK
- [x] Tests pass (320/320)
- [ ] Manual: verify tab drag-to-reorder still works (cursor changes to `grabbing`, ghost follows mouse, tabs shift)
- [ ] Manual: verify resize handles still work (cursor, `resizing` class on body)

---

🤖 PR created automatically by the Refactor Agent

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>