### PR TITLE
refactor: factorize try-catch IPC handler pattern

### DIFF
--- a/main/fs-manager-helpers.js
+++ b/main/fs-manager-helpers.js
@@ -1,26 +1,21 @@
 const fs = require('fs');
 const fsp = fs.promises;
 const path = require('path');
+const { runSafe } = require('./safe-handler');
 
 const MAX_FILE_SIZE = 2 * 1024 * 1024; // 2MB
 
-/** Wrap an async function — returns { error } on failure instead of throwing. */
-async function safeAsync(fn) {
-  try {
-    return await fn();
-  } catch (err) {
-    return { error: err.message };
-  }
-}
-
 /**
- * Factory that wraps an async function with safeAsync error handling.
+ * Factory that wraps an async function with error handling.
+ * On success returns the result of fn directly.
+ * On failure returns { error: err.message }.
+ *
  * @param {(...args: unknown[]) => Promise<unknown>} fn - async function to wrap
  * @returns {(...args: unknown[]) => Promise<unknown>} wrapped function with same signature
  */
 function createSafeHandler(fn) {
   return function (...args) {
-    return safeAsync(() => fn(...args));
+    return runSafe(() => fn(...args), (err) => ({ error: err.message }));
   };
 }
 

--- a/main/fs-manager-helpers.js
+++ b/main/fs-manager-helpers.js
@@ -7,13 +7,16 @@ const MAX_FILE_SIZE = 2 * 1024 * 1024; // 2MB
 
 /**
  * Factory that wraps an async function with error handling.
- * On success returns the result of fn directly.
+ * On success returns the result of fn directly (passthrough — no envelope).
  * On failure returns { error: err.message }.
+ *
+ * Distinct from `createSafeHandler` in safe-handler.js, which wraps results
+ * in a { success, data } envelope for IPC.
  *
  * @param {(...args: unknown[]) => Promise<unknown>} fn - async function to wrap
  * @returns {(...args: unknown[]) => Promise<unknown>} wrapped function with same signature
  */
-function createSafeHandler(fn) {
+function wrapSafe(fn) {
   return function (...args) {
     return runSafe(() => fn(...args), (err) => ({ error: err.message }));
   };
@@ -64,4 +67,4 @@ function dirFirstCompare(a, b) {
   return a.name.localeCompare(b.name);
 }
 
-module.exports = { MAX_FILE_SIZE, createSafeHandler, doCopy, dirFirstCompare };
+module.exports = { MAX_FILE_SIZE, wrapSafe, doCopy, dirFirstCompare };

--- a/main/fs-manager.js
+++ b/main/fs-manager.js
@@ -2,7 +2,7 @@ const fs = require('fs');
 const fsp = fs.promises;
 const path = require('path');
 const os = require('os');
-const { MAX_FILE_SIZE, createSafeHandler, doCopy, dirFirstCompare } = require('./fs-manager-helpers');
+const { MAX_FILE_SIZE, wrapSafe, doCopy, dirFirstCompare } = require('./fs-manager-helpers');
 
 // ---------------------------------------------------------------------------
 // File Watcher
@@ -51,34 +51,34 @@ async function readDirectory(dirPath) {
   }
 }
 
-const readFile = createSafeHandler(async (filePath) => {
+const readFile = wrapSafe(async (filePath) => {
   const stat = await fsp.stat(filePath);
   if (stat.size > MAX_FILE_SIZE) return { error: 'File too large (>2MB)' };
   const content = await fsp.readFile(filePath, 'utf-8');
   return { content, size: stat.size };
 });
 
-const writeFile = createSafeHandler(async (filePath, content) => {
+const writeFile = wrapSafe(async (filePath, content) => {
   await fsp.writeFile(filePath, content, 'utf-8');
   return { success: true };
 });
 
-const makeDir = createSafeHandler(async (dirPath) => {
+const makeDir = wrapSafe(async (dirPath) => {
   await fsp.mkdir(dirPath, { recursive: true });
   return { success: true };
 });
 
-const copyEntry = createSafeHandler(async (srcPath) => {
+const copyEntry = wrapSafe(async (srcPath) => {
   const destPath = await doCopy(srcPath, path.dirname(srcPath), true);
   return { success: true, destPath };
 });
 
-const copyFileTo = createSafeHandler(async (srcPath, destDir) => {
+const copyFileTo = wrapSafe(async (srcPath, destDir) => {
   const destPath = await doCopy(srcPath, destDir, false);
   return { success: true, destPath };
 });
 
-const renameEntry = createSafeHandler(async (oldPath, newName) => {
+const renameEntry = wrapSafe(async (oldPath, newName) => {
   const newPath = path.join(path.dirname(oldPath), newName);
   await fsp.rename(oldPath, newPath);
   return { success: true, newPath };

--- a/main/ipc-handlers.js
+++ b/main/ipc-handlers.js
@@ -1,5 +1,6 @@
 const { ipcMain } = require('electron');
 const { registerManagerHandlers, safeSend } = require('./ipc-helpers');
+const { createSafeHandler } = require('./safe-handler');
 
 /**
  * Register all IPC handlers.
@@ -41,14 +42,9 @@ function register(getWindow, { targets, ptyManager, sessionManager }) {
   });
 
   // FS: trash needs Electron shell
-  ipcMain.handle('fs:trash', async (_, filePath) => {
-    try {
-      await shell.trashItem(filePath);
-      return { success: true };
-    } catch (err) {
-      return { error: err.message };
-    }
-  });
+  ipcMain.handle('fs:trash', createSafeHandler(async (_, filePath) => {
+    await shell.trashItem(filePath);
+  }));
 
   // Dialog: needs window reference
   ipcMain.handle('dialog:openFolder', async () => {

--- a/main/logger.js
+++ b/main/logger.js
@@ -1,3 +1,5 @@
+const { runSafe } = require('./safe-handler');
+
 /**
  * Lightweight logger factory for main-process modules.
  * Standardises log format: [module] message
@@ -36,12 +38,10 @@ function createLogger(module) {
  * @returns {Promise<unknown>}
  */
 async function trySafe(fn, defaultValue, { log, label } = {}) {
-  try {
-    return await fn();
-  } catch (err) {
+  return runSafe(fn, (err) => {
     if (log && label) log.warn(`${label} failed`, err);
     return defaultValue;
-  }
+  });
 }
 
 module.exports = { createLogger, trySafe };

--- a/main/safe-handler.js
+++ b/main/safe-handler.js
@@ -36,7 +36,7 @@ function createSafeHandler(asyncFn) {
   return async (...args) => {
     try {
       const result = await asyncFn(...args);
-      return { success: true, data: result };
+      return result === undefined ? { success: true } : { success: true, data: result };
     } catch (err) {
       return { error: err.message };
     }

--- a/main/safe-handler.js
+++ b/main/safe-handler.js
@@ -1,0 +1,46 @@
+/**
+ * Shared factory for wrapping async functions with try-catch error handling.
+ *
+ * IPC handlers use the { success, data, error } shape.
+ * Lower-level helpers (safeAsync, trySafe) are unified via runSafe.
+ */
+
+/**
+ * Core primitive: run `fn`, return its result on success, or call `onError`
+ * with the caught Error on failure.
+ *
+ * @template T
+ * @param {() => Promise<T>} fn
+ * @param {(err: Error) => T} onError
+ * @returns {Promise<T>}
+ */
+async function runSafe(fn, onError) {
+  try {
+    return await fn();
+  } catch (err) {
+    return onError(err);
+  }
+}
+
+/**
+ * Factory that returns a wrapped async function.
+ * On success: returns { success: true, data: <result> }.
+ * On failure: returns { error: <message> }.
+ *
+ * Intended for IPC handlers that need a uniform {success/error} envelope.
+ *
+ * @param {(...args: unknown[]) => Promise<unknown>} asyncFn
+ * @returns {(...args: unknown[]) => Promise<{ success: true, data: unknown } | { error: string }>}
+ */
+function createSafeHandler(asyncFn) {
+  return async (...args) => {
+    try {
+      const result = await asyncFn(...args);
+      return { success: true, data: result };
+    } catch (err) {
+      return { error: err.message };
+    }
+  };
+}
+
+module.exports = { runSafe, createSafeHandler };

--- a/tests/main/fs-manager-helpers.test.js
+++ b/tests/main/fs-manager-helpers.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-const { MAX_FILE_SIZE, createSafeHandler, dirFirstCompare } = require('../../main/fs-manager-helpers');
+const { MAX_FILE_SIZE, wrapSafe, dirFirstCompare } = require('../../main/fs-manager-helpers');
 
 describe('fs-manager-helpers', () => {
   describe('MAX_FILE_SIZE', () => {
@@ -8,15 +8,15 @@ describe('fs-manager-helpers', () => {
     });
   });
 
-  describe('createSafeHandler', () => {
+  describe('wrapSafe', () => {
     it('wraps a function and returns its result on success', async () => {
-      const handler = createSafeHandler(async () => ({ value: 42 }));
+      const handler = wrapSafe(async () => ({ value: 42 }));
       const result = await handler();
       expect(result).toEqual({ value: 42 });
     });
 
     it('wraps a function and returns { error } on throw', async () => {
-      const handler = createSafeHandler(async () => { throw new Error('boom'); });
+      const handler = wrapSafe(async () => { throw new Error('boom'); });
       const result = await handler();
       expect(result).toEqual({ error: 'boom' });
     });


### PR DESCRIPTION
## Refactoring

- Created `main/safe-handler.js` with `createSafeHandler()` factory
- Unified `safeAsync()` and `trySafe()` to use the shared factory
- Applied factory to IPC custom handlers in `ipc-handlers.js`
- Eliminates duplicated try-catch → {success, error} boilerplate

Closes #174

## Vérifications

- [x] Build OK
- [x] Tests OK

---

📂 Path local : `/Users/rekta/projet/coding/refactor-pikagent`
🤖 PR créée automatiquement par l'Agent Refactor