### PR TITLE
refactor: factorize inline rename and drag body state patterns

### DIFF
--- a/src/components/flow-view.js
+++ b/src/components/flow-view.js
@@ -1,4 +1,5 @@
-import { _el, showPromptDialog, setupInlineInput, renderButtonBar } from '../utils/dom.js';
+import { _el, startInlineRename, renderButtonBar } from '../utils/dom.js';
+import { showPromptDialog } from '../utils/dom-dialogs.js';
 import { generateId } from '../utils/id.js';
 import { registerComponent, getComponent } from '../utils/component-registry.js';
 import {
@@ -216,22 +217,15 @@ export class FlowView {
     const cat = this.catData.categories.find(c => c.id === catId);
     if (!cat) return;
 
-    const input = _el('input', {
-      className: 'flow-category-name-input',
-      value: cat.name,
-    });
-
-    nameEl.parentNode.replaceChild(input, nameEl);
-    input.focus();
-    input.select();
-
     const finish = async (newName) => {
       if (newName && newName !== cat.name) cat.name = newName;
       await this._persistCategories();
       this._renderList();
     };
 
-    setupInlineInput(input, {
+    startInlineRename(nameEl, {
+      className: 'flow-category-name-input',
+      value: cat.name,
       onCommit: finish,
       onCancel: () => finish(null),
     });

--- a/src/utils/dom.js
+++ b/src/utils/dom.js
@@ -149,6 +149,46 @@ export function setupKeyboardShortcuts(el, { onEnter, onEscape } = {}) {
   return () => el.removeEventListener('keydown', handler);
 }
 
+/**
+ * Start an inline rename workflow: create an input, replace the target element,
+ * focus + select, and wire up commit/cancel via setupInlineInput.
+ *
+ * @param {HTMLElement} targetEl - element to replace with the input
+ * @param {{ className: string, value: string, selectRange?: [number, number],
+ *           blurDelay?: number,
+ *           replaceFn?: (targetEl: HTMLElement, input: HTMLInputElement) => void,
+ *           restoreFn?: (targetEl: HTMLElement, input: HTMLInputElement) => void,
+ *           onCommit: (value: string) => void,
+ *           onCancel?: () => void }} opts
+ * @returns {HTMLInputElement}
+ */
+export function startInlineRename(targetEl, { className, value, selectRange, blurDelay, replaceFn, restoreFn, onCommit, onCancel }) {
+  const input = _el('input', { className, value });
+
+  if (replaceFn) {
+    replaceFn(targetEl, input);
+  } else {
+    targetEl.replaceWith(input);
+  }
+
+  input.focus();
+  if (selectRange) {
+    input.setSelectionRange(selectRange[0], selectRange[1]);
+  } else {
+    input.select();
+  }
+
+  const restore = restoreFn ? () => restoreFn(targetEl, input) : undefined;
+
+  setupInlineInput(input, {
+    blurDelay,
+    onCommit: (val) => { if (restore) restore(); onCommit(val); },
+    onCancel: () => { if (restore) restore(); if (onCancel) onCancel(); },
+  });
+
+  return input;
+}
+
 /** Safely call fitAddon.fit(), swallowing errors from detached terminals. */
 export function _safeFit(fitAddon) {
   try { fitAddon.fit(); } catch {}

--- a/src/utils/drag-helpers.js
+++ b/src/utils/drag-helpers.js
@@ -5,13 +5,26 @@
  * Pure DOM helper — no component dependencies.
  */
 
+/** Set cursor and disable text selection on document.body during a drag. */
+export function setDragBodyState(cursor) {
+  document.body.style.cursor = cursor;
+  document.body.style.userSelect = 'none';
+}
+
+/** Clear cursor and re-enable text selection on document.body after a drag. */
+export function clearDragBodyState() {
+  document.body.style.cursor = '';
+  document.body.style.userSelect = '';
+}
+
 /**
  * Start a mouse-drag session: set cursor, throttle moves via RAF, clean up on mouseup.
  * @param {string} cursor - CSS cursor value during the drag (e.g. 'grabbing', 'col-resize')
  * @param {(e: MouseEvent) => void} onMove - called on each mousemove (RAF-throttled)
  * @param {() => void} onDone - called after cleanup on mouseup
+ * @param {{ bodyClass?: string }} [opts] - optional overrides (bodyClass defaults to 'resizing')
  */
-export function trackMouse(cursor, onMove, onDone) {
+export function trackMouse(cursor, onMove, onDone, { bodyClass = 'resizing' } = {}) {
   let rafPending = false;
   const move = (e) => {
     if (rafPending) return;
@@ -21,14 +34,35 @@ export function trackMouse(cursor, onMove, onDone) {
   const up = () => {
     document.removeEventListener('mousemove', move);
     document.removeEventListener('mouseup', up);
-    document.body.style.cursor = '';
-    document.body.style.userSelect = '';
-    document.body.classList.remove('resizing');
+    clearDragBodyState();
+    if (bodyClass) document.body.classList.remove(bodyClass);
     onDone();
   };
-  document.body.style.cursor = cursor;
-  document.body.style.userSelect = 'none';
-  document.body.classList.add('resizing');
+  setDragBodyState(cursor);
+  if (bodyClass) document.body.classList.add(bodyClass);
   document.addEventListener('mousemove', move);
   document.addEventListener('mouseup', up);
+}
+
+/**
+ * Compute the insertion index for a drag-and-drop operation by comparing
+ * the cursor position to the midpoints of the container's child elements.
+ *
+ * Works on both axes: pass `'y'` for vertical lists, `'x'` for horizontal ones.
+ *
+ * @param {HTMLElement[]} elements  — ordered array of child elements to test against
+ * @param {number} cursorPos       — clientX or clientY depending on axis
+ * @param {'x'|'y'} [axis='y']    — axis to measure
+ * @returns {number} index where the item should be inserted, or -1 to append at end
+ */
+export function computeInsertionIndex(elements, cursorPos, axis = 'y') {
+  const start = axis === 'x' ? 'left' : 'top';
+  const size  = axis === 'x' ? 'width' : 'height';
+
+  for (let i = 0; i < elements.length; i++) {
+    const rect = elements[i].getBoundingClientRect();
+    const mid = rect[start] + rect[size] / 2;
+    if (cursorPos < mid) return i;
+  }
+  return -1; // append at end
 }

--- a/src/utils/file-tree-drop.js
+++ b/src/utils/file-tree-drop.js
@@ -4,7 +4,7 @@
  */
 
 import { bus, EVENTS } from './events.js';
-import { _el, setupInlineInput, setupDropZone as _setupDropZone } from './dom.js';
+import { _el, setupInlineInput, startInlineRename, setupDropZone as _setupDropZone } from './dom.js';
 import { INPUT_BLUR_DELAY, computeIndent } from './file-tree-helpers.js';
 
 /**
@@ -63,25 +63,18 @@ export async function handleFileDrop(files, destDir, { copyTo }) {
  */
 export function promptRename(entryPath, nameEl, { rename }) {
   const oldName = entryPath.split('/').pop();
-  const input = _el('input', { className: 'file-tree-rename-input', type: 'text', value: oldName });
-
-  nameEl.style.display = 'none';
-  nameEl.parentElement.appendChild(input);
-  input.focus();
   const dotIndex = oldName.lastIndexOf('.');
-  input.setSelectionRange(0, dotIndex > 0 ? dotIndex : oldName.length);
 
-  setupInlineInput(input, {
+  startInlineRename(nameEl, {
+    className: 'file-tree-rename-input',
+    value: oldName,
+    selectRange: [0, dotIndex > 0 ? dotIndex : oldName.length],
     blurDelay: INPUT_BLUR_DELAY,
+    replaceFn: (el, input) => { el.style.display = 'none'; el.parentElement.appendChild(input); },
+    restoreFn: (el, input) => { input.remove(); el.style.display = ''; },
     onCommit: async (newName) => {
-      input.remove();
-      nameEl.style.display = '';
       if (!newName || newName === oldName) return;
       await rename(entryPath, newName);
-    },
-    onCancel: () => {
-      input.remove();
-      nameEl.style.display = '';
     },
   });
 }

--- a/src/utils/tab-drag.js
+++ b/src/utils/tab-drag.js
@@ -9,6 +9,7 @@
  */
 
 import { DRAG_THRESHOLD } from './tab-manager-helpers.js';
+import { trackMouse, computeInsertionIndex } from './drag-helpers.js';
 
 // ── Internal helpers ────────────────────────────────────────────────
 
@@ -34,36 +35,25 @@ function clearTabShifts(getTabElements) {
  * @returns {{ dropTargetId: string|null, dropBefore: boolean, insertIdx: number }}
  */
 function computeDropPosition(getTabElements, mx, orderedIds, dragId) {
-  let dropTargetId = null;
-  let dropBefore = true;
-  let insertIdx = -1;
+  // Build the list of non-dragged tab elements in order
+  const candidates = orderedIds.filter((id) => id !== dragId);
+  const elements = candidates.map((id) => getTabElements().get(id));
 
-  for (let i = 0; i < orderedIds.length; i++) {
-    const id = orderedIds[i];
-    if (id === dragId) continue;
-    const el = getTabElements().get(id);
-    const rect = el.getBoundingClientRect();
-    const midX = rect.left + rect.width / 2;
+  const rawIdx = computeInsertionIndex(elements, mx, 'x');
 
-    if (mx < midX) {
-      dropTargetId = id;
-      dropBefore = true;
-      insertIdx = i;
-      break;
-    }
+  if (rawIdx !== -1) {
+    // Map back from candidate-space index to orderedIds-space index
+    const dropTargetId = candidates[rawIdx];
+    const insertIdx = orderedIds.indexOf(dropTargetId);
+    return { dropTargetId, dropBefore: true, insertIdx };
   }
 
-  // If no target found, insert after last
-  if (insertIdx === -1) {
-    const lastId = orderedIds.filter((id) => id !== dragId).pop();
-    if (lastId) {
-      dropTargetId = lastId;
-      dropBefore = false;
-      insertIdx = orderedIds.length;
-    }
+  // No target found → insert after last
+  const lastId = candidates[candidates.length - 1] ?? null;
+  if (lastId) {
+    return { dropTargetId: lastId, dropBefore: false, insertIdx: orderedIds.length };
   }
-
-  return { dropTargetId, dropBefore, insertIdx };
+  return { dropTargetId: null, dropBefore: true, insertIdx: -1 };
 }
 
 /**
@@ -126,15 +116,15 @@ function initDragState() {
 }
 
 /**
- * Apply visual drag-start effects: add CSS class, set cursor, and create
- * a floating ghost clone of the tab element.
+ * Apply visual drag-start effects: add CSS class and create a floating
+ * ghost clone of the tab element.
+ *
+ * Body cursor/userSelect are managed by trackMouse() — not set here.
  *
  * @returns {HTMLElement} the ghost element appended to document.body
  */
 function handleDragStart(tabEl) {
   tabEl.classList.add('tab-dragging');
-  document.body.style.cursor = 'grabbing';
-  document.body.style.userSelect = 'none';
 
   // Create floating ghost clone
   const ghost = tabEl.cloneNode(true);
@@ -153,6 +143,8 @@ function handleDragStart(tabEl) {
  * Clean up after a drag operation: remove visual effects, commit the
  * reorder if the tab was dropped on a valid target, and reset state.
  *
+ * Body cursor/userSelect are cleared by trackMouse() — not here.
+ *
  * @param {TabDragDeps} deps
  * @param {HTMLElement} tabEl
  * @param {HTMLElement|null} ghost
@@ -161,8 +153,6 @@ function handleDragStart(tabEl) {
  */
 function handleDragEnd({ getTabElements, reorderTab }, tabEl, ghost, state, tabId) {
   tabEl.classList.remove('tab-dragging');
-  document.body.style.cursor = '';
-  document.body.style.userSelect = '';
   if (ghost) { ghost.remove(); }
   clearTabShifts(getTabElements);
 
@@ -184,7 +174,6 @@ function handleDragEnd({ getTabElements, reorderTab }, tabEl, ghost, state, tabI
  */
 export function setupTabDrag({ getTabElements, reorderTab }, tabEl, tabId) {
   let startX = 0;
-  let dragging = false;
   let ghost = null;
   let offsetX = 0;
 
@@ -195,30 +184,42 @@ export function setupTabDrag({ getTabElements, reorderTab }, tabEl, tabId) {
     startX = e.clientX;
     const rect = tabEl.getBoundingClientRect();
     offsetX = e.clientX - rect.left;
-    dragging = false;
 
-    const onMouseMove = (ev) => {
-      if (!dragging && Math.abs(ev.clientX - startX) > DRAG_THRESHOLD) {
-        dragging = true;
-        ghost = handleDragStart(tabEl);
-      }
-      if (dragging && ghost) {
-        ghost.style.left = `${ev.clientX - offsetX}px`;
-        updateTabDropTarget(getTabElements, state, ev.clientX, tabId);
-      }
+    // Phase 1: detect threshold before activating drag.
+    // Once the threshold is exceeded we hand off to trackMouse() which
+    // manages cursor/userSelect, RAF-throttled moves, and mouseup cleanup.
+    const onThresholdMove = (ev) => {
+      if (Math.abs(ev.clientX - startX) <= DRAG_THRESHOLD) return;
+
+      // Threshold crossed — remove these preliminary listeners
+      document.removeEventListener('mousemove', onThresholdMove);
+      document.removeEventListener('mouseup', onThresholdUp);
+
+      // Phase 2: real drag via trackMouse()
+      ghost = handleDragStart(tabEl);
+      // Process the first move immediately so the ghost starts in the right position
+      ghost.style.left = `${ev.clientX - offsetX}px`;
+      updateTabDropTarget(getTabElements, state, ev.clientX, tabId);
+
+      trackMouse('grabbing',
+        (mv) => {
+          ghost.style.left = `${mv.clientX - offsetX}px`;
+          updateTabDropTarget(getTabElements, state, mv.clientX, tabId);
+        },
+        () => {
+          handleDragEnd({ getTabElements, reorderTab }, tabEl, ghost, state, tabId);
+          ghost = null;
+        },
+        { bodyClass: 'dragging' },
+      );
     };
 
-    const onMouseUp = () => {
-      document.removeEventListener('mousemove', onMouseMove);
-      document.removeEventListener('mouseup', onMouseUp);
-
-      if (dragging) {
-        handleDragEnd({ getTabElements, reorderTab }, tabEl, ghost, state, tabId);
-        ghost = null;
-      }
+    const onThresholdUp = () => {
+      document.removeEventListener('mousemove', onThresholdMove);
+      document.removeEventListener('mouseup', onThresholdUp);
     };
 
-    document.addEventListener('mousemove', onMouseMove);
-    document.addEventListener('mouseup', onMouseUp);
+    document.addEventListener('mousemove', onThresholdMove);
+    document.addEventListener('mouseup', onThresholdUp);
   });
 }

--- a/src/utils/tab-renderer.js
+++ b/src/utils/tab-renderer.js
@@ -7,7 +7,7 @@
  *
  * @typedef {{ activeTabId: string|null, tabs: Map<string, import('./tab-manager-helpers.js').WorkspaceTab>, switchTo: (id: string) => void, closeTab: (id: string) => void, renameTab: (id: string, nameEl: HTMLElement) => void, setTabColorGroup: (id: string, colorGroupId: string|null) => void, toggleNoShortcut: (id: string) => void, dragDeps: import('./tab-drag.js').TabDragDeps }} TabElementDeps
  */
-import { _el, setupInlineInput } from './dom.js';
+import { _el, startInlineRename } from './dom.js';
 import { COLOR_GROUPS } from './tab-manager-helpers.js';
 import { setupTabDrag } from './tab-drag.js';
 import { attachContextMenu } from './context-menu.js';
@@ -151,12 +151,9 @@ export function bindTabContextMenu(deps, tabEl, id, tab, nameEl) {
  * @param {() => void} onCancel - callback on cancel (re-render only, no save)
  */
 export function inlineRenameTab(tab, nameEl, onCommit, onCancel) {
-  const input = _el('input', { className: 'tab-rename-input', value: tab.name });
-  nameEl.replaceWith(input);
-  input.focus();
-  input.select();
-
-  setupInlineInput(input, {
+  startInlineRename(nameEl, {
+    className: 'tab-rename-input',
+    value: tab.name,
     onCommit: (newName) => {
       tab.name = newName || tab.name;
       onCommit();


### PR DESCRIPTION
## Refactoring

- Extracted `startInlineRename()` helper to eliminate duplication across tab-renderer, file-tree-drop, and flow-view
- Made tab-drag.js use `trackMouse()` from drag-helpers.js instead of reimplementing body state management

Closes #154

## Vérifications

- [x] Build OK
- [x] Tests OK

---

📂 Path local : `/Users/rekta/projet/coding/refactor-pikagent`
🤖 PR créée automatiquement par l'Agent Refactor