### PR TITLE
refactor: replace loose JSDoc types with precise annotations

### DIFF
--- a/main/ipc-helpers.js
+++ b/main/ipc-helpers.js
@@ -45,9 +45,9 @@ const { forward: FORWARD_TABLE, spread: SPREAD_TABLE } = buildTablesFromSchema(A
 /**
  * @internal Exported for testing only — production code uses registerManagerHandlers().
  * Register forward-style handlers on ipcMain for a given target.
- * @param {object} ipc - Electron ipcMain
- * @param {object} target - The object whose methods will be called
- * @param {Array} entries - Array of [channel, method] tuples
+ * @param {Electron.IpcMain} ipc - Electron ipcMain
+ * @param {Record<string, Function>} target - The object whose methods will be called
+ * @param {Array<[string, string]>} entries - Array of [channel, method] tuples
  */
 function registerForward(ipc, target, entries) {
   for (const [channel, method] of entries) {
@@ -58,9 +58,9 @@ function registerForward(ipc, target, entries) {
 /**
  * @internal Exported for testing only — production code uses registerManagerHandlers().
  * Register spread-style handlers on ipcMain for a given target.
- * @param {object} ipc - Electron ipcMain
- * @param {object} target - The object whose methods will be called
- * @param {Array} entries - Array of [channel, method, keys] tuples
+ * @param {Electron.IpcMain} ipc - Electron ipcMain
+ * @param {Record<string, Function>} target - The object whose methods will be called
+ * @param {Array<[string, string, string[]]>} entries - Array of [channel, method, keys] tuples
  */
 function registerSpread(ipc, target, entries) {
   for (const [channel, method, keys] of entries) {
@@ -73,8 +73,8 @@ function registerSpread(ipc, target, entries) {
  * Resolves each domain from the provided targets map.
  * Method name is derived from the channel (domain:method).
  *
- * @param {object} ipc - Electron ipcMain
- * @param {Record<string, object>} targets - Map of domain -> target object
+ * @param {Electron.IpcMain} ipc - Electron ipcMain
+ * @param {Record<string, Record<string, Function>>} targets - Map of domain -> target object
  * @param {Set<string>} [skip] - Channels to skip (registered as custom handlers elsewhere)
  */
 function registerManagerHandlers(ipc, targets, skip = new Set()) {

--- a/shared/aggregation-utils.js
+++ b/shared/aggregation-utils.js
@@ -47,7 +47,7 @@ function groupAndAggregate(items, keyFn, aggFn) {
 
 /**
  * Counts occurrences of each key produced by keyFn.
- * @param {Array} items
+ * @param {Array<unknown>} items
  * @param {(item: unknown) => string} keyFn - Returns the key for each item
  * @returns {Record<string, number>} map of key -> count
  */

--- a/src/utils/diff-parser.js
+++ b/src/utils/diff-parser.js
@@ -148,7 +148,7 @@ export function buildSideBySideRows(hunks) {
 
 /**
  * Count additions and deletions across parsed hunks.
- * @param {Array} hunks - Parsed hunk objects from parseDiff().
+ * @param {Array<{changes: Array<{type: string, content: string}>}>} hunks - Parsed hunk objects from parseDiff().
  * @returns {{ additions: number, deletions: number }}
  */
 export function countDiffStats(hunks) {

--- a/src/utils/flow-view-helpers.js
+++ b/src/utils/flow-view-helpers.js
@@ -9,8 +9,8 @@ import { groupAndAggregate, countBy } from './aggregation-utils.js';
 
 /**
  * Toggle a value in a Set (add if absent, delete if present).
- * @param {Set} set
- * @param {*} value
+ * @param {Set<string>} set
+ * @param {string} value
  * @returns {boolean} true if the value is now in the set
  */
 export function toggleInSet(set, value) {
@@ -57,8 +57,8 @@ export function buildDotTooltip(run) {
 
 /**
  * Build a Map keyed by flow.id for fast lookup.
- * @param {Array} flows
- * @returns {Map<string, Object>}
+ * @param {Array<{id: string}>} flows
+ * @returns {Map<string, {id: string}>}
  */
 function buildFlowMap(flows) {
   return new Map(flows.map(f => [f.id, f]));
@@ -67,8 +67,8 @@ function buildFlowMap(flows) {
 /**
  * Resolve an array of flow IDs to flow objects using a flow map.
  * @param {string[]} ids
- * @param {Map<string, Object>} flowMap
- * @returns {Array}
+ * @param {Map<string, {id: string}>} flowMap
+ * @returns {Array<{id: string}>}
  */
 function resolveIds(ids, flowMap) {
   return ids.map(id => flowMap.get(id)).filter(Boolean);
@@ -76,10 +76,10 @@ function resolveIds(ids, flowMap) {
 
 /**
  * Return flows belonging to a given category, ordered by catData.order.
- * @param {Array} flows - all flow objects
+ * @param {Array<{id: string}>} flows - all flow objects
  * @param {Record<string, string[]>} order - catData.order mapping catId → [flowId, …]
  * @param {string} catId - category id
- * @returns {Array} ordered flows for this category
+ * @returns {Array<{id: string}>} ordered flows for this category
  */
 export function getFlowsForCategory(flows, order, catId) {
   return resolveIds(order[catId] || [], buildFlowMap(flows));
@@ -88,9 +88,9 @@ export function getFlowsForCategory(flows, order, catId) {
 /**
  * Return flows not assigned to any named category, respecting the
  * UNCATEGORIZED order when present, and appending any remaining flows.
- * @param {Array} flows - all flow objects
+ * @param {Array<{id: string}>} flows - all flow objects
  * @param {Record<string, string[]>} order - catData.order mapping catId → [flowId, …]
- * @returns {Array} ordered uncategorized flows
+ * @returns {Array<{id: string}>} ordered uncategorized flows
  */
 export function getUncategorizedFlows(flows, order) {
   const assigned = new Set();

--- a/src/utils/tab-manager-init.js
+++ b/src/utils/tab-manager-init.js
@@ -61,7 +61,7 @@ export async function initTabManager(deps) {
  * Returns the subscription handle for cleanup.
  *
  * @param {BusListenerDeps} deps
- * @returns {Array} subscription handle
+ * @returns {Array<() => void>} subscription handle
  */
 export function setupBusListeners(deps) {
   return subscribeBus([


### PR DESCRIPTION
## Refactoring

Remplace 16 annotations JSDoc lâches (`{Array}`, `{object}`, `{Set}`, `{*}`) par des types précis avec paramètres de type.

Closes #183

## Fichier(s) modifié(s)

- `main/ipc-helpers.js` — `{object}` → `{Electron.IpcMain}`, `{Record<string, Function>}` ; `{Array}` → tuples typés
- `src/utils/flow-view-helpers.js` — `{Set}` → `{Set<string>}`, `{*}` → `{string}`, `{Array}` → `{Array<{id: string}>}`
- `src/utils/diff-parser.js` — `{Array}` → type hunk structuré
- `shared/aggregation-utils.js` — `{Array}` → `{Array<unknown>}` (cohérent avec le reste du fichier)
- `src/utils/tab-manager-init.js` — `{Array}` → `{Array<() => void>}`

## Vérifications

- [x] Build OK
- [x] Tests OK (344/344)

---

📂 Path local : `/Users/rekta/projet/coding/refactor-pikagent`
🤖 PR créée automatiquement par l'Agent Refactor