### PR TITLE
refactor: clean up aggregation utils — remove dead re-exports

### DIFF
--- a/src/utils/flow-view-helpers.js
+++ b/src/utils/flow-view-helpers.js
@@ -5,7 +5,6 @@
 
 import { formatDateTime } from './date-utils.js';
 import { getLastRun } from '../../shared/flow-utils.js';
-import { groupAndAggregate, countBy } from './aggregation-utils.js';
 
 /**
  * Toggle a value in a Set (add if absent, delete if present).
@@ -161,8 +160,6 @@ export function deleteCategoryData(catData, catId) {
 // getLastRun imported from shared/flow-utils.js and re-exported
 export { getLastRun };
 
-// groupAndAggregate and countBy imported from shared/aggregation-utils.js and re-exported
-export { groupAndAggregate, countBy };
 
 /**
  * Build the list of card action descriptors for a given flow state.


### PR DESCRIPTION
## Refactoring

Les utilitaires d'agrégation (`aggregateByKey`, `groupAndAggregate`, `countBy`) sont déjà correctement centralisés dans `shared/aggregation-utils.js` (travail fait dans les PRs précédentes).

`flow-view-helpers.js` importait et ré-exportait `groupAndAggregate` et `countBy` sans qu'aucun consommateur n'utilise ces ré-exports. Suppression de ce code mort.

Closes #175

## Fichier(s) modifié(s)

- `src/utils/flow-view-helpers.js` — suppression de l'import et du re-export morts

## Vérifications

- [x] Build OK
- [x] Tests OK (344/344)

---

📂 Path local : `/Users/rekta/projet/coding/refactor-pikagent`
🤖 PR créée automatiquement par l'Agent Refactor