### PR TITLE
refactor: migrate stopPropagation patterns to onClickStopped helper

### DIFF
--- a/src/components/file-viewer-webview.js
+++ b/src/components/file-viewer-webview.js
@@ -3,6 +3,7 @@
  * Extracted from file-viewer.js to reduce component size.
  */
 import { _el } from '../utils/dom.js';
+import { onClickStopped } from '../utils/event-helpers.js';
 import { setupInlineInput } from '../utils/form-helpers.js';
 import { generateId } from '../utils/id.js';
 import { bus, EVENTS } from '../utils/events.js';
@@ -85,8 +86,7 @@ export class WebviewManager {
     const btn = _el('button', `mode-btn mode-btn-webview${currentMode === wt.id ? ' active' : ''}`);
     btn.appendChild(_el('span', null, wt.label));
     const closeBtn = _el('span', 'mode-btn-close', { textContent: '\u00d7' });
-    closeBtn.addEventListener('click', (e) => {
-      e.stopPropagation();
+    onClickStopped(closeBtn, () => {
       const removedId = this.removeWebview(wt.id);
       if (currentMode === removedId) this._switchMode('files');
       else this._renderModeBar();

--- a/src/components/settings-keybindings.js
+++ b/src/components/settings-keybindings.js
@@ -4,6 +4,7 @@
  */
 import { formatCombo } from '../utils/shortcut-helpers.js';
 import { _el, createActionButton } from '../utils/dom.js';
+import { onClickStopped } from '../utils/event-helpers.js';
 import { createSettingsSection } from '../utils/settings-section-builder.js';
 import { registerComponent } from '../utils/component-registry.js';
 
@@ -30,8 +31,7 @@ export function createKeyBadge(binding, index, shortcutManager, startRecordingFn
   });
 
   const removeBtn = _el('span', 'keybinding-badge-remove', '×');
-  removeBtn.addEventListener('click', (e) => {
-    e.stopPropagation();
+  onClickStopped(removeBtn, () => {
     binding.keys.splice(index, 1);
     shortcutManager.updateBinding(binding.id, binding.keys);
     renderKeybindingsFn();

--- a/src/utils/form-helpers.js
+++ b/src/utils/form-helpers.js
@@ -5,6 +5,7 @@
  */
 
 import { _el } from './dom.js';
+import { onClickStopped } from './event-helpers.js';
 import { setupKeyboardShortcuts } from './keyboard-helpers.js';
 
 /**
@@ -34,7 +35,7 @@ export function setupInlineInput(input, { onCommit, onCancel, blurDelay = 0 }) {
     if (blurDelay > 0) setTimeout(() => { if (!committed) commit(); }, blurDelay);
     else if (!committed) commit();
   });
-  input.addEventListener('click', (e) => e.stopPropagation());
+  onClickStopped(input, () => {});
 }
 
 /**

--- a/src/utils/terminal-node-builder.js
+++ b/src/utils/terminal-node-builder.js
@@ -5,6 +5,7 @@
 
 import { bus, EVENTS } from './events.js';
 import { _el } from './dom.js';
+import { onClickStopped } from './event-helpers.js';
 import { SplitNode, DRAG_GRIP, createSplitContainer } from './terminal-panel-helpers.js';
 import { TerminalInstance } from './terminal-instance.js';
 
@@ -26,10 +27,7 @@ export function buildTopBar(node, { onClose, setupDrag }) {
     textContent: '×',
     title: 'Close terminal',
   });
-  closeBtn.addEventListener('click', (e) => {
-    e.stopPropagation();
-    onClose();
-  });
+  onClickStopped(closeBtn, () => onClose());
 
   topBar.appendChild(dragHandle);
   topBar.appendChild(closeBtn);


### PR DESCRIPTION
## Refactoring

Migre les derniers patterns `addEventListener('click', (e) => { e.stopPropagation(); ... })` vers le helper `onClickStopped` de `event-helpers.js`.

4 fichiers migrés, éliminant le boilerplate stopPropagation inline.

Closes #173

## Fichier(s) modifié(s)

- `src/components/settings-keybindings.js` — removeBtn click handler
- `src/components/file-viewer-webview.js` — closeBtn click handler
- `src/utils/terminal-node-builder.js` — closeBtn click handler
- `src/utils/form-helpers.js` — input click swallow

## Vérifications

- [x] Build OK
- [x] Tests OK (344/344)

---

📂 Path local : `/Users/rekta/projet/coding/refactor-pikagent`
🤖 PR créée automatiquement par l'Agent Refactor