### PR TITLE
refactor: remove backward-compat re-exports from dom.js

### DIFF
--- a/src/utils/dom.js
+++ b/src/utils/dom.js
@@ -163,10 +163,3 @@ export function positionInViewport(x, y, width, height, padding = 8) {
   };
 }
 
-// ---------------------------------------------------------------------------
-// Re-exports for backward compatibility — prefer importing from the dedicated
-// modules directly: form-helpers.js, drop-zone-helpers.js, keyboard-helpers.js
-// ---------------------------------------------------------------------------
-export { setupKeyboardShortcuts } from './keyboard-helpers.js';
-export { setupInlineInput, startInlineRename } from './form-helpers.js';
-export { setupDropZone } from './drop-zone-helpers.js';


### PR DESCRIPTION
## Refactoring

Supprime les re-exports de compatibilité de `dom.js` (lignes 170-172) : `setupKeyboardShortcuts`, `setupInlineInput`, `startInlineRename`, `setupDropZone`.

Tous les importeurs ont déjà été migrés vers les modules dédiés (`keyboard-helpers.js`, `form-helpers.js`, `drop-zone-helpers.js`) — aucun fichier n'importait encore ces helpers depuis `dom.js`.

Closes #172

## Fichier(s) modifié(s)

- `src/utils/dom.js` — suppression des 4 re-exports morts

## Vérifications

- [x] Build OK
- [x] Tests OK (344/344)

---

📂 Path local : `/Users/rekta/projet/coding/refactor-pikagent`
🤖 PR créée automatiquement par l'Agent Refactor