### PR TITLE
refactor: tighten remaining JSDoc types (#189)

### DIFF
--- a/src/utils/board-helpers.js
+++ b/src/utils/board-helpers.js
@@ -65,7 +65,7 @@ export function resolveCardStatus(dataBytes) {
 
 /**
  * Get the tab name for a terminal ID.
- * @param {Map} tabs - tabManager.tabs
+ * @param {Map<string, import('./tab-manager-helpers.js').WorkspaceTab>} tabs - tabManager.tabs
  * @param {string} termId
  * @returns {string|null}
  */

--- a/src/utils/disposable.js
+++ b/src/utils/disposable.js
@@ -15,6 +15,7 @@
 /**
  * @typedef {'dispose' | 'disconnect' | 'call' | 'remove' | 'clearInterval' | 'clearTimeout'} CleanupAction
  * @typedef {{ ref: object, key: string, action: CleanupAction }} ResourceDescriptor
+ * @typedef {{ disposed?: boolean } & Record<string, unknown>} DisposableOwner
  */
 
 /**
@@ -62,9 +63,9 @@ export function disposeResources(resources) {
  *   4. Calls the optional `afterDispose` callback for any cleanup that cannot be
  *      expressed as a resource descriptor (e.g. method calls with arguments).
  *
- * @param {object} owner              — the object that owns the resources
- * @param {(owner: object) => ResourceDescriptor[]} buildResources — returns the descriptor list
- * @param {((owner: object) => void)|null} [afterDispose] — extra cleanup after resources are freed
+ * @param {DisposableOwner} owner              — the object that owns the resources
+ * @param {(owner: DisposableOwner) => ResourceDescriptor[]} buildResources — returns the descriptor list
+ * @param {((owner: DisposableOwner) => void)|null} [afterDispose] — extra cleanup after resources are freed
  * @returns {() => void} a dispose function bound to `owner`
  */
 export function createGuardedDispose(owner, buildResources, afterDispose = null) {

--- a/src/utils/tab-color-filter.js
+++ b/src/utils/tab-color-filter.js
@@ -17,9 +17,9 @@ export function isTabVisible(tab, activeColorFilter, excludedColors) {
 
 /**
  * Build the color filter bar DOM element.
- * @param {Map} tabs
+ * @param {Map<string, import('./tab-manager-helpers.js').WorkspaceTab>} tabs
  * @param {string|null} activeColorFilter
- * @param {Set} excludedColors
+ * @param {Set<string>} excludedColors
  * @param {{ onClearFilter: () => void, onSetFilter: (colorGroupId: string) => void, onToggleExclude: (colorGroupId: string) => void }} handlers
  * @returns {HTMLElement|null}
  */


### PR DESCRIPTION
## Refactoring

Tighten loose JSDoc types (Map/Set without generics, generic {object}) in files not covered by #183.

Closes #189

## Fichier(s) modifié(s)

- \`src/utils/disposable.js\`
- \`src/utils/tab-color-filter.js\`
- \`src/utils/board-helpers.js\`

## Vérifications

- [x] Build OK
- [x] Tests OK

---

📂 Path local : \`/Users/rekta/projet/coding/refactor-pikagent\`
🤖 PR créée automatiquement par l'Agent Refactor