### PR TITLE
refactor: factor addEventListener patterns via event-helpers (#173)

### DIFF
--- a/src/components/git-changes-view.js
+++ b/src/components/git-changes-view.js
@@ -1,5 +1,6 @@
 import { bus, EVENTS } from '../utils/events.js';
 import { _el } from '../utils/dom.js';
+import { onClickStopped } from '../utils/event-helpers.js';
 import { STATUS_LABELS, CHEVRON, CHANGE_SECTIONS, computeTotalChanges, buildFileKey } from '../utils/git-changes-helpers.js';
 import { registerComponent, getComponent } from '../utils/component-registry.js';
 
@@ -71,6 +72,12 @@ export class GitChangesView {
     const key = buildFileKey(file.path, isStaged);
     const isExpanded = this.expandedFile === key;
 
+    const openBtn = _el('span', { className: 'git-open-btn', textContent: '→', title: 'Open file' });
+    onClickStopped(openBtn, () => {
+      /** @fires file:open {{ path: string, name: string }} */
+      bus.emit(EVENTS.FILE_OPEN, { path: `${this.gitCwd}/${file.path}`, name: file.path.split('/').pop() });
+    });
+
     const row = _el('div', { className: 'git-file-item', onClick: () => {
       this.expandedFile = this.expandedFile === key ? null : key;
       this.loadChanges();
@@ -78,11 +85,7 @@ export class GitChangesView {
       _el('span', 'git-chevron', isExpanded ? CHEVRON.expanded : CHEVRON.collapsed),
       _el('span', `git-file-status git-status-${file.status}`, STATUS_LABELS[file.status] || file.status),
       _el('span', { className: 'git-file-name-label', textContent: file.path, title: file.path }),
-      _el('span', { className: 'git-open-btn', textContent: '→', title: 'Open file', onClick: (e) => {
-        e.stopPropagation();
-        /** @fires file:open {{ path: string, name: string }} */
-        bus.emit(EVENTS.FILE_OPEN, { path: `${this.gitCwd}/${file.path}`, name: file.path.split('/').pop() });
-      }}),
+      openBtn,
     );
 
     const item = _el('div', 'git-file-row', row);

--- a/src/utils/dom.js
+++ b/src/utils/dom.js
@@ -10,6 +10,11 @@
  *   - setupInlineInput, startInlineRename  → ./form-helpers.js
  *   - setupDropZone                        → ./drop-zone-helpers.js
  *   - setupKeyboardShortcuts               → ./keyboard-helpers.js
+ */
+import { onClickStopped } from './event-helpers.js';
+
+/**
+ * Create a DOM element.
  *
  * Supports two calling conventions:
  *   _el('div', { className: 'c', textContent: 't', onClick: fn }, child…)  — object attrs
@@ -63,9 +68,8 @@ export function createActionButton({ text, label = '', title, cls, className, on
   if (title) btn.title = title;
   if (childNode) btn.appendChild(childNode);
   if (onClick) {
-    btn.addEventListener('click', stopPropagation
-      ? (e) => { e.stopPropagation(); onClick(e); }
-      : onClick);
+    if (stopPropagation) onClickStopped(btn, onClick);
+    else btn.addEventListener('click', onClick);
   }
   return btn;
 }


### PR DESCRIPTION
## Refactoring

Factor duplicated addEventListener patterns (click+stopPropagation+preventDefault, keydown Enter/Escape) into `src/utils/event-helpers.js`. Replace inline boilerplate across the renderer.

Earlier refactors already extracted most patterns (helpers present in `event-helpers.js`: `onClickStopped`, `onKeyAction`, `onDragEvents`). This PR sweeps the two remaining inline occurrences that still matched the helper contract:

- `src/utils/dom.js#createActionButton` — delegate the `stopPropagation: true` branch to `onClickStopped`.
- `src/components/git-changes-view.js` — the per-file "Open" button now uses `onClickStopped` instead of an inline `e.stopPropagation()` handler.

All other mentioned files (`tab-renderer.js`, `flow-card-setup.js`, `context-menu.js`, `file-tree-renderer.js`, `form-helpers.js` (ex `dom.setupInlineInput`), `file-tree-drop.js`, `flow-view.js`) were already migrated and either use the helpers directly or delegate via `createActionButton` / `renderButtonBar` / `setupKeyboardShortcuts`.

Conservative: complex keydown handlers (Cmd+S, Tab, shortcut recording) and drop-zone callbacks that merely call `stopPropagation` inside their own hooks were left untouched — they do not match the helper contract cleanly.

Closes #173

## Fichier(s) modifié(s)

- `src/utils/dom.js` (createActionButton now uses `onClickStopped`)
- `src/components/git-changes-view.js` (open-file button wired with `onClickStopped`)

## Vérifications

- [x] Build OK
- [x] Tests OK (349/349)

---

📂 Path local : `/Users/rekta/projet/coding/refactor-pikagent`
🤖 PR créée automatiquement par l'Agent Refactor