### PR TITLE
refactor: tighten remaining loose JSDoc types

### DIFF
--- a/main/ipc-handlers.js
+++ b/main/ipc-handlers.js
@@ -9,7 +9,7 @@ const { createSafeHandler } = require('./safe-handler');
  * `manager-init.js`.  This module only cares about IPC dispatching.
  *
  * @param {() => import('electron').BrowserWindow} getWindow
- * @param {{ targets: Record<string, object>, ptyManager: object, sessionManager: object }} deps
+ * @param {{ targets: Record<string, Record<string, unknown>>, ptyManager: Record<string, unknown>, sessionManager: Record<string, unknown> }} deps
  */
 function register(getWindow, { targets, ptyManager, sessionManager }) {
   const { shell, dialog } = require('electron');

--- a/main/ipc-helpers.js
+++ b/main/ipc-helpers.js
@@ -46,7 +46,7 @@ const { forward: FORWARD_TABLE, spread: SPREAD_TABLE } = buildTablesFromSchema(A
  * @internal Exported for testing only — production code uses registerManagerHandlers().
  * Register forward-style handlers on ipcMain for a given target.
  * @param {Electron.IpcMain} ipc - Electron ipcMain
- * @param {Record<string, Function>} target - The object whose methods will be called
+ * @param {Record<string, (...args: unknown[]) => unknown>} target - The object whose methods will be called
  * @param {Array<[string, string]>} entries - Array of [channel, method] tuples
  */
 function registerForward(ipc, target, entries) {
@@ -59,7 +59,7 @@ function registerForward(ipc, target, entries) {
  * @internal Exported for testing only — production code uses registerManagerHandlers().
  * Register spread-style handlers on ipcMain for a given target.
  * @param {Electron.IpcMain} ipc - Electron ipcMain
- * @param {Record<string, Function>} target - The object whose methods will be called
+ * @param {Record<string, (...args: unknown[]) => unknown>} target - The object whose methods will be called
  * @param {Array<[string, string, string[]]>} entries - Array of [channel, method, keys] tuples
  */
 function registerSpread(ipc, target, entries) {
@@ -74,7 +74,7 @@ function registerSpread(ipc, target, entries) {
  * Method name is derived from the channel (domain:method).
  *
  * @param {Electron.IpcMain} ipc - Electron ipcMain
- * @param {Record<string, Record<string, Function>>} targets - Map of domain -> target object
+ * @param {Record<string, Record<string, (...args: unknown[]) => unknown>>} targets - Map of domain -> target object
  * @param {Set<string>} [skip] - Channels to skip (registered as custom handlers elsewhere)
  */
 function registerManagerHandlers(ipc, targets, skip = new Set()) {

--- a/main/logger.js
+++ b/main/logger.js
@@ -28,13 +28,17 @@ function createLogger(module) {
 }
 
 /**
+ * @typedef {{ info: (msg: string, err?: unknown) => void, warn: (msg: string, err?: unknown) => void, error: (msg: string, err?: unknown) => void }} Logger
+ */
+
+/**
  * Generic safe-execution wrapper.
  * Runs `fn`, returns its result on success or `defaultValue` on error.
  * Optionally logs failures via a logger's `warn` method.
  *
  * @param {() => unknown} fn - async or sync function to execute
  * @param {unknown} defaultValue - value returned when fn throws
- * @param {{ log: object, label: string }} [opts] - optional logger & label
+ * @param {{ log: Logger, label: string }} [opts] - optional logger & label
  * @returns {Promise<unknown>}
  */
 async function trySafe(fn, defaultValue, { log, label } = {}) {

--- a/shared/flow-utils.js
+++ b/shared/flow-utils.js
@@ -5,9 +5,13 @@
  */
 
 /**
+ * @typedef {{ date: string, timestamp: string, logTimestamp?: string, status: string }} FlowRun
+ */
+
+/**
  * Return the last run from a flow's runs array, or null if none.
- * @param {{ runs?: Array }} flow
- * @returns {{ date: string, timestamp: string, logTimestamp?: string, status: string }|null}
+ * @param {{ runs?: FlowRun[] }} flow
+ * @returns {FlowRun|null}
  */
 function getLastRun(flow) {
   return flow.runs?.at(-1) ?? null;

--- a/src/utils/context-menu.js
+++ b/src/utils/context-menu.js
@@ -78,6 +78,17 @@ export class ContextMenu {
 export const contextMenu = new ContextMenu();
 
 /**
+ * @typedef {{
+ *   label?: string,
+ *   action?: () => void,
+ *   separator?: boolean,
+ *   children?: ContextMenuItem[],
+ *   colorDot?: string,
+ *   shortcut?: string
+ * }} ContextMenuItem
+ */
+
+/**
  * Attach a contextmenu listener to `el` that prevents the default behaviour,
  * stops propagation, and – when `buildItems` returns an array of menu items –
  * shows the context menu at the pointer position.
@@ -87,7 +98,7 @@ export const contextMenu = new ContextMenu();
  * colour filter).
  *
  * @param {HTMLElement} el - element to listen on
- * @param {(e: MouseEvent) => Array|void} buildItems - receives the raw event,
+ * @param {(e: MouseEvent) => ContextMenuItem[]|void|Promise<ContextMenuItem[]|void>} buildItems - receives the raw event,
  *   should return an items array (or nothing).
  */
 export function attachContextMenu(el, buildItems) {

--- a/src/utils/disposable.js
+++ b/src/utils/disposable.js
@@ -14,7 +14,7 @@
 
 /**
  * @typedef {'dispose' | 'disconnect' | 'call' | 'remove' | 'clearInterval' | 'clearTimeout'} CleanupAction
- * @typedef {{ ref: object, key: string, action: CleanupAction }} ResourceDescriptor
+ * @typedef {{ ref: Record<string, unknown>, key: string, action: CleanupAction }} ResourceDescriptor
  * @typedef {{ disposed?: boolean } & Record<string, unknown>} DisposableOwner
  */
 

--- a/src/utils/dom.js
+++ b/src/utils/dom.js
@@ -22,7 +22,7 @@ import { onClickStopped } from './event-helpers.js';
  *
  * @param {string} tag
  * @param {Record<string, unknown>|string|null} [attrsOrClass]
- * @param {...(Node|string|Object|null|false)} children
+ * @param {...(Node|string|Record<string, unknown>|null|false)} children
  */
 export function _el(tag, attrsOrClass, ...children) {
   const el = document.createElement(tag);

--- a/src/utils/file-tree-drop.js
+++ b/src/utils/file-tree-drop.js
@@ -14,7 +14,7 @@ import { INPUT_BLUR_DELAY, computeIndent } from './file-tree-helpers.js';
  * dropped from the OS file manager are copied into a target directory.
  *
  * @param {HTMLElement} el - element to receive drop events
- * @param {string|Function} getTargetDir - target dir path or a function returning it
+ * @param {string|(() => string)} getTargetDir - target dir path or a function returning it
  * @param {(files: FileList, destDir: string) => Promise<void>} handleFileDrop
  * @param {string} [className='drop-target'] - CSS class toggled during drag
  */

--- a/src/utils/usage-view-helpers.js
+++ b/src/utils/usage-view-helpers.js
@@ -40,7 +40,7 @@ function _td(text, attrs = {}) {
  *   - A DOM Node (inserted as-is into the row)
  *   - An object { value, className?, style?, title? } → converted via _td()
  *
- * @param {Array<Node | { value: string|number, className?: string, style?: object, title?: string }>} columns
+ * @param {Array<Node | { value: string|number, className?: string, style?: Partial<CSSStyleDeclaration>, title?: string }>} columns
  * @returns {HTMLTableRowElement}
  */
 export function buildTableRow(columns) {

--- a/src/utils/workspace-serializer.js
+++ b/src/utils/workspace-serializer.js
@@ -3,6 +3,16 @@
  *
  * Handles tab serialization and config restoration.
  *
+ * @typedef {{
+ *   name: string,
+ *   cwd: string,
+ *   noShortcut: boolean,
+ *   colorGroup: string|null,
+ *   splitTree: unknown,
+ *   panels: Record<string, number>,
+ *   webviewTabs?: unknown[]
+ * }} SerializedTab
+ *
  * @typedef {{ tabs: Map<string, WorkspaceTab>, activeTabId: string|null }} SerializeDeps
  *
  * @typedef {{ tabs: Map<string, WorkspaceTab>, setActiveTabId: (id: string|null) => void, defaultCwd: string, renderTabBar: () => void, switchTo: (id: string) => void, configManager: { isRestoring: boolean }, viewStore: import('./sidebar-manager.js').SideViewStore }} RestoreConfigDeps
@@ -19,7 +29,7 @@ import { disposeAllTabs } from './workspace-cleanup.js';
 /**
  * Serialize all tabs into a config object.
  * @param {SerializeDeps} deps
- * @returns {{ tabs: Array, activeTabIndex: number }}
+ * @returns {{ tabs: SerializedTab[], activeTabIndex: number }}
  */
 export function serialize({ tabs, activeTabId }) {
   const serializedTabs = [];


### PR DESCRIPTION
## Refactoring

Tighten loose JSDoc types in 10 files (complement to #110, #183, #189).

Changes:
- `src/utils/dom.js` : `Object` → `Record<string, unknown>` in `_el` children
- `src/utils/disposable.js` : `ref: object` → `ref: Record<string, unknown>`
- `main/logger.js` : add `Logger` typedef and use it for `log` opts
- `main/ipc-handlers.js` : `object` × 3 → `Record<string, unknown>`
- `main/ipc-helpers.js` : `Function` × 3 → `(...args: unknown[]) => unknown`
- `src/utils/usage-view-helpers.js` : `style?: object` → `Partial<CSSStyleDeclaration>`
- `src/utils/file-tree-drop.js` : `Function` → `() => string`
- `src/utils/workspace-serializer.js` : add `SerializedTab` typedef and use it
- `src/utils/context-menu.js` : add `ContextMenuItem` typedef and use it
- `shared/flow-utils.js` : add `FlowRun` typedef and use it

Note : `src/utils/flow-card-setup.js` line 96 (`@typedef {object} CreateFlowCardDeps`) is left as-is — the typedef is followed by 9 `@property` tags that already define the precise shape; this is the canonical JSDoc form.

Closes #194

## Vérifications

- [x] Build OK (`npm run build`)
- [x] Tests OK (341/341 passed) — pre-existing happy-dom resolution warning unchanged

---

📂 Path local : \`/Users/rekta/projet/coding/refactor-pikagent\`
🤖 PR créée automatiquement par l'Agent Refactor