### PR TITLE
refactor: factor async-stop and listener-button patterns

### DIFF
--- a/src/components/flow-modal.js
+++ b/src/components/flow-modal.js
@@ -1,5 +1,6 @@
 import { generateId } from '../utils/id.js';
 import { _el, createActionButton, createModalOverlay } from '../utils/dom.js';
+import { appendListenerButtons } from '../utils/event-helpers.js';
 import {
   SCHEDULE_LABELS, DAY_NAMES, WEEKDAY_INDICES, INTERVAL_HOURS,
   DEFAULT_TIME, buildScheduleData,
@@ -121,19 +122,16 @@ function _buildIntervalChip(existing) {
 function _buildDaysChip(existing) {
   const selectedDays = new Set(existing?.schedule?.days || WEEKDAY_INDICES);
   const daysChip = _el('div', { className: 'flow-modal-chip flow-modal-days' });
-  for (let d = 0; d < 7; d++) {
-    const dayBtn = createActionButton({
-      text: DAY_NAMES[d],
-      cls: 'flow-day-btn',
-      onClick: (e) => {
-        e.preventDefault();
-        selectedDays.has(d) ? selectedDays.delete(d) : selectedDays.add(d);
-        dayBtn.classList.toggle('active');
-      },
-    });
-    if (selectedDays.has(d)) dayBtn.classList.add('active');
-    daysChip.appendChild(dayBtn);
-  }
+  const dayIndices = [0, 1, 2, 3, 4, 5, 6];
+  appendListenerButtons(daysChip, dayIndices, {
+    renderButton: (d) => createActionButton({ text: DAY_NAMES[d], cls: 'flow-day-btn' }),
+    isActive: (d) => selectedDays.has(d),
+    onClick: (e, d, btn) => {
+      e.preventDefault();
+      selectedDays.has(d) ? selectedDays.delete(d) : selectedDays.add(d);
+      btn.classList.toggle('active');
+    },
+  });
   return { daysChip, selectedDays };
 }
 

--- a/src/components/settings-appearance.js
+++ b/src/components/settings-appearance.js
@@ -5,6 +5,7 @@
 import { TERMINAL_THEMES, getTerminalThemeName, setTerminalTheme, getTerminalTheme, switchTerminalForMode } from '../utils/terminal-themes.js';
 import { getAppTheme, setAppTheme } from '../utils/app-theme.js';
 import { _el, createActionButton } from '../utils/dom.js';
+import { appendListenerButtons } from '../utils/event-helpers.js';
 import { MODE_BUTTONS, THEME_PREVIEW_LINES, COLOR_DOT_KEYS } from '../utils/settings-helpers.js';
 import { createSettingsSection } from '../utils/settings-section-builder.js';
 import { registerComponent } from '../utils/component-registry.js';
@@ -78,19 +79,15 @@ export function renderAppearance(contentEl, tabManager, renderAppearanceFn) {
   const modeToggle = _el('div', 'theme-mode-toggle');
   const currentMode = getAppTheme();
 
-  for (const { mode, label } of MODE_BUTTONS) {
-    const btn = createActionButton({
-      text: label,
-      cls: 'theme-mode-btn',
-      onClick: () => {
-        setAppTheme(mode);
-        if (switchTerminalForMode(mode)) applyThemeToTerminals(tabManager);
-        renderAppearanceFn();
-      },
-    });
-    if (currentMode === mode) btn.classList.add('active');
-    modeToggle.appendChild(btn);
-  }
+  appendListenerButtons(modeToggle, MODE_BUTTONS, {
+    renderButton: ({ label }) => createActionButton({ text: label, cls: 'theme-mode-btn' }),
+    isActive: ({ mode }) => currentMode === mode,
+    onClick: (_e, { mode }) => {
+      setAppTheme(mode);
+      if (switchTerminalForMode(mode)) applyThemeToTerminals(tabManager);
+      renderAppearanceFn();
+    },
+  });
 
   modeRow.appendChild(modeToggle);
 

--- a/src/components/settings-configs.js
+++ b/src/components/settings-configs.js
@@ -3,20 +3,26 @@
  * Extracted from settings-modal.js to reduce component size.
  */
 import { _el, renderButtonBar } from '../utils/dom.js';
+import { asyncStopHandler } from '../utils/event-helpers.js';
 import { CONFIG_ACTIONS, BOTTOM_CONFIG_BUTTONS, formatConfigMeta } from '../utils/settings-helpers.js';
 import { createSettingsSection } from '../utils/settings-section-builder.js';
 import { registerComponent } from '../utils/component-registry.js';
 
 function _createConfigActions(config, tabManager, renderConfigsFn) {
+  const hasTabManager = () => !!tabManager;
   const handlers = {
-    setDefault: async (e) => { e.stopPropagation(); await window.api.config.setDefault(config.name); renderConfigsFn(); },
-    overwrite: async (e) => {
-      e.stopPropagation();
-      if (!tabManager) return;
-      await window.api.config.save(config.name, tabManager.serialize());
-      renderConfigsFn();
-    },
-    delete: async (e) => { e.stopPropagation(); await window.api.config.delete(config.name); renderConfigsFn(); },
+    setDefault: asyncStopHandler(
+      () => window.api.config.setDefault(config.name),
+      { onSuccess: renderConfigsFn },
+    ),
+    overwrite: asyncStopHandler(
+      () => window.api.config.save(config.name, tabManager.serialize()),
+      { guard: hasTabManager, onSuccess: renderConfigsFn },
+    ),
+    delete: asyncStopHandler(
+      () => window.api.config.delete(config.name),
+      { onSuccess: renderConfigsFn },
+    ),
   };
 
   const configs = CONFIG_ACTIONS

--- a/src/utils/event-helpers.js
+++ b/src/utils/event-helpers.js
@@ -56,3 +56,55 @@ export function onDragEvents(el, { onDragStart, onDragEnd, onDragOver, onDrop } 
   if (onDragOver)  el.addEventListener('dragover',  onDragOver);
   if (onDrop)      el.addEventListener('drop',      onDrop);
 }
+
+/**
+ * Wrap an async handler so it always stops event propagation, optionally
+ * short-circuits when `guard()` returns falsy, and optionally invokes
+ * `onSuccess()` after the async call resolves.
+ *
+ * Captures the canonical pattern:
+ *   async (e) => { e.stopPropagation(); if (!guard) return; await fn(e); render(); }
+ *
+ * @param {(e: Event) => Promise<void>|void} asyncFn
+ * @param {{ guard?: () => unknown, onSuccess?: () => void }} [opts]
+ * @returns {(e: Event) => Promise<void>}
+ */
+export function asyncStopHandler(asyncFn, { guard, onSuccess } = {}) {
+  return async (e) => {
+    e.stopPropagation();
+    if (guard && !guard()) return;
+    await asyncFn(e);
+    if (onSuccess) onSuccess();
+  };
+}
+
+/**
+ * Build a button per item, attach a click listener, and append into `container`.
+ * Optionally toggles an `active` class via the `isActive` predicate.
+ *
+ * Captures the canonical loop pattern:
+ *   for (const item of items) {
+ *     const btn = makeBtn(item);
+ *     if (isActive(item)) btn.classList.add('active');
+ *     btn.addEventListener('click', e => handler(e, item));
+ *     container.appendChild(btn);
+ *   }
+ *
+ * @template T
+ * @param {HTMLElement} container
+ * @param {T[]} items
+ * @param {{
+ *   renderButton: (item: T) => HTMLElement,
+ *   isActive?: (item: T) => boolean,
+ *   onClick: (e: MouseEvent, item: T, btn: HTMLElement) => void,
+ *   activeClass?: string,
+ * }} opts
+ */
+export function appendListenerButtons(container, items, { renderButton, isActive, onClick, activeClass = 'active' }) {
+  for (const item of items) {
+    const btn = renderButton(item);
+    if (isActive && isActive(item)) btn.classList.add(activeClass);
+    btn.addEventListener('click', (e) => onClick(e, item, btn));
+    container.appendChild(btn);
+  }
+}

--- a/src/utils/sidebar-manager.js
+++ b/src/utils/sidebar-manager.js
@@ -18,6 +18,7 @@
 
 import { getComponent } from './component-registry.js';
 import { _el } from './dom.js';
+import { appendListenerButtons } from './event-helpers.js';
 import { ACTIVITY_BUTTONS, SIDE_VIEWS } from './tab-manager-helpers.js';
 
 /**
@@ -69,12 +70,11 @@ export function renderActivityBar({ sidebarMode, setSidebarMode, onOpenSettings 
 
   const topSection = _el('div', 'activity-bar-top');
 
-  for (const { label, mode } of ACTIVITY_BUTTONS) {
-    const btn = _el('button', 'activity-btn', label);
-    if (sidebarMode === mode) btn.classList.add('active');
-    btn.addEventListener('click', () => setSidebarMode(mode));
-    topSection.appendChild(btn);
-  }
+  appendListenerButtons(topSection, ACTIVITY_BUTTONS, {
+    renderButton: ({ label }) => _el('button', 'activity-btn', label),
+    isActive: ({ mode }) => sidebarMode === mode,
+    onClick: (_e, { mode }) => setSidebarMode(mode),
+  });
 
   topSection.appendChild(_el('button', 'activity-btn', '\u2026'));
   activityBar.appendChild(topSection);


### PR DESCRIPTION
## Refactoring

Add two reusable helpers in `src/utils/event-helpers.js` and migrate the duplicated patterns identified in #196.

### New helpers

- **`asyncStopHandler(asyncFn, { guard, onSuccess })`** — captures the canonical pattern `async (e) => { e.stopPropagation(); if (!guard) return; await fn(); render(); }`.
- **`appendListenerButtons(container, items, { renderButton, isActive, onClick })`** — captures the canonical loop that builds buttons, optionally toggles `active`, attaches a click listener, and appends to a container.

### Call sites migrated

- `src/components/settings-configs.js` — 3 handlers (`setDefault`, `overwrite`, `delete`) now use `asyncStopHandler`. The `tabManager` guard for `overwrite` is expressed via the `guard` option.
- `src/components/settings-appearance.js` — mode buttons loop uses `appendListenerButtons`.
- `src/components/flow-modal.js` — day-of-week buttons loop uses `appendListenerButtons`.
- `src/utils/sidebar-manager.js` — activity bar buttons loop uses `appendListenerButtons`.

### Out of scope

- The bottom-action handlers in `settings-configs.js` (`new`, `duplicate`) wrap *callbacks* around an async API and don't fit the `asyncStopHandler` shape — left as-is to avoid forcing the helper.
- A `wrapHandlers()` umbrella helper was deemed over-engineered for the 2 occurrences that would use it; `asyncStopHandler` already covers each handler individually with one line.

Closes #196

## Vérifications

- [x] Build OK (`npm run build`)
- [x] Tests OK (341/341 passed)

---

📂 Path local : \`/Users/rekta/projet/coding/refactor-pikagent\`
🤖 PR créée automatiquement par l'Agent Refactor