### PR TITLE
refactor: split long functions in usage-helpers and tab-drag

### DIFF
--- a/main/usage-helpers.js
+++ b/main/usage-helpers.js
@@ -86,30 +86,26 @@ function projectShortName(proj) {
   return parts.length > 2 ? parts.slice(-2).join('/') : parts.join('/');
 }
 
-function aggregateTokenData(labels, projectResults) {
-  // Build the set of valid date keys from labels for filtering
+/** @internal Build aggregated per-day token buckets from project results, filtered to valid label dates. */
+function buildGlobalPerDay(labels, projectResults) {
   const validDates = new Set(labels.map(d => d.date));
 
-  // Flatten all per-day entries from every project into a single stream,
-  // then aggregate via aggregateByKey (replaces the manual nested loop).
   const perDayEntries = projectResults.flatMap(({ perDayMap }) =>
     Object.entries(perDayMap)
       .filter(([dateKey]) => validDates.has(dateKey))
       .map(([dateKey, dayData]) => ({ dateKey, dayData })),
   );
 
-  const globalPerDay = aggregateByKey(
+  return aggregateByKey(
     perDayEntries,
     ({ dateKey }) => dateKey,
     () => newPerDayTotals(),
     (bucket, { dayData }) => addTokens(bucket, dayData, PERDAY_KEYS),
   );
+}
 
-  // Accumulate overall totals across all projects
-  const totals = newTokenTotals();
-  for (const { totals: pt } of projectResults) addTokens(totals, pt);
-
-  // Aggregate per-project token data using aggregateByKey
+/** @internal Aggregate per-project token data, sorted by total descending. */
+function buildPerProjectRanking(projectResults) {
   const perProjectAgg = aggregateByKey(
     projectResults.filter(({ totals: pt }) => PERDAY_KEYS.reduce((sum, k) => sum + pt[k], 0) > 0),
     ({ proj }) => projectShortName(proj),
@@ -120,16 +116,23 @@ function aggregateTokenData(labels, projectResults) {
     },
   );
 
-  const tokenPerDay = labels.map((day) => {
+  return Object.entries(perProjectAgg)
+    .map(([project, data]) => ({ project, ...data }))
+    .sort((a, b) => b.total - a.total)
+    .slice(0, TOP_PROJECTS_LIMIT);
+}
+
+function aggregateTokenData(labels, projectResults) {
+  const globalPerDay = buildGlobalPerDay(labels, projectResults);
+
+  const totals = newTokenTotals();
+  for (const { totals: pt } of projectResults) addTokens(totals, pt);
+
+  const perDay = labels.map((day) => {
     const g = globalPerDay[day.date] || newPerDayTotals();
     const total = PERDAY_KEYS.reduce((sum, k) => sum + g[k], 0);
     return { ...day, ...g, total };
   });
-
-  const perProject = Object.entries(perProjectAgg)
-    .map(([project, data]) => ({ project, ...data }))
-    .sort((a, b) => b.total - a.total)
-    .slice(0, TOP_PROJECTS_LIMIT);
 
   return {
     totalInput: totals.input,
@@ -137,8 +140,8 @@ function aggregateTokenData(labels, projectResults) {
     totalCacheRead: totals.cacheRead,
     totalCacheCreate: totals.cacheCreate,
     total: totals.input + totals.output,
-    perDay: tokenPerDay,
-    perProject,
+    perDay,
+    perProject: buildPerProjectRanking(projectResults),
   };
 }
 

--- a/src/utils/tab-drag.js
+++ b/src/utils/tab-drag.js
@@ -166,60 +166,66 @@ function handleDragEnd({ getTabElements, reorderTab }, tabEl, ghost, state, tabI
 // ── Public API ──────────────────────────────────────────────────────
 
 /**
+ * Activate the full drag phase: create ghost, wire trackMouse, and handle end.
+ * @internal
+ */
+function activateDrag(deps, tabEl, tabId, state, ctx, ev) {
+  const { getTabElements, reorderTab } = deps;
+  ctx.ghost = handleDragStart(tabEl);
+  ctx.ghost.style.left = `${ev.clientX - ctx.offsetX}px`;
+  updateTabDropTarget(getTabElements, state, ev.clientX, tabId);
+
+  trackMouse('grabbing',
+    (mv) => {
+      ctx.ghost.style.left = `${mv.clientX - ctx.offsetX}px`;
+      updateTabDropTarget(getTabElements, state, mv.clientX, tabId);
+    },
+    () => {
+      handleDragEnd(deps, tabEl, ctx.ghost, state, tabId);
+      ctx.ghost = null;
+    },
+    { bodyClass: 'dragging' },
+  );
+}
+
+/**
+ * Install threshold listeners that wait for a minimum drag distance
+ * before activating the full drag phase.
+ * @internal
+ */
+function installThresholdListeners(deps, tabEl, tabId, state, ctx) {
+  const onThresholdMove = (ev) => {
+    if (Math.abs(ev.clientX - ctx.startX) <= DRAG_THRESHOLD) return;
+    document.removeEventListener('mousemove', onThresholdMove);
+    document.removeEventListener('mouseup', onThresholdUp);
+    activateDrag(deps, tabEl, tabId, state, ctx, ev);
+  };
+
+  const onThresholdUp = () => {
+    document.removeEventListener('mousemove', onThresholdMove);
+    document.removeEventListener('mouseup', onThresholdUp);
+  };
+
+  document.addEventListener('mousemove', onThresholdMove);
+  document.addEventListener('mouseup', onThresholdUp);
+}
+
+/**
  * Wire drag-to-reorder behaviour on a single tab element.
  *
  * @param {TabDragDeps} deps  — explicit dependency interface
  * @param {HTMLElement} tabEl — the tab DOM element
  * @param {string} tabId     — the tab's unique id
  */
-export function setupTabDrag({ getTabElements, reorderTab }, tabEl, tabId) {
-  let startX = 0;
-  let ghost = null;
-  let offsetX = 0;
-
+export function setupTabDrag(deps, tabEl, tabId) {
   const state = initDragState();
+  const ctx = { startX: 0, ghost: null, offsetX: 0 };
 
   tabEl.addEventListener('mousedown', (e) => {
     if (e.button !== 0) return;
-    startX = e.clientX;
+    ctx.startX = e.clientX;
     const rect = tabEl.getBoundingClientRect();
-    offsetX = e.clientX - rect.left;
-
-    // Phase 1: detect threshold before activating drag.
-    // Once the threshold is exceeded we hand off to trackMouse() which
-    // manages cursor/userSelect, RAF-throttled moves, and mouseup cleanup.
-    const onThresholdMove = (ev) => {
-      if (Math.abs(ev.clientX - startX) <= DRAG_THRESHOLD) return;
-
-      // Threshold crossed — remove these preliminary listeners
-      document.removeEventListener('mousemove', onThresholdMove);
-      document.removeEventListener('mouseup', onThresholdUp);
-
-      // Phase 2: real drag via trackMouse()
-      ghost = handleDragStart(tabEl);
-      // Process the first move immediately so the ghost starts in the right position
-      ghost.style.left = `${ev.clientX - offsetX}px`;
-      updateTabDropTarget(getTabElements, state, ev.clientX, tabId);
-
-      trackMouse('grabbing',
-        (mv) => {
-          ghost.style.left = `${mv.clientX - offsetX}px`;
-          updateTabDropTarget(getTabElements, state, mv.clientX, tabId);
-        },
-        () => {
-          handleDragEnd({ getTabElements, reorderTab }, tabEl, ghost, state, tabId);
-          ghost = null;
-        },
-        { bodyClass: 'dragging' },
-      );
-    };
-
-    const onThresholdUp = () => {
-      document.removeEventListener('mousemove', onThresholdMove);
-      document.removeEventListener('mouseup', onThresholdUp);
-    };
-
-    document.addEventListener('mousemove', onThresholdMove);
-    document.addEventListener('mouseup', onThresholdUp);
+    ctx.offsetX = e.clientX - rect.left;
+    installThresholdListeners(deps, tabEl, tabId, state, ctx);
   });
 }


### PR DESCRIPTION
## Refactoring

Split two functions that exceeded the 50-line threshold:
- `aggregateTokenData()` (55→22 lines) — extracted `buildGlobalPerDay()` and `buildPerProjectRanking()` as internal helpers
- `setupTabDrag()` (51→11 lines) — extracted `activateDrag()` and `installThresholdListeners()` as internal helpers

No change to public API or behavior.

Closes #200

## Fichier(s) modifié(s)
- main/usage-helpers.js
- src/utils/tab-drag.js

## Vérifications
- [x] Build OK
- [x] Tests OK (349/349 passed)

---
📂 Path local : `/Users/rekta/projet/coding/refactor-pikagent`
🤖 PR créée automatiquement par l'Agent Refactor