### PR TITLE
refactor: remove test-only exports from ipc-helpers

### DIFF
--- a/main/ipc-helpers.js
+++ b/main/ipc-helpers.js
@@ -14,7 +14,7 @@ function safeSend(getWindow, channel, payload) {
 }
 
 /**
- * @internal Exported for testing only — production code uses registerManagerHandlers().
+ * @internal
  * Derive FORWARD_TABLE and SPREAD_TABLE from API_SCHEMA.
  *
  * FORWARD_TABLE entries: [channel, domain]
@@ -43,7 +43,7 @@ function buildTablesFromSchema(schema) {
 const { forward: FORWARD_TABLE, spread: SPREAD_TABLE } = buildTablesFromSchema(API_SCHEMA);
 
 /**
- * @internal Exported for testing only — production code uses registerManagerHandlers().
+ * @internal
  * Register forward-style handlers on ipcMain for a given target.
  * @param {Electron.IpcMain} ipc - Electron ipcMain
  * @param {Record<string, Function>} target - The object whose methods will be called
@@ -56,7 +56,7 @@ function registerForward(ipc, target, entries) {
 }
 
 /**
- * @internal Exported for testing only — production code uses registerManagerHandlers().
+ * @internal
  * Register spread-style handlers on ipcMain for a given target.
  * @param {Electron.IpcMain} ipc - Electron ipcMain
  * @param {Record<string, Function>} target - The object whose methods will be called
@@ -95,4 +95,7 @@ function registerManagerHandlers(ipc, targets, skip = new Set()) {
   }
 }
 
-module.exports = { safeSend, buildTablesFromSchema, registerForward, registerSpread, registerManagerHandlers };
+module.exports = { safeSend, registerManagerHandlers };
+
+/** @internal — exposed for unit tests only; not part of the public API. */
+module.exports._internals = { buildTablesFromSchema, registerForward, registerSpread };

--- a/tests/main/ipc-helpers.test.js
+++ b/tests/main/ipc-helpers.test.js
@@ -1,8 +1,10 @@
 import { describe, it, expect, vi } from 'vitest';
-const { safeSend, buildTablesFromSchema, registerForward, registerSpread, registerManagerHandlers } = require('../../main/ipc-helpers');
+const helpers = require('../../main/ipc-helpers');
+const { safeSend, registerManagerHandlers } = helpers;
+const { buildTablesFromSchema, registerForward, registerSpread } = helpers._internals;
 const { API_SCHEMA } = require('../../api-schema');
 
-// Derive tables via public API (no longer exported directly)
+// Derive tables via internal helper (not part of the public API)
 const { forward: FORWARD_TABLE, spread: SPREAD_TABLE } = buildTablesFromSchema(API_SCHEMA);
 
 describe('ipc-helpers', () => {


### PR DESCRIPTION
## Summary
- Remove `buildTablesFromSchema`, `registerForward`, and `registerSpread` from the public `module.exports` of `main/ipc-helpers.js`
- These 3 functions were marked "Exported for testing only" and are not imported by any production code
- Functions are now marked `@internal` and exposed via `module.exports._internals` for test access only
- Tests updated to import from `_internals` instead of the public API

Closes #202

## Fichier(s) modifié(s)
- `main/ipc-helpers.js` — removed 3 functions from public exports, added `_internals` property
- `tests/main/ipc-helpers.test.js` — updated imports to use `_internals`

## Vérifications
- [x] Build OK (`npm run build`)
- [x] Tests OK (24 files, 349 tests passed)

---
📂 Path local : `/Users/rekta/projet/coding/refactor-pikagent`
🤖 PR créée automatiquement par l'Agent Refactor