### PR TITLE
refactor: factor async handlers in settings/flow components

### DIFF
--- a/src/components/flow-modal.js
+++ b/src/components/flow-modal.js
@@ -9,6 +9,7 @@ import {
   _vis, _createSelect, _createChip, _updateScheduleVis,
 } from '../utils/flow-modal-helpers.js';
 import { registerComponent } from '../utils/component-registry.js';
+import { createAsyncHandler } from '../utils/event-helpers.js';
 
 // --- Section builders ---
 
@@ -57,15 +58,17 @@ function _buildCwdPicker(state) {
     className: 'flow-modal-chip flow-modal-chip-btn',
     type: 'button',
     title: state.selectedCwd || DEFAULT_CWD_LABEL,
-    onClick: async (e) => {
-      e.preventDefault();
-      const folder = await window.api.dialog.openFolder();
-      if (folder) {
-        state.selectedCwd = folder;
-        cwdLabel.textContent = folder.split('/').pop();
-        cwdChip.title = folder;
-      }
-    },
+    onClick: createAsyncHandler(
+      { stopProp: false },
+      async () => {
+        const folder = await window.api.dialog.openFolder();
+        if (folder) {
+          state.selectedCwd = folder;
+          cwdLabel.textContent = folder.split('/').pop();
+          cwdChip.title = folder;
+        }
+      },
+    ),
   }, _el('span', { textContent: '\u{1F4C2}' }), cwdLabel);
 
   state.cwdLabel = cwdLabel;

--- a/src/components/settings-appearance.js
+++ b/src/components/settings-appearance.js
@@ -8,6 +8,7 @@ import { _el, createActionButton } from '../utils/dom.js';
 import { MODE_BUTTONS, THEME_PREVIEW_LINES, COLOR_DOT_KEYS } from '../utils/settings-helpers.js';
 import { createSettingsSection } from '../utils/settings-section-builder.js';
 import { registerComponent } from '../utils/component-registry.js';
+import { createAsyncHandler } from '../utils/event-helpers.js';
 
 /**
  * Apply the current terminal theme to all terminal panels across tabs.
@@ -55,11 +56,10 @@ function _createThemeCard(name, theme, isActive, tabManager, renderAppearanceFn)
   card.appendChild(preview);
   card.appendChild(_el('div', 'theme-card-label', name));
 
-  card.addEventListener('click', () => {
-    setTerminalTheme(name);
-    applyThemeToTerminals(tabManager);
-    renderAppearanceFn();
-  });
+  card.addEventListener('click', createAsyncHandler(
+    { stopProp: false, onSuccess: renderAppearanceFn },
+    () => { setTerminalTheme(name); applyThemeToTerminals(tabManager); },
+  ));
 
   return card;
 }
@@ -82,11 +82,10 @@ export function renderAppearance(contentEl, tabManager, renderAppearanceFn) {
     const btn = createActionButton({
       text: label,
       cls: 'theme-mode-btn',
-      onClick: () => {
-        setAppTheme(mode);
-        if (switchTerminalForMode(mode)) applyThemeToTerminals(tabManager);
-        renderAppearanceFn();
-      },
+      onClick: createAsyncHandler(
+        { stopProp: false, onSuccess: renderAppearanceFn },
+        () => { setAppTheme(mode); if (switchTerminalForMode(mode)) applyThemeToTerminals(tabManager); },
+      ),
     });
     if (currentMode === mode) btn.classList.add('active');
     modeToggle.appendChild(btn);

--- a/src/components/settings-configs.js
+++ b/src/components/settings-configs.js
@@ -6,17 +6,22 @@ import { _el, renderButtonBar } from '../utils/dom.js';
 import { CONFIG_ACTIONS, BOTTOM_CONFIG_BUTTONS, formatConfigMeta } from '../utils/settings-helpers.js';
 import { createSettingsSection } from '../utils/settings-section-builder.js';
 import { registerComponent } from '../utils/component-registry.js';
+import { createAsyncHandler } from '../utils/event-helpers.js';
 
 function _createConfigActions(config, tabManager, renderConfigsFn) {
   const handlers = {
-    setDefault: async (e) => { e.stopPropagation(); await window.api.config.setDefault(config.name); renderConfigsFn(); },
-    overwrite: async (e) => {
-      e.stopPropagation();
-      if (!tabManager) return;
-      await window.api.config.save(config.name, tabManager.serialize());
-      renderConfigsFn();
-    },
-    delete: async (e) => { e.stopPropagation(); await window.api.config.delete(config.name); renderConfigsFn(); },
+    setDefault: createAsyncHandler(
+      { onSuccess: renderConfigsFn },
+      () => window.api.config.setDefault(config.name),
+    ),
+    overwrite: createAsyncHandler(
+      { guard: () => !!tabManager, onSuccess: renderConfigsFn },
+      () => window.api.config.save(config.name, tabManager.serialize()),
+    ),
+    delete: createAsyncHandler(
+      { onSuccess: renderConfigsFn },
+      () => window.api.config.delete(config.name),
+    ),
   };
 
   const configs = CONFIG_ACTIONS
@@ -47,11 +52,10 @@ function _createConfigRow(config, currentName, tabManager, renderConfigsFn) {
   const row = _el('div', 'config-row');
   if (config.name === currentName) row.classList.add('config-active');
 
-  row.addEventListener('click', async () => {
-    if (!tabManager) return;
-    await tabManager.configManager.switchConfig(config.name);
-    renderConfigsFn();
-  });
+  row.addEventListener('click', createAsyncHandler(
+    { stopProp: false, guard: () => !!tabManager, onSuccess: renderConfigsFn },
+    () => tabManager.configManager.switchConfig(config.name),
+  ));
 
   row.appendChild(_buildConfigRowLeft(config));
   row.appendChild(_createConfigActions(config, tabManager, renderConfigsFn));

--- a/src/utils/event-helpers.js
+++ b/src/utils/event-helpers.js
@@ -8,6 +8,26 @@
  */
 
 /**
+ * Create a reusable async handler that optionally stops propagation, checks a
+ * guard predicate, awaits an API call, then invokes an onSuccess callback.
+ *
+ * This extracts the repeated pattern found across settings/flow components:
+ *   stopPropagation → guard check → API call → re-render
+ *
+ * @param {{ guard?: () => boolean, stopProp?: boolean, onSuccess?: () => void }} opts
+ * @param {(...args: unknown[]) => Promise<unknown>} apiCall
+ * @returns {(e: Event, ...args: unknown[]) => Promise<void>}
+ */
+export function createAsyncHandler({ guard, stopProp = true, onSuccess }, apiCall) {
+  return async (e, ...args) => {
+    if (stopProp) e.stopPropagation();
+    if (guard && !guard()) return;
+    await apiCall(...args);
+    if (onSuccess) onSuccess();
+  };
+}
+
+/**
  * Attach a click listener that always calls stopPropagation (and optionally
  * preventDefault) before invoking the handler.
  *

--- a/src/utils/sidebar-manager.js
+++ b/src/utils/sidebar-manager.js
@@ -19,6 +19,7 @@
 import { getComponent } from './component-registry.js';
 import { _el } from './dom.js';
 import { ACTIVITY_BUTTONS, SIDE_VIEWS } from './tab-manager-helpers.js';
+import { createAsyncHandler } from './event-helpers.js';
 
 /**
  * Declarative map for sidebar view rendering — single source of truth for
@@ -83,9 +84,10 @@ export function renderActivityBar({ sidebarMode, setSidebarMode, onOpenSettings 
   const bottomSection = _el('div', 'activity-bar-bottom');
   const settingsBtn = _el('button', 'activity-btn activity-btn-settings');
   settingsBtn.append(_el('span', 'activity-btn-icon', '\u2699'), 'Settings');
-  settingsBtn.addEventListener('click', () => {
-    if (onOpenSettings) onOpenSettings();
-  });
+  settingsBtn.addEventListener('click', createAsyncHandler(
+    { stopProp: false, guard: () => !!onOpenSettings },
+    () => onOpenSettings(),
+  ));
   bottomSection.appendChild(settingsBtn);
 
   activityBar.appendChild(bottomSection);


### PR DESCRIPTION
## Refactoring

Extract repeated async handler pattern (stopPropagation -> guard -> API call -> re-render) into a shared `createAsyncHandler()` helper in event-helpers.js.

Applied to:
- settings-configs.js
- settings-appearance.js
- flow-modal.js
- sidebar-manager.js

Closes #196

## Fichier(s) modifie(s)
- src/utils/event-helpers.js (new helper)
- src/components/settings-configs.js
- src/components/settings-appearance.js
- src/components/flow-modal.js
- src/utils/sidebar-manager.js

## Verifications
- [x] Build OK
- [x] Tests OK (349/349 passing)

---
Path local : `/Users/rekta/projet/coding/refactor-pikagent`

Generated with [Claude Code](https://claude.com/claude-code)