### PR TITLE
refactor: replace loose JSDoc types with precise annotations

### DIFF
--- a/main/ipc-handlers.js
+++ b/main/ipc-handlers.js
@@ -9,7 +9,7 @@ const { createSafeHandler } = require('./safe-handler');
  * `manager-init.js`.  This module only cares about IPC dispatching.
  *
  * @param {() => import('electron').BrowserWindow} getWindow
- * @param {{ targets: Record<string, object>, ptyManager: object, sessionManager: object }} deps
+ * @param {{ targets: Record<string, Record<string, (...args: unknown[]) => unknown>>, ptyManager: { create: (opts: { id: string, cwd: string, cols: number, rows: number }) => { pid: number, onData: (cb: (data: string) => void) => void, onExit: (cb: (info: { exitCode: number }) => void) => void }, processes: Map<string, unknown> }, sessionManager: { onTerminalExit: (id: string) => void } }} deps
  */
 function register(getWindow, { targets, ptyManager, sessionManager }) {
   const { shell, dialog } = require('electron');

--- a/main/ipc-helpers.js
+++ b/main/ipc-helpers.js
@@ -46,7 +46,7 @@ const { forward: FORWARD_TABLE, spread: SPREAD_TABLE } = buildTablesFromSchema(A
  * @internal Exported for testing only — production code uses registerManagerHandlers().
  * Register forward-style handlers on ipcMain for a given target.
  * @param {Electron.IpcMain} ipc - Electron ipcMain
- * @param {Record<string, Function>} target - The object whose methods will be called
+ * @param {Record<string, (...args: unknown[]) => unknown>} target - The object whose methods will be called
  * @param {Array<[string, string]>} entries - Array of [channel, method] tuples
  */
 function registerForward(ipc, target, entries) {
@@ -59,7 +59,7 @@ function registerForward(ipc, target, entries) {
  * @internal Exported for testing only — production code uses registerManagerHandlers().
  * Register spread-style handlers on ipcMain for a given target.
  * @param {Electron.IpcMain} ipc - Electron ipcMain
- * @param {Record<string, Function>} target - The object whose methods will be called
+ * @param {Record<string, (...args: unknown[]) => unknown>} target - The object whose methods will be called
  * @param {Array<[string, string, string[]]>} entries - Array of [channel, method, keys] tuples
  */
 function registerSpread(ipc, target, entries) {
@@ -74,7 +74,7 @@ function registerSpread(ipc, target, entries) {
  * Method name is derived from the channel (domain:method).
  *
  * @param {Electron.IpcMain} ipc - Electron ipcMain
- * @param {Record<string, Record<string, Function>>} targets - Map of domain -> target object
+ * @param {Record<string, Record<string, (...args: unknown[]) => unknown>>} targets - Map of domain -> target object
  * @param {Set<string>} [skip] - Channels to skip (registered as custom handlers elsewhere)
  */
 function registerManagerHandlers(ipc, targets, skip = new Set()) {

--- a/main/logger.js
+++ b/main/logger.js
@@ -34,7 +34,7 @@ function createLogger(module) {
  *
  * @param {() => unknown} fn - async or sync function to execute
  * @param {unknown} defaultValue - value returned when fn throws
- * @param {{ log: object, label: string }} [opts] - optional logger & label
+ * @param {{ log: { warn: (msg: string, err?: unknown) => void }, label: string }} [opts] - optional logger & label
  * @returns {Promise<unknown>}
  */
 async function trySafe(fn, defaultValue, { log, label } = {}) {

--- a/shared/flow-utils.js
+++ b/shared/flow-utils.js
@@ -6,7 +6,7 @@
 
 /**
  * Return the last run from a flow's runs array, or null if none.
- * @param {{ runs?: Array }} flow
+ * @param {{ runs?: Array<{ date: string, timestamp: string, logTimestamp?: string, status: string }> }} flow
  * @returns {{ date: string, timestamp: string, logTimestamp?: string, status: string }|null}
  */
 function getLastRun(flow) {

--- a/src/utils/context-menu.js
+++ b/src/utils/context-menu.js
@@ -87,7 +87,7 @@ export const contextMenu = new ContextMenu();
  * colour filter).
  *
  * @param {HTMLElement} el - element to listen on
- * @param {(e: MouseEvent) => Array|void} buildItems - receives the raw event,
+ * @param {(e: MouseEvent) => Array<{ label?: string, action?: () => void, separator?: boolean, shortcut?: string, colorDot?: string, children?: Array<unknown> }>|void} buildItems - receives the raw event,
  *   should return an items array (or nothing).
  */
 export function attachContextMenu(el, buildItems) {

--- a/src/utils/disposable.js
+++ b/src/utils/disposable.js
@@ -14,7 +14,7 @@
 
 /**
  * @typedef {'dispose' | 'disconnect' | 'call' | 'remove' | 'clearInterval' | 'clearTimeout'} CleanupAction
- * @typedef {{ ref: object, key: string, action: CleanupAction }} ResourceDescriptor
+ * @typedef {{ ref: Record<string, unknown>, key: string, action: CleanupAction }} ResourceDescriptor
  * @typedef {{ disposed?: boolean } & Record<string, unknown>} DisposableOwner
  */
 

--- a/src/utils/dom.js
+++ b/src/utils/dom.js
@@ -22,7 +22,7 @@ import { onClickStopped } from './event-helpers.js';
  *
  * @param {string} tag
  * @param {Record<string, unknown>|string|null} [attrsOrClass]
- * @param {...(Node|string|Object|null|false)} children
+ * @param {...(Node|string|Record<string, unknown>|null|false)} children
  */
 export function _el(tag, attrsOrClass, ...children) {
   const el = document.createElement(tag);

--- a/src/utils/file-tree-drop.js
+++ b/src/utils/file-tree-drop.js
@@ -14,7 +14,7 @@ import { INPUT_BLUR_DELAY, computeIndent } from './file-tree-helpers.js';
  * dropped from the OS file manager are copied into a target directory.
  *
  * @param {HTMLElement} el - element to receive drop events
- * @param {string|Function} getTargetDir - target dir path or a function returning it
+ * @param {string|(() => string)} getTargetDir - target dir path or a function returning it
  * @param {(files: FileList, destDir: string) => Promise<void>} handleFileDrop
  * @param {string} [className='drop-target'] - CSS class toggled during drag
  */

--- a/src/utils/flow-card-setup.js
+++ b/src/utils/flow-card-setup.js
@@ -93,18 +93,7 @@ export function setupCardHeaderClick(headerRow, flow, isRunning, { expandedCards
 /**
  * Build a complete flow card element.
  *
- * @typedef {object} CreateFlowCardDeps
- * @property {Record<string, string>} runningMap        - { [flowId]: ptyId }
- * @property {Set<string>} expandedCards
- * @property {{ flowId: string|null, catId: string|null }} drag - mutable drag state
- * @property {{ createLiveTerminal: (flowId: string, ptyId: string) => HTMLElement, loadLogIntoContainer: (flowId: string, run: unknown, container: HTMLElement) => void, disposeLogTerminal: (flowId: string) => void }} termManager - FlowCardTerminalManager instance
- * @property {() => void} onRenderList
- * @property {(flow: { id: string }, run: unknown) => void} onShowLog
- * @property {(flowId: string) => void} onRun
- * @property {(flowId: string) => Promise<void>} onToggle
- * @property {() => void} onRefresh
- * @property {(flow: { id: string }) => void} onOpenModal
- * @property {(flowId: string) => void} onDeleteFlow
+ * @typedef {{ runningMap: Record<string, string>, expandedCards: Set<string>, drag: { flowId: string|null, catId: string|null }, termManager: { createLiveTerminal: (flowId: string, ptyId: string) => HTMLElement, loadLogIntoContainer: (flowId: string, run: unknown, container: HTMLElement) => void, disposeLogTerminal: (flowId: string) => void }, onRenderList: () => void, onShowLog: (flow: { id: string }, run: unknown) => void, onRun: (flowId: string) => void, onToggle: (flowId: string) => Promise<void>, onRefresh: () => void, onOpenModal: (flow: { id: string }) => void, onDeleteFlow: (flowId: string) => void }} CreateFlowCardDeps
  *
  * @param {CreateFlowCardDeps} deps
  * @param {{ id: string, runs?: Array<unknown>, enabled?: boolean }} flow

--- a/src/utils/usage-view-helpers.js
+++ b/src/utils/usage-view-helpers.js
@@ -40,7 +40,7 @@ function _td(text, attrs = {}) {
  *   - A DOM Node (inserted as-is into the row)
  *   - An object { value, className?, style?, title? } → converted via _td()
  *
- * @param {Array<Node | { value: string|number, className?: string, style?: object, title?: string }>} columns
+ * @param {Array<Node | { value: string|number, className?: string, style?: Record<string, string>, title?: string }>} columns
  * @returns {HTMLTableRowElement}
  */
 export function buildTableRow(columns) {

--- a/src/utils/workspace-serializer.js
+++ b/src/utils/workspace-serializer.js
@@ -19,7 +19,7 @@ import { disposeAllTabs } from './workspace-cleanup.js';
 /**
  * Serialize all tabs into a config object.
  * @param {SerializeDeps} deps
- * @returns {{ tabs: Array, activeTabIndex: number }}
+ * @returns {{ tabs: Array<{ name: string, cwd: string, noShortcut: boolean, colorGroup: string|null, splitTree: unknown, panels: Record<string, unknown>, webviewTabs?: unknown }>, activeTabIndex: number }}
  */
 export function serialize({ tabs, activeTabId }) {
   const serializedTabs = [];


### PR DESCRIPTION
## Refactoring

Replace loose JSDoc types ({object}, {Object}, {Function}, {Array} without generics) with precise type annotations across 11 files.

Closes #194

## Fichier(s) modifié(s)
- src/utils/flow-card-setup.js
- src/utils/disposable.js
- main/logger.js
- main/ipc-handlers.js
- src/utils/usage-view-helpers.js
- src/utils/dom.js
- src/utils/file-tree-drop.js
- main/ipc-helpers.js
- src/utils/workspace-serializer.js
- src/utils/context-menu.js
- shared/flow-utils.js

## Vérifications
- [x] Build OK
- [x] Tests OK

---
📂 Path local : `/Users/rekta/projet/coding/refactor-pikagent`
🤖 PR créée automatiquement par l'Agent Refactor