### PR TITLE
refactor: remove dead main/polling-timer.js re-export

### DIFF
--- a/main/polling-timer.js
+++ b/main/polling-timer.js
@@ -1,5 +1,0 @@
-/**
- * Re-exports the shared PollingTimer for the main process.
- * Implementation lives in shared/polling-timer.js.
- */
-module.exports = require('../shared/polling-timer');


### PR DESCRIPTION
## Refactoring

Suppression du fichier `main/polling-timer.js` qui re-exportait `PollingTimer` depuis `shared/polling-timer.js` sans jamais être importé par aucun module du projet. Vestige du refactoring #111.

Closes #217

## Fichier(s) modifié(s)

- `main/polling-timer.js` (supprimé)

## Vérifications

- [x] Build OK
- [x] Tests OK (341 tests passent)

---

📂 Path local : `/Users/rekta/projet/coding/refactor-pikagent`
🤖 PR créée automatiquement par l'Agent Refactor