### PR TITLE
refactor: extract createOnceGuard and createLookupMap helpers

### DIFF
--- a/shared/aggregation-utils.js
+++ b/shared/aggregation-utils.js
@@ -60,4 +60,25 @@ function countBy(items, keyFn) {
   return counts;
 }
 
-module.exports = { aggregateByKey, groupAndAggregate, countBy };
+/**
+ * Build a Map keyed by `keyFn(item)` for O(1) lookup.
+ * @param {Array<unknown>} items
+ * @param {(item: unknown) => string} keyFn - extracts the lookup key from each item
+ * @returns {Map<string, unknown>}
+ */
+function createLookupMap(items, keyFn) {
+  return new Map(items.map(item => [keyFn(item), item]));
+}
+
+/**
+ * Resolve an array of keys to their values using a lookup Map.
+ * Keys not found in the map are silently skipped.
+ * @param {Map<string, unknown>} map
+ * @param {string[]} keys
+ * @returns {Array<unknown>}
+ */
+function resolveFromMap(map, keys) {
+  return keys.map(k => map.get(k)).filter(Boolean);
+}
+
+module.exports = { aggregateByKey, groupAndAggregate, countBy, createLookupMap, resolveFromMap };

--- a/src/utils/flow-view-helpers.js
+++ b/src/utils/flow-view-helpers.js
@@ -5,7 +5,7 @@
 
 import { formatDateTime } from './date-utils.js';
 import { getLastRun } from '../../shared/flow-utils.js';
-import { countBy } from '../../shared/aggregation-utils.js';
+import { countBy, createLookupMap, resolveFromMap } from '../../shared/aggregation-utils.js';
 
 /**
  * Toggle a value in a Set (add if absent, delete if present).
@@ -56,25 +56,6 @@ export function buildDotTooltip(run) {
 }
 
 /**
- * Build a Map keyed by flow.id for fast lookup.
- * @param {Array<{id: string}>} flows
- * @returns {Map<string, {id: string}>}
- */
-function buildFlowMap(flows) {
-  return new Map(flows.map(f => [f.id, f]));
-}
-
-/**
- * Resolve an array of flow IDs to flow objects using a flow map.
- * @param {string[]} ids
- * @param {Map<string, {id: string}>} flowMap
- * @returns {Array<{id: string}>}
- */
-function resolveIds(ids, flowMap) {
-  return ids.map(id => flowMap.get(id)).filter(Boolean);
-}
-
-/**
  * Return flows belonging to a given category, ordered by catData.order.
  * @param {Array<{id: string}>} flows - all flow objects
  * @param {Record<string, string[]>} order - catData.order mapping catId → [flowId, …]
@@ -82,7 +63,7 @@ function resolveIds(ids, flowMap) {
  * @returns {Array<{id: string}>} ordered flows for this category
  */
 export function getFlowsForCategory(flows, order, catId) {
-  return resolveIds(order[catId] || [], buildFlowMap(flows));
+  return resolveFromMap(createLookupMap(flows, f => f.id), order[catId] || []);
 }
 
 /**
@@ -97,9 +78,9 @@ export function getUncategorizedFlows(flows, order) {
   // Any id with a count > 0 is "assigned" to at least one category (including UNCATEGORIZED).
   const assignedCounts = countBy(Object.values(order).flat(), id => id);
 
-  const flowMap = buildFlowMap(flows);
+  const flowMap = createLookupMap(flows, f => f.id);
   const orderedIds = order[UNCATEGORIZED] || [];
-  const ordered = resolveIds(orderedIds, flowMap);
+  const ordered = resolveFromMap(flowMap, orderedIds);
   const inOrder = new Set(orderedIds);
 
   for (const f of flows) {

--- a/src/utils/form-helpers.js
+++ b/src/utils/form-helpers.js
@@ -9,31 +9,36 @@ import { onClickStopped } from './event-helpers.js';
 import { setupKeyboardShortcuts } from './keyboard-helpers.js';
 
 /**
+ * Create a guard that ensures `fn` is called at most once.
+ * Subsequent calls are silently ignored.
+ * @param {(...args: unknown[]) => void} fn
+ * @returns {(...args: unknown[]) => void}
+ */
+export function createOnceGuard(fn) {
+  let called = false;
+  return (...args) => { if (called) return; called = true; fn(...args); };
+}
+
+/**
  * Wire up Enter / Escape / blur / click on an inline <input>.
  * Guarantees onCommit fires at most once.
  * @param {HTMLInputElement} input
  * @param {{ onCommit: (value: string) => void, onCancel?: () => void, blurDelay?: number }} opts
  */
 export function setupInlineInput(input, { onCommit, onCancel, blurDelay = 0 }) {
-  let committed = false;
-  const commit = () => {
-    if (committed) return;
-    committed = true;
-    onCommit(input.value.trim());
-  };
-  const cancel = () => {
-    committed = true;
+  const commit = createOnceGuard(() => onCommit(input.value.trim()));
+  const cancel = createOnceGuard(() => {
     if (onCancel) onCancel();
     else input.remove();
-  };
+  });
 
   setupKeyboardShortcuts(input, {
     onEnter: (e) => { e.preventDefault(); e.stopPropagation(); commit(); },
     onEscape: (e) => { e.stopPropagation(); cancel(); },
   });
   input.addEventListener('blur', () => {
-    if (blurDelay > 0) setTimeout(() => { if (!committed) commit(); }, blurDelay);
-    else if (!committed) commit();
+    if (blurDelay > 0) setTimeout(() => commit(), blurDelay);
+    else commit();
   });
   onClickStopped(input, () => {});
 }


### PR DESCRIPTION
## Refactoring

1. **`createLookupMap` + `resolveFromMap`** ajoutés dans `shared/aggregation-utils.js` — remplacent les helpers locaux `buildFlowMap`/`resolveIds` dans `flow-view-helpers.js`.
2. **`createOnceGuard`** ajouté dans `src/utils/form-helpers.js` — remplace le pattern manuel `let committed = false; if (committed) return;` dans `setupInlineInput`.
3. La logique drop zone indicator est déjà bien factorisée via `setupDropZone` — aucun changement nécessaire.

Closes #218

## Fichier(s) modifié(s)

- `shared/aggregation-utils.js` — ajout de `createLookupMap` et `resolveFromMap`
- `src/utils/flow-view-helpers.js` — utilisation des helpers partagés, suppression des helpers locaux
- `src/utils/form-helpers.js` — ajout de `createOnceGuard`, simplification de `setupInlineInput`

## Vérifications

- [x] Build OK
- [x] Tests OK (341 tests passent)

---

📂 Path local : `/Users/rekta/projet/coding/refactor-pikagent`
🤖 PR créée automatiquement par l'Agent Refactor