### PR TITLE
refactor: reduce dom.js to core-only exports

### DIFF
--- a/src/components/board-view.js
+++ b/src/components/board-view.js
@@ -1,8 +1,8 @@
 import { WebLinksAddon } from '@xterm/addon-web-links';
 import { subscribeBus, unsubscribeBus } from '../utils/events.js';
 import { FilePathLinkProvider } from '../utils/file-link-provider.js';
-import { _el, _safeFit, renderButtonBar } from '../utils/dom.js';
-import { createTerminal, disposeTerminal, disposeTerminalMap } from '../utils/terminal-factory.js';
+import { _el, renderButtonBar } from '../utils/dom.js';
+import { _safeFit, createTerminal, disposeTerminal, disposeTerminalMap } from '../utils/terminal-factory.js';
 import { registerComponent } from '../utils/component-registry.js';
 import { RendererPollingTimer } from '../utils/polling.js';
 import {

--- a/src/components/flow-card-terminal.js
+++ b/src/components/flow-card-terminal.js
@@ -2,9 +2,10 @@
  * Terminal management for flow cards: live terminals, inline log terminals, and log modal.
  * Extracted from FlowView to reduce component size.
  */
-import { _el, _safeFit, createModalOverlay } from '../utils/dom.js';
+import { _el } from '../utils/dom.js';
+import { createModalOverlay } from '../utils/dom-dialogs.js';
 import { setupKeyboardShortcuts } from '../utils/keyboard-helpers.js';
-import { createReadonlyTerminal, disposeTerminal, disposeTerminalMap } from '../utils/terminal-factory.js';
+import { _safeFit, createReadonlyTerminal, disposeTerminal, disposeTerminalMap } from '../utils/terminal-factory.js';
 import {
   FIT_DELAY_MS, LOG_SCROLLBACK, LIVE_SCROLLBACK,
   STATUS_LABELS, NO_LOG_MESSAGE, NO_LOG_MODAL_MESSAGE,

--- a/src/components/flow-modal.js
+++ b/src/components/flow-modal.js
@@ -1,5 +1,6 @@
 import { generateId } from '../utils/id.js';
-import { _el, createActionButton, createModalOverlay } from '../utils/dom.js';
+import { _el, createActionButton } from '../utils/dom.js';
+import { createModalOverlay } from '../utils/dom-dialogs.js';
 import {
   SCHEDULE_LABELS, DAY_NAMES, WEEKDAY_INDICES, INTERVAL_HOURS,
   DEFAULT_TIME, buildScheduleData,

--- a/src/components/settings-modal.js
+++ b/src/components/settings-modal.js
@@ -1,5 +1,6 @@
 import { formatCombo, eventToCombo } from '../utils/shortcut-helpers.js';
-import { _el, createActionButton, createModalOverlay } from '../utils/dom.js';
+import { _el, createActionButton } from '../utils/dom.js';
+import { createModalOverlay } from '../utils/dom-dialogs.js';
 import { MODAL_CLOSE_TRANSITION_MS, MODIFIER_KEYS, NAV_SECTIONS } from '../utils/settings-helpers.js';
 import { getComponent } from '../utils/component-registry.js';
 

--- a/src/utils/context-menu.js
+++ b/src/utils/context-menu.js
@@ -2,9 +2,25 @@
  * @typedef {{ label?: string, action?: () => void, separator?: boolean, shortcut?: string, colorDot?: string, children?: Array<ContextMenuItem> }} ContextMenuItem
  */
 
-import { _el, positionInViewport } from './dom.js';
+import { _el } from './dom.js';
 import { onClickStopped } from './event-helpers.js';
 import { setupKeyboardShortcuts } from './keyboard-helpers.js';
+
+/**
+ * Clamp (x, y) so a box of (width, height) stays within the viewport.
+ * @param {number} x
+ * @param {number} y
+ * @param {number} width
+ * @param {number} height
+ * @param {number} [padding=8]
+ * @returns {{ left: number, top: number }}
+ */
+function positionInViewport(x, y, width, height, padding = 8) {
+  return {
+    left: Math.min(x, window.innerWidth  - width  - padding),
+    top:  Math.min(y, window.innerHeight - height - padding),
+  };
+}
 
 export class ContextMenu {
   constructor() {

--- a/src/utils/dom-dialogs.js
+++ b/src/utils/dom-dialogs.js
@@ -6,8 +6,25 @@
  * buildChevronRow, etc.) import directly from './dom.js'.
  */
 
-import { _el, createActionButton, createModalOverlay } from './dom.js';
+import { _el, createActionButton } from './dom.js';
 import { setupKeyboardShortcuts } from './keyboard-helpers.js';
+
+/**
+ * Create a modal overlay with click-outside-to-close behavior.
+ * Returns { overlay, modal } DOM elements. Caller appends children to modal.
+ *
+ * @param {string} overlayClass
+ * @param {string} modalClass
+ * @param {() => void} onClose
+ * @returns {{ overlay: HTMLElement, modal: HTMLElement }}
+ */
+export function createModalOverlay(overlayClass, modalClass, onClose) {
+  const overlay = _el('div', overlayClass);
+  const modal = _el('div', modalClass);
+  overlay.appendChild(modal);
+  overlay.addEventListener('click', (e) => { if (e.target === overlay) onClose(); });
+  return { overlay, modal };
+}
 
 // ── Private dialog lifecycle ──
 

--- a/src/utils/dom.js
+++ b/src/utils/dom.js
@@ -2,14 +2,18 @@
  * Core DOM utilities.
  *
  * This module keeps only the essential DOM factories:
- *   _el, createActionButton, createSelect, renderButtonBar, buildChevronRow,
- *   createModalOverlay, positionInViewport, _safeFit
+ *   _el, createActionButton, renderButtonBar, buildChevronRow
  *
  * The following helpers have been extracted to dedicated modules — import
  * them directly from there instead of going through this file:
- *   - setupInlineInput, startInlineRename  → ./form-helpers.js
- *   - setupDropZone                        → ./drop-zone-helpers.js
- *   - setupKeyboardShortcuts               → ./keyboard-helpers.js
+ *   - createModalOverlay, createCustomModal,
+ *     showPromptDialog, showConfirmDialog   → ./dom-dialogs.js
+ *   - setupInlineInput, startInlineRename   → ./form-helpers.js
+ *   - setupDropZone                         → ./drop-zone-helpers.js
+ *   - setupKeyboardShortcuts                → ./keyboard-helpers.js
+ *   - _safeFit                              → ./terminal-factory.js
+ *   - createSelect                          → ./flow-modal-helpers.js (private)
+ *   - positionInViewport                    → ./context-menu.js (private)
  */
 import { onClickStopped } from './event-helpers.js';
 
@@ -104,38 +108,6 @@ export function renderButtonBar({ containerClass, configs, handlers }) {
 }
 
 /**
- * Create a <select> element from an options map.
- * @param {{ options: Record<string, string>, value?: string, className?: string, onChange?: (e: Event) => void }} opts
- * @returns {HTMLSelectElement}
- */
-export function createSelect({ options, value, className, onChange } = {}) {
-  const select = _el('select', { className: className || '' });
-  for (const [val, label] of Object.entries(options)) {
-    select.appendChild(_el('option', { value: val, textContent: label }));
-  }
-  if (value !== undefined) select.value = value;
-  if (onChange) select.addEventListener('change', onChange);
-  return select;
-}
-
-/** Safely call fitAddon.fit(), swallowing errors from detached terminals. */
-export function _safeFit(fitAddon) {
-  try { fitAddon.fit(); } catch {}
-}
-
-/**
- * Create a modal overlay with click-outside-to-close behavior.
- * Returns { overlay, modal } DOM elements. Caller appends children to modal.
- */
-export function createModalOverlay(overlayClass, modalClass, onClose) {
-  const overlay = _el('div', overlayClass);
-  const modal = _el('div', modalClass);
-  overlay.appendChild(modal);
-  overlay.addEventListener('click', (e) => { if (e.target === overlay) onClose(); });
-  return { overlay, modal };
-}
-
-/**
  * Build a row containing a chevron span and a name span.
  *
  * Used by file-tree rows and flow-category headers — any place that needs
@@ -150,19 +122,4 @@ export function buildChevronRow(opts) {
   return { chevron, name };
 }
 
-/**
- * Clamp (x, y) so a box of (width, height) stays within the viewport.
- * @param {number} x
- * @param {number} y
- * @param {number} width
- * @param {number} height
- * @param {number} [padding=8]
- * @returns {{ left: number, top: number }}
- */
-export function positionInViewport(x, y, width, height, padding = 8) {
-  return {
-    left: Math.min(x, window.innerWidth  - width  - padding),
-    top:  Math.min(y, window.innerHeight - height - padding),
-  };
-}
 

--- a/src/utils/flow-modal-helpers.js
+++ b/src/utils/flow-modal-helpers.js
@@ -1,5 +1,20 @@
-import { _el, createSelect } from './dom.js';
+import { _el } from './dom.js';
 import { SCHEDULE_TYPE_CONFIG } from './flow-schedule-helpers.js';
+
+/**
+ * Create a <select> element from an options map.
+ * @param {{ options: Record<string, string>, value?: string, className?: string, onChange?: (e: Event) => void }} opts
+ * @returns {HTMLSelectElement}
+ */
+function createSelect({ options, value, className, onChange } = {}) {
+  const select = _el('select', { className: className || '' });
+  for (const [val, label] of Object.entries(options)) {
+    select.appendChild(_el('option', { value: val, textContent: label }));
+  }
+  if (value !== undefined) select.value = value;
+  if (onChange) select.addEventListener('change', onChange);
+  return select;
+}
 
 // --- Constants ---
 

--- a/src/utils/terminal-factory.js
+++ b/src/utils/terminal-factory.js
@@ -1,8 +1,12 @@
 import { Terminal } from '@xterm/xterm';
 import { FitAddon } from '@xterm/addon-fit';
 import { getTerminalTheme } from './terminal-themes.js';
-import { _safeFit } from './dom.js';
 import { disposeResources } from './disposable.js';
+
+/** Safely call fitAddon.fit(), swallowing errors from detached terminals. */
+export function _safeFit(fitAddon) {
+  try { fitAddon.fit(); } catch {}
+}
 
 const BASE_FONT_FAMILY =
   '"JetBrains Mono", "Fira Code", "Cascadia Code", Menlo, monospace';


### PR DESCRIPTION
## Refactoring

Réduit la surface d'API de dom.js en extrayant 4 exports vers des modules plus appropriés :

| Export déplacé | Destination | Raison |
|---|---|---|
| `_safeFit` | `terminal-factory.js` | Spécifique à xterm |
| `createModalOverlay` | `dom-dialogs.js` | Consolidation logique modale |
| `createSelect` | `flow-modal-helpers.js` | Seul consommateur |
| `positionInViewport` | `context-menu.js` | Seul consommateur |

dom.js ne conserve plus que le noyau : `_el`, `createActionButton`, `renderButtonBar`, `buildChevronRow`.

Closes #203

## Fichier(s) modifié(s)

- `src/utils/dom.js` — suppression de 4 exports
- `src/utils/terminal-factory.js` — ajout de `_safeFit`
- `src/utils/dom-dialogs.js` — ajout de `createModalOverlay`
- `src/utils/flow-modal-helpers.js` — ajout de `createSelect` (privé)
- `src/utils/context-menu.js` — ajout de `positionInViewport` (privé)
- `src/components/board-view.js` — import mis à jour
- `src/components/flow-card-terminal.js` — import mis à jour
- `src/components/flow-modal.js` — import mis à jour
- `src/components/settings-modal.js` — import mis à jour

## Vérifications

- [x] Build OK
- [x] Tests OK (341 tests passent)

---

📂 Path local : `/Users/rekta/projet/coding/refactor-pikagent`
🤖 PR créée automatiquement par l'Agent Refactor