### PR TITLE
refactor: remove dead wrapper file and unnecessary export

### DIFF
--- a/src/utils/aggregation-utils.js
+++ b/src/utils/aggregation-utils.js
@@ -1,8 +1,0 @@
-/**
- * Aggregation utilities for the renderer process.
- * Delegates to shared/aggregation-utils.js to avoid duplicating logic.
- */
-
-import { aggregateByKey, groupAndAggregate, countBy } from '../../shared/aggregation-utils.js';
-
-export { aggregateByKey, groupAndAggregate, countBy };

--- a/src/utils/form-helpers.js
+++ b/src/utils/form-helpers.js
@@ -14,7 +14,7 @@ import { setupKeyboardShortcuts } from './keyboard-helpers.js';
  * @param {(...args: unknown[]) => void} fn
  * @returns {(...args: unknown[]) => void}
  */
-export function createOnceGuard(fn) {
+function createOnceGuard(fn) {
   let called = false;
   return (...args) => { if (called) return; called = true; fn(...args); };
 }


### PR DESCRIPTION
## Refactoring

- Suppression de `src/utils/aggregation-utils.js` : fichier wrapper qui ré-exportait depuis `shared/aggregation-utils.js` mais n'était importé par aucun module
- Retrait de l'`export` sur `createOnceGuard()` dans `form-helpers.js` : fonction uniquement utilisée en interne dans le même fichier

Note : les 2 autres éléments de l'issue (#222) se sont révélés faux positifs après vérification :
- `date-utils.js` est importé par `flow-view-helpers.js`
- `_safeFit()` est importée par `board-view.js` et `flow-card-terminal.js`

Closes #222

## Fichier(s) modifié(s)

- `src/utils/aggregation-utils.js` (supprimé)
- `src/utils/form-helpers.js` (export retiré)

## Vérifications

- [x] Build OK
- [x] Tests OK (350/350)

---

📂 Path local : `/Users/rekta/projet/coding/refactor-pikagent`
🤖 PR créée automatiquement par l'Agent Refactor