### PR TITLE
refactor: decompose file-viewer.js into smaller modules

### DIFF
--- a/src/components/file-viewer.js
+++ b/src/components/file-viewer.js
@@ -1,10 +1,12 @@
 import { detectLanguage } from '../utils/file-icons.js';
-import { bus, subscribeBus, unsubscribeBus, EVENTS } from '../utils/events.js';
+import { bus, unsubscribeBus, EVENTS } from '../utils/events.js';
 import { _el } from '../utils/dom.js';
-import { EMPTY_MESSAGE, STATIC_MODES, MODE_CONFIG, ALL_STATIC_ELEMENTS, MODE_ACTIVATE, pinnedFiles } from '../utils/editor-helpers.js';
+import { EMPTY_MESSAGE, MODE_CONFIG, ALL_STATIC_ELEMENTS, MODE_ACTIVATE, pinnedFiles } from '../utils/editor-helpers.js';
 import { createEditorDOM, bindEditorEvents, updateLineNumbers, updateHighlight, updateStatusBar, saveFile } from '../utils/file-editor-renderer.js';
 import { createMarkdownPreviewDOM, updatePreviewStatusBar } from '../utils/markdown-preview-renderer.js';
 import { renderTabs as renderTabsHelper } from '../utils/file-viewer-tabs.js';
+import { renderModeBar } from '../utils/file-viewer-mode-bar.js';
+import { setupFileViewerListeners } from '../utils/file-viewer-listeners.js';
 import { registerComponent, getComponent } from '../utils/component-registry.js';
 
 export class FileViewer {
@@ -26,12 +28,19 @@ export class FileViewer {
       () => this._renderModeBar(),
     );
     this._renderModeBar();
-    this._setupListeners();
+    this._busListeners = setupFileViewerListeners(
+      { isActive: () => this.isActive() },
+      {
+        switchMode: (m) => this.switchMode(m),
+        openFile: (p, n) => this.openFile(p, n),
+        gitChanges: this.gitChanges,
+        getMode: () => this.mode,
+        loadPinnedFiles: () => this.loadPinnedFiles(),
+      },
+    );
   }
 
   static get pinnedFiles() { return pinnedFiles; }
-
-  // ===== Build =====
 
   render() {
     this.container.replaceChildren();
@@ -58,29 +67,6 @@ export class FileViewer {
     this.container.appendChild(this.statusBar);
 
     this.showEmpty();
-  }
-
-  _setupListeners() {
-    // Bus event listeners — single declaration drives both subscription and cleanup
-    this._busListeners = subscribeBus([
-      /** @listens file:open {{ path: string, name: string }} */
-      [EVENTS.FILE_OPEN, ({ path, name }) => {
-        if (!this.isActive()) return;
-        this.switchMode('files');
-        this.openFile(path, name);
-      }],
-      /** @listens terminal:cwdChanged {{ id: string, cwd: string }} */
-      [EVENTS.TERMINAL_CWD_CHANGED, ({ cwd }) => {
-        if (!this.isActive()) return;
-        this.gitChanges.setCwd(cwd);
-        if (this.mode === 'git') this.gitChanges.loadChanges();
-      }],
-      /** @listens workspace:activated {undefined} */
-      [EVENTS.WORKSPACE_ACTIVATED, () => {
-        if (!this.isActive()) return;
-        this.loadPinnedFiles();
-      }],
-    ]);
   }
 
   async loadPinnedFiles() {
@@ -277,19 +263,8 @@ export class FileViewer {
     this.statusBar.replaceChildren();
   }
 
-  // ===== Mode Bar =====
-
   _renderModeBar() {
-    this.modeBar.replaceChildren();
-    for (const { key, label } of STATIC_MODES) {
-      const btn = _el('button', `mode-btn${this.mode === key ? ' active' : ''}`, label);
-      btn.addEventListener('click', () => this.switchMode(key));
-      this.modeBar.appendChild(btn);
-    }
-    for (const wt of this._webviewMgr.webviewTabs) {
-      this.modeBar.appendChild(this._webviewMgr.buildWebviewModeBtn(wt, this.mode));
-    }
-    this.modeBar.appendChild(this._webviewMgr.buildAddWebviewBtn(this.modeBar));
+    renderModeBar(this.modeBar, this.mode, { switchMode: (m) => this.switchMode(m) }, this._webviewMgr);
   }
 
   // ===== Webview Management (delegated) =====

--- a/src/utils/file-viewer-listeners.js
+++ b/src/utils/file-viewer-listeners.js
@@ -1,0 +1,42 @@
+/**
+ * Bus-event listener setup for FileViewer.
+ * Extracted from file-viewer.js to reduce component size.
+ */
+
+import { subscribeBus, EVENTS } from './events.js';
+
+/**
+ * Subscribe to bus events that drive file-viewer behaviour.
+ * Returns the listener handles needed for cleanup via `unsubscribeBus`.
+ *
+ * @param {{ isActive: () => boolean }} guards
+ * @param {{
+ *   switchMode: (mode: string) => void,
+ *   openFile: (path: string, name: string) => void,
+ *   gitChanges: { setCwd: (cwd: string) => void, loadChanges: () => void },
+ *   getMode: () => string,
+ *   loadPinnedFiles: () => void,
+ * }} handlers
+ * @returns {Array} listener handles for `unsubscribeBus`
+ */
+export function setupFileViewerListeners({ isActive }, handlers) {
+  return subscribeBus([
+    /** @listens file:open {{ path: string, name: string }} */
+    [EVENTS.FILE_OPEN, ({ path, name }) => {
+      if (!isActive()) return;
+      handlers.switchMode('files');
+      handlers.openFile(path, name);
+    }],
+    /** @listens terminal:cwdChanged {{ id: string, cwd: string }} */
+    [EVENTS.TERMINAL_CWD_CHANGED, ({ cwd }) => {
+      if (!isActive()) return;
+      handlers.gitChanges.setCwd(cwd);
+      if (handlers.getMode() === 'git') handlers.gitChanges.loadChanges();
+    }],
+    /** @listens workspace:activated {undefined} */
+    [EVENTS.WORKSPACE_ACTIVATED, () => {
+      if (!isActive()) return;
+      handlers.loadPinnedFiles();
+    }],
+  ]);
+}

--- a/src/utils/file-viewer-mode-bar.js
+++ b/src/utils/file-viewer-mode-bar.js
@@ -1,0 +1,28 @@
+/**
+ * Mode-bar rendering helper for FileViewer.
+ * Extracted from file-viewer.js to reduce component size.
+ */
+
+import { _el } from './dom.js';
+import { STATIC_MODES } from './editor-helpers.js';
+
+/**
+ * Rebuild the mode bar with static mode buttons and webview tabs.
+ *
+ * @param {HTMLElement} modeBar - the mode bar container element
+ * @param {string} currentMode - the currently active mode key
+ * @param {{ switchMode: (mode: string) => void }} callbacks
+ * @param {{ webviewTabs: Array, buildWebviewModeBtn: Function, buildAddWebviewBtn: Function }} webviewMgr
+ */
+export function renderModeBar(modeBar, currentMode, { switchMode }, webviewMgr) {
+  modeBar.replaceChildren();
+  for (const { key, label } of STATIC_MODES) {
+    const btn = _el('button', `mode-btn${currentMode === key ? ' active' : ''}`, label);
+    btn.addEventListener('click', () => switchMode(key));
+    modeBar.appendChild(btn);
+  }
+  for (const wt of webviewMgr.webviewTabs) {
+    modeBar.appendChild(webviewMgr.buildWebviewModeBtn(wt, currentMode));
+  }
+  modeBar.appendChild(webviewMgr.buildAddWebviewBtn(modeBar));
+}


### PR DESCRIPTION
## Summary

- Extracted `_renderModeBar` logic into `src/utils/file-viewer-mode-bar.js`
- Extracted `_setupListeners` logic into `src/utils/file-viewer-listeners.js`
- Reduced `file-viewer.js` from 324 lines to 299 lines (under the 300-line target)

Closes #225

## Fichier(s) modifie(s)

- `src/components/file-viewer.js` (modified — imports new helpers, delegates logic)
- `src/utils/file-viewer-mode-bar.js` (new — mode bar rendering)
- `src/utils/file-viewer-listeners.js` (new — bus event listener setup)

## Verifications

- [x] Build OK (`npm run build`)
- [x] Tests OK (`npm test` — 25 files, 365 tests passing)

---

PR creee automatiquement par l'Agent Refactor