### PR TITLE
refactor: remove dead getLastRun re-export from flow-helpers.js

### DIFF
--- a/main/flow-helpers.js
+++ b/main/flow-helpers.js
@@ -45,8 +45,6 @@ function _buildAgentCmd(agent, prompt, opts = {}) {
   return parts.join(' ');
 }
 
-// getLastRun imported from shared/flow-utils.js
-
 /* ── Schedule day filters (single source of truth) ─────────────── */
 
 const SCHEDULE_DAY_FILTER = {
@@ -159,6 +157,6 @@ module.exports = {
   SCHEDULER_INTERVAL_MS, SHELL_INIT_DELAY_MS, MAX_RUN_HISTORY,
   DEFAULT_PTY_COLS, DEFAULT_PTY_ROWS, MAX_FLOW_RUNTIME_MS,
   flowPath, logPath,
-  getLastRun, shouldRun, buildFlowCommand,
+  shouldRun, buildFlowCommand,
   createOutputProcessor,
 };

--- a/tests/main/flow-helpers.test.js
+++ b/tests/main/flow-helpers.test.js
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
-const { getLastRun, shouldRun, buildFlowCommand } = require('../../main/flow-helpers');
+const { shouldRun, buildFlowCommand } = require('../../main/flow-helpers');
+const { getLastRun } = require('../../shared/flow-utils');
 
 describe('flow-helpers', () => {
   describe('getLastRun', () => {


### PR DESCRIPTION
## Refactoring

Suppression du re-export inutilisé de `getLastRun` dans `main/flow-helpers.js`. Cette fonction est importée depuis `shared/flow-utils.js` et utilisée en interne par `shouldRun`, mais le re-export n'est consommé par aucun fichier du projet. Le test a été mis à jour pour importer directement depuis la source.

Closes #226

## Fichier(s) modifié(s)

- `main/flow-helpers.js` (retrait du re-export)
- `tests/main/flow-helpers.test.js` (import depuis shared/flow-utils)

## Vérifications

- [x] Build OK
- [x] Tests OK (350/350)

---

📂 Path local : `/Users/rekta/projet/coding/refactor-pikagent`
🤖 PR créée automatiquement par l'Agent Refactor