### PR TITLE
refactor: remove unused adjacentPanels export

### DIFF
--- a/src/utils/terminal-panel-helpers.js
+++ b/src/utils/terminal-panel-helpers.js
@@ -48,7 +48,7 @@ export function createSplitContainer(direction, flex = '1') {
 }
 
 /** Find the adjacent non-handle panels around a split handle. */
-export function adjacentPanels(handle, splitEl) {
+function adjacentPanels(handle, splitEl) {
   const children = Array.from(splitEl.children);
   const idx = children.indexOf(handle);
   let before = null, after = null;


### PR DESCRIPTION
## Refactoring

Removed the `export` keyword from `adjacentPanels` in `terminal-panel-helpers.js`. This function is only used internally by `doResize` in the same file and was never imported elsewhere.

Closes #232

## Fichier(s) modifié(s)

- `src/utils/terminal-panel-helpers.js`

## Vérifications

- [x] Build OK
- [x] Tests OK

---

📂 Path local : `/Users/rekta/projet/coding/refactor-pikagent`
🤖 PR créée automatiquement par l'Agent Refactor