### PR TITLE
refactor: remove unused getLastRun re-export

### DIFF
--- a/main/flow-helpers.js
+++ b/main/flow-helpers.js
@@ -45,8 +45,6 @@ function _buildAgentCmd(agent, prompt, opts = {}) {
   return parts.join(' ');
 }
 
-// getLastRun imported from shared/flow-utils.js
-
 /* ── Schedule day filters (single source of truth) ─────────────── */
 
 const SCHEDULE_DAY_FILTER = {
@@ -159,6 +157,6 @@ module.exports = {
   SCHEDULER_INTERVAL_MS, SHELL_INIT_DELAY_MS, MAX_RUN_HISTORY,
   DEFAULT_PTY_COLS, DEFAULT_PTY_ROWS, MAX_FLOW_RUNTIME_MS,
   flowPath, logPath,
-  getLastRun, shouldRun, buildFlowCommand,
+  shouldRun, buildFlowCommand,
   createOutputProcessor,
 };

--- a/tests/main/flow-helpers.test.js
+++ b/tests/main/flow-helpers.test.js
@@ -1,8 +1,9 @@
 import { describe, it, expect } from 'vitest';
-const { getLastRun, shouldRun, buildFlowCommand } = require('../../main/flow-helpers');
+const { shouldRun, buildFlowCommand } = require('../../main/flow-helpers');
+const { getLastRun } = require('../../shared/flow-utils');
 
 describe('flow-helpers', () => {
-  describe('getLastRun', () => {
+  describe('getLastRun (from shared/flow-utils)', () => {
     it('returns last run from array', () => {
       const flow = { runs: [{ id: 1 }, { id: 2 }] };
       expect(getLastRun(flow)).toEqual({ id: 2 });


### PR DESCRIPTION
## Refactoring

Removed the unused `getLastRun` re-export from `main/flow-helpers.js`. All consumers import `getLastRun` directly from `shared/flow-utils.js`, making this re-export dead code.

Closes #226

## Fichier(s) modifié(s)

- `main/flow-helpers.js` — removed `getLastRun` from `module.exports` and removed stale comment
- `tests/main/flow-helpers.test.js` — updated to import `getLastRun` from `shared/flow-utils` directly

## Vérifications

- [x] Build OK
- [x] Tests OK (363/363 passing)

---

📂 Path local : `/Users/rekta/projet/coding/refactor-pikagent`
🤖 PR créée automatiquement par l'Agent Refactor