### PR TITLE
refactor: factor basename extraction into shared utility

### DIFF
--- a/src/utils/file-tree-context-menu.js
+++ b/src/utils/file-tree-context-menu.js
@@ -3,7 +3,7 @@
  * Extracted from FileTree to reduce component size.
  */
 import { bus, EVENTS } from './events.js';
-import { getRelativePath } from './file-tree-helpers.js';
+import { getRelativePath, getBaseName } from './file-tree-helpers.js';
 
 /**
  * Build the common context menu items shared between files and directories.
@@ -16,7 +16,7 @@ import { getRelativePath } from './file-tree-helpers.js';
  * @returns {Array<{ label?: string, separator?: boolean, action?: () => void }>} menu items
  */
 export function buildCommonContextItems(entryPath, nameEl, rootCwd, promptRenameFn, deleteLabel, { clipboardWrite, fsCopy, showInFolder, fsTrash }) {
-  const displayName = entryPath.split('/').pop();
+  const displayName = getBaseName(entryPath);
   return [
     { label: 'Rename', action: () => promptRenameFn(entryPath, nameEl) },
     { separator: true },
@@ -64,7 +64,7 @@ export function buildFileContextItems(entryPath, nameEl, rootCwd, promptRenameFn
  * @returns {Array<{ label?: string, separator?: boolean, action?: () => void }>} menu items
  */
 export function buildDirContextItems(dirPath, rootCwd, contentEl, depth, expandedDirs, nameEl, promptRenameFn, promptNewEntryFn, api) {
-  const dirName = dirPath.split('/').pop();
+  const dirName = getBaseName(dirPath);
   return [
     { label: 'New File', action: () => promptNewEntryFn(dirPath, contentEl, depth, expandedDirs, 'file') },
     { label: 'New Folder', action: () => promptNewEntryFn(dirPath, contentEl, depth, expandedDirs, 'folder') },

--- a/src/utils/file-tree-drop.js
+++ b/src/utils/file-tree-drop.js
@@ -7,7 +7,7 @@ import { bus, EVENTS } from './events.js';
 import { _el } from './dom.js';
 import { setupInlineInput, startInlineRename } from './form-helpers.js';
 import { setupDropZone as _setupDropZone } from './drop-zone-helpers.js';
-import { INPUT_BLUR_DELAY, computeIndent } from './file-tree-helpers.js';
+import { INPUT_BLUR_DELAY, computeIndent, getBaseName } from './file-tree-helpers.js';
 
 /**
  * Attach dragover / dragleave / drop listeners to an element so that files
@@ -64,7 +64,7 @@ export async function handleFileDrop(files, destDir, { copyTo }) {
  * @param {{ rename: (entryPath: string, newName: string) => Promise<unknown> }} api - injected API methods
  */
 export function promptRename(entryPath, nameEl, { rename }) {
-  const oldName = entryPath.split('/').pop();
+  const oldName = getBaseName(entryPath);
   const dotIndex = oldName.lastIndexOf('.');
 
   startInlineRename(nameEl, {

--- a/src/utils/file-tree-helpers.js
+++ b/src/utils/file-tree-helpers.js
@@ -35,13 +35,17 @@ export function getRelativePath(fullPath, rootCwd) {
 }
 
 /**
- * Extract the folder display name from a cwd path.
- * @param {string} cwd
+ * Return the last segment (base name) of a path string.
+ * Works for both file and directory paths.
+ * @param {string} path
  * @returns {string}
  */
-export function extractFolderName(cwd) {
-  return cwd.split('/').filter(Boolean).pop() || '/';
+export function getBaseName(path) {
+  return path.split('/').filter(Boolean).pop() || '/';
 }
+
+/** @deprecated Use {@link getBaseName} instead. */
+export const extractFolderName = getBaseName;
 
 /**
  * Strip the watch prefix from a watchId to get the original cwd.

--- a/tests/utils/di-injection.test.js
+++ b/tests/utils/di-injection.test.js
@@ -36,6 +36,8 @@ describe('DI: file-tree-context-menu', () => {
     vi.doMock('../../src/utils/events.js', () => ({ bus: { emit: vi.fn(), on: vi.fn() } }));
     vi.doMock('../../src/utils/file-tree-helpers.js', () => ({
       getRelativePath: (p, root) => p.replace(root + '/', ''),
+      getBaseName: (p) => p.split('/').filter(Boolean).pop() || '/',
+      extractFolderName: (p) => p.split('/').filter(Boolean).pop() || '/',
       INPUT_BLUR_DELAY: 100,
       computeIndent: () => 0,
     }));
@@ -121,6 +123,8 @@ describe('DI: file-tree-drop handleFileDrop', () => {
     }));
     vi.doMock('../../src/utils/events.js', () => ({ bus: { emit: vi.fn(), on: vi.fn() } }));
     vi.doMock('../../src/utils/file-tree-helpers.js', () => ({
+      getBaseName: (p) => p.split('/').filter(Boolean).pop() || '/',
+      extractFolderName: (p) => p.split('/').filter(Boolean).pop() || '/',
       INPUT_BLUR_DELAY: 100,
       computeIndent: () => 0,
     }));


### PR DESCRIPTION
## Refactoring

Generalized `extractFolderName()` into `getBaseName()` in `file-tree-helpers.js` and replaced 3 inline `split('/').pop()` calls with imports of this shared utility.

Closes #231

## Fichier(s) modifié(s)

- `src/utils/file-tree-helpers.js`
- `src/utils/file-tree-context-menu.js`
- `src/utils/file-tree-drop.js`
- `tests/utils/di-injection.test.js`

## Vérifications

- [x] Build OK
- [x] Tests OK (363/363)

---

📂 Path local : `/Users/rekta/projet/coding/refactor-pikagent`
🤖 PR créée automatiquement par l'Agent Refactor