### PR TITLE
refactor: decompose tab-manager.js into smaller modules

### DIFF
--- a/src/components/tab-manager.js
+++ b/src/components/tab-manager.js
@@ -15,7 +15,15 @@ import {
   isTabVisible,
   createTab as doCreateTab, closeTab as doCloseTab,
   switchTo as doSwitchTo,
-  reorderEntries, findCycleTarget, findColorGroupTarget,
+  reorderEntries,
+  setColorFilter as doSetColorFilter,
+  toggleExcludeColor as doToggleExcludeColor,
+  ensureVisibleTabActive as doEnsureVisibleTabActive,
+  nextTab as doNextTab, prevTab as doPrevTab,
+  goToColorGroup as doGoToColorGroup, focusDirection as doFocusDirection,
+  setTabColorGroup as doSetTabColorGroup,
+  toggleNoShortcut as doToggleNoShortcut,
+  buildPrApi, buildWorktreeApi, buildViewStore,
 } from '../utils/tab-facade.js';
 
 export class TabManager {
@@ -46,48 +54,9 @@ export class TabManager {
     this.init();
   }
 
-  /**
-   * Adapter exposing the git + shell surface needed by the open-PR flow.
-   * @returns {import('../utils/open-pr-flow.js').OpenPrApi}
-   */
-  _prApi() {
-    return {
-      branch:       (cwd) => window.api.git.branch(cwd),
-      remoteUrl:    (cwd) => window.api.git.remoteUrl(cwd),
-      pushBranch:   ({ cwd, branch }) => window.api.git.pushBranch(cwd, branch),
-      ghAvailable:  () => window.api.git.ghAvailable(),
-      ghPrCreate:   ({ cwd, baseBranch }) => window.api.git.ghPrCreate(cwd, baseBranch),
-      openExternal: (url) => window.api.shell.openExternal(url),
-    };
-  }
-
-  /**
-   * Adapter exposing the git-worktree IPC surface as an object-style API,
-   * matching {@link import('../utils/worktree-flow.js').GitWorktreeApi}.
-   * @returns {import('../utils/worktree-flow.js').GitWorktreeApi}
-   */
-  _worktreeApi() {
-    return {
-      isRepo:       (cwd) => window.api.git.isRepo(cwd),
-      branch:       (cwd) => window.api.git.branch(cwd),
-      listBranches: (cwd) => window.api.git.listBranches(cwd),
-      worktreeList: (cwd) => window.api.git.worktreeList(cwd),
-      worktreeAdd:  ({ cwd, branch, targetPath, createBranch, baseBranch }) =>
-        window.api.git.worktreeAdd(cwd, branch, targetPath, createBranch, baseBranch),
-      worktreeRemove: ({ cwd, worktreePath, force }) =>
-        window.api.git.worktreeRemove(cwd, worktreePath, force),
-    };
-  }
-
-  /** @returns {import('../utils/sidebar-manager.js').SideViewStore} */
-  _viewStore() {
-    return {
-      getView: (key) => this[key],
-      setView: (key, val) => { this[key] = val; },
-      getContainer: (key) => this[key],
-      setContainer: (key, val) => { this[key] = val; },
-    };
-  }
+  _prApi() { return buildPrApi(window.api); }
+  _worktreeApi() { return buildWorktreeApi(window.api); }
+  _viewStore() { return buildViewStore(this); }
 
   async init() {
     this.defaultCwd = await initTabManager({
@@ -143,6 +112,7 @@ export class TabManager {
   }
 
   switchToBoard() { this.setSidebarMode('board'); }
+
   async renderWorkspace(tab) {
     return doRenderWorkspace({
       workspaceContainer: this.workspaceContainer,
@@ -172,6 +142,7 @@ export class TabManager {
   }
 
   autoSave() { return this.configManager.autoSave(); }
+
   createTab(name = null, cwd = null) {
     return doCreateTab({
       tabs: this.tabs,
@@ -212,18 +183,11 @@ export class TabManager {
   }
 
   setColorFilter(colorGroupId) {
-    this.excludedColors.clear();
-    this.activeColorFilter = this.activeColorFilter === colorGroupId ? null : colorGroupId;
-    this.renderTabBar();
-    this._ensureVisibleTabActive();
+    doSetColorFilter(this, colorGroupId, () => this.renderTabBar(), () => this._ensureVisibleTabActive());
   }
 
   toggleExcludeColor(colorGroupId) {
-    this.activeColorFilter = null;
-    if (this.excludedColors.has(colorGroupId)) this.excludedColors.delete(colorGroupId);
-    else this.excludedColors.add(colorGroupId);
-    this.renderTabBar();
-    this._ensureVisibleTabActive();
+    doToggleExcludeColor(this, colorGroupId, () => this.renderTabBar(), () => this._ensureVisibleTabActive());
   }
 
   _isTabVisible(tab) {
@@ -231,11 +195,7 @@ export class TabManager {
   }
 
   _ensureVisibleTabActive() {
-    const active = this._activeTab();
-    if (active && this._isTabVisible(active)) return;
-    for (const [id, tab] of this.tabs) {
-      if (this._isTabVisible(tab)) { this.switchTo(id); return; }
-    }
+    doEnsureVisibleTabActive(this.tabs, () => this._activeTab(), this.activeColorFilter, this.excludedColors, (id) => this.switchTo(id));
   }
 
   renderTabBar() {
@@ -288,24 +248,15 @@ export class TabManager {
   }
 
   setTabColorGroup(id, colorGroupId) {
-    const tab = this.tabs.get(id);
-    if (!tab) return;
-    tab.colorGroup = colorGroupId;
-    this.renderTabBar();
-    this.configManager.scheduleAutoSave();
+    doSetTabColorGroup(this.tabs, id, colorGroupId, () => this.renderTabBar(), this.configManager);
   }
 
   goToColorGroup(colorGroupId) {
-    const target = findColorGroupTarget(this.tabs, this.activeTabId, colorGroupId);
-    if (target) this.switchTo(target);
+    doGoToColorGroup(this.tabs, this.activeTabId, colorGroupId, (id) => this.switchTo(id));
   }
 
   toggleNoShortcut(id) {
-    const tab = this.tabs.get(id);
-    if (!tab) return;
-    tab.noShortcut = !tab.noShortcut;
-    this.renderTabBar();
-    this.configManager.scheduleAutoSave();
+    doToggleNoShortcut(this.tabs, id, () => this.renderTabBar(), this.configManager);
   }
 
   isActiveNoShortcut() { return this._activeTab()?.noShortcut ?? false; }
@@ -313,20 +264,14 @@ export class TabManager {
   splitVertical() { this._activeTab()?.terminalPanel?.splitActive('vertical'); }
 
   focusDirection(direction) {
-    if (this.sidebarMode === 'board' && this.boardView) {
-      this.boardView.focusDirection(direction);
-      return;
-    }
-    this._activeTab()?.terminalPanel?.focusDirection(direction);
+    doFocusDirection(direction, this.sidebarMode, this.boardView, () => this._activeTab());
   }
 
   nextTab() {
-    const target = findCycleTarget(this.tabs, this.activeTabId, 1);
-    if (target) this.switchTo(target);
+    doNextTab(this.tabs, this.activeTabId, (id) => this.switchTo(id));
   }
 
   prevTab() {
-    const target = findCycleTarget(this.tabs, this.activeTabId, -1);
-    if (target) this.switchTo(target);
+    doPrevTab(this.tabs, this.activeTabId, (id) => this.switchTo(id));
   }
 }

--- a/src/utils/tab-color-filter.js
+++ b/src/utils/tab-color-filter.js
@@ -23,6 +23,60 @@ export function isTabVisible(tab, activeColorFilter, excludedColors) {
  * @param {{ onClearFilter: () => void, onSetFilter: (colorGroupId: string) => void, onToggleExclude: (colorGroupId: string) => void }} handlers
  * @returns {HTMLElement|null}
  */
+/**
+ * Apply "include only this color" filter and ensure a visible tab is active.
+ * @param {{ activeColorFilter: string|null, excludedColors: Set<string> }} state
+ * @param {string} colorGroupId
+ * @param {() => void} renderTabBar
+ * @param {() => void} ensureVisibleTabActive
+ */
+export function setColorFilter(state, colorGroupId, renderTabBar, ensureVisibleTabActive) {
+  state.excludedColors.clear();
+  state.activeColorFilter = state.activeColorFilter === colorGroupId ? null : colorGroupId;
+  renderTabBar();
+  ensureVisibleTabActive();
+}
+
+/**
+ * Toggle exclusion of a color group and ensure a visible tab is active.
+ * @param {{ activeColorFilter: string|null, excludedColors: Set<string> }} state
+ * @param {string} colorGroupId
+ * @param {() => void} renderTabBar
+ * @param {() => void} ensureVisibleTabActive
+ */
+export function toggleExcludeColor(state, colorGroupId, renderTabBar, ensureVisibleTabActive) {
+  state.activeColorFilter = null;
+  if (state.excludedColors.has(colorGroupId)) state.excludedColors.delete(colorGroupId);
+  else state.excludedColors.add(colorGroupId);
+  renderTabBar();
+  ensureVisibleTabActive();
+}
+
+/**
+ * If the active tab is not visible under the current filter, switch to
+ * the first visible tab.
+ * @param {Map<string, import('./tab-manager-helpers.js').WorkspaceTab>} tabs
+ * @param {() => import('./tab-manager-helpers.js').WorkspaceTab|undefined} getActiveTab
+ * @param {string|null} activeColorFilter
+ * @param {Set<string>} excludedColors
+ * @param {(id: string) => void} switchTo
+ */
+export function ensureVisibleTabActive(tabs, getActiveTab, activeColorFilter, excludedColors, switchTo) {
+  const active = getActiveTab();
+  if (active && isTabVisible(active, activeColorFilter, excludedColors)) return;
+  for (const [id, tab] of tabs) {
+    if (isTabVisible(tab, activeColorFilter, excludedColors)) { switchTo(id); return; }
+  }
+}
+
+/**
+ * Build the color filter bar DOM element.
+ * @param {Map<string, import('./tab-manager-helpers.js').WorkspaceTab>} tabs
+ * @param {string|null} activeColorFilter
+ * @param {Set<string>} excludedColors
+ * @param {{ onClearFilter: () => void, onSetFilter: (colorGroupId: string) => void, onToggleExclude: (colorGroupId: string) => void }} handlers
+ * @returns {HTMLElement|null}
+ */
 export function buildColorFilters(tabs, activeColorFilter, excludedColors, handlers) {
   const usedColors = new Set();
   for (const [, tab] of tabs) {

--- a/src/utils/tab-facade.js
+++ b/src/utils/tab-facade.js
@@ -9,8 +9,15 @@
 
 export { inlineRenameTab } from './tab-renderer.js';
 export { renderTabBar } from './tab-bar-renderer.js';
-export { isTabVisible } from './tab-color-filter.js';
+export {
+  isTabVisible, setColorFilter, toggleExcludeColor, ensureVisibleTabActive,
+} from './tab-color-filter.js';
 export { createTab, closeTab, switchTo } from './tab-lifecycle.js';
 export {
-  reorderEntries, findCycleTarget, findColorGroupTarget,
+  reorderEntries,
 } from './tab-manager-helpers.js';
+export {
+  nextTab, prevTab, goToColorGroup, focusDirection,
+  setTabColorGroup, toggleNoShortcut,
+} from './tab-navigation.js';
+export { buildPrApi, buildWorktreeApi, buildViewStore } from './tab-manager-api.js';

--- a/src/utils/tab-manager-api.js
+++ b/src/utils/tab-manager-api.js
@@ -1,0 +1,68 @@
+/**
+ * Tab manager API adapters — extracted from tab-manager.js.
+ *
+ * These factory functions build narrow API objects consumed by extracted
+ * helpers (worktree-flow, open-pr-flow, sidebar-manager) so that the
+ * main TabManager class stays focused on orchestration.
+ *
+ * All functions receive their dependencies via parameters — no direct
+ * window.api references.
+ */
+
+/**
+ * @typedef {{ branch: Function, remoteUrl: Function, pushBranch: Function, ghAvailable: Function, ghPrCreate: Function }} GitApi
+ * @typedef {{ openExternal: Function }} ShellApi
+ */
+
+/**
+ * Adapter exposing the git + shell surface needed by the open-PR flow.
+ * @param {{ git: GitApi, shell: ShellApi }} api — injected API surface
+ * @returns {import('./open-pr-flow.js').OpenPrApi}
+ */
+export function buildPrApi(api) {
+  return {
+    branch:       (cwd) => api.git.branch(cwd),
+    remoteUrl:    (cwd) => api.git.remoteUrl(cwd),
+    pushBranch:   ({ cwd, branch }) => api.git.pushBranch(cwd, branch),
+    ghAvailable:  () => api.git.ghAvailable(),
+    ghPrCreate:   ({ cwd, baseBranch }) => api.git.ghPrCreate(cwd, baseBranch),
+    openExternal: (url) => api.shell.openExternal(url),
+  };
+}
+
+/**
+ * @typedef {{ isRepo: Function, branch: Function, listBranches: Function, worktreeList: Function, worktreeAdd: Function, worktreeRemove: Function }} GitWorktreeIpc
+ */
+
+/**
+ * Adapter exposing the git-worktree IPC surface as an object-style API,
+ * matching {@link import('./worktree-flow.js').GitWorktreeApi}.
+ * @param {{ git: GitWorktreeIpc }} api — injected API surface
+ * @returns {import('./worktree-flow.js').GitWorktreeApi}
+ */
+export function buildWorktreeApi(api) {
+  return {
+    isRepo:       (cwd) => api.git.isRepo(cwd),
+    branch:       (cwd) => api.git.branch(cwd),
+    listBranches: (cwd) => api.git.listBranches(cwd),
+    worktreeList: (cwd) => api.git.worktreeList(cwd),
+    worktreeAdd:  ({ cwd, branch, targetPath, createBranch, baseBranch }) =>
+      api.git.worktreeAdd(cwd, branch, targetPath, createBranch, baseBranch),
+    worktreeRemove: ({ cwd, worktreePath, force }) =>
+      api.git.worktreeRemove(cwd, worktreePath, force),
+  };
+}
+
+/**
+ * Build a view store adapter for sidebar-manager.
+ * @param {object} self — the TabManager instance (or any object holding side-view properties)
+ * @returns {import('./sidebar-manager.js').SideViewStore}
+ */
+export function buildViewStore(self) {
+  return {
+    getView: (key) => self[key],
+    setView: (key, val) => { self[key] = val; },
+    getContainer: (key) => self[key],
+    setContainer: (key, val) => { self[key] = val; },
+  };
+}

--- a/src/utils/tab-navigation.js
+++ b/src/utils/tab-navigation.js
@@ -1,0 +1,88 @@
+/**
+ * Tab navigation & property helpers — extracted from tab-manager.js.
+ *
+ * Contains keyboard-driven tab switching, color group navigation,
+ * split/focus actions, and tab property mutations (colorGroup, noShortcut).
+ */
+
+import { findCycleTarget, findColorGroupTarget } from './tab-manager-helpers.js';
+
+/**
+ * Switch to the next tab in the cycle.
+ * @param {Map<string, import('./tab-manager-helpers.js').WorkspaceTab>} tabs
+ * @param {string|null} activeTabId
+ * @param {(id: string) => void} switchTo
+ */
+export function nextTab(tabs, activeTabId, switchTo) {
+  const target = findCycleTarget(tabs, activeTabId, 1);
+  if (target) switchTo(target);
+}
+
+/**
+ * Switch to the previous tab in the cycle.
+ * @param {Map<string, import('./tab-manager-helpers.js').WorkspaceTab>} tabs
+ * @param {string|null} activeTabId
+ * @param {(id: string) => void} switchTo
+ */
+export function prevTab(tabs, activeTabId, switchTo) {
+  const target = findCycleTarget(tabs, activeTabId, -1);
+  if (target) switchTo(target);
+}
+
+/**
+ * Navigate to the next tab in a given color group (round-robin).
+ * @param {Map<string, import('./tab-manager-helpers.js').WorkspaceTab>} tabs
+ * @param {string|null} activeTabId
+ * @param {string} colorGroupId
+ * @param {(id: string) => void} switchTo
+ */
+export function goToColorGroup(tabs, activeTabId, colorGroupId, switchTo) {
+  const target = findColorGroupTarget(tabs, activeTabId, colorGroupId);
+  if (target) switchTo(target);
+}
+
+/**
+ * Move focus in a direction — delegates to board view or terminal panel.
+ * @param {string} direction
+ * @param {string} sidebarMode
+ * @param {object|null} boardView
+ * @param {() => import('./tab-manager-helpers.js').WorkspaceTab|undefined} getActiveTab
+ */
+export function focusDirection(direction, sidebarMode, boardView, getActiveTab) {
+  if (sidebarMode === 'board' && boardView) {
+    boardView.focusDirection(direction);
+    return;
+  }
+  getActiveTab()?.terminalPanel?.focusDirection(direction);
+}
+
+/**
+ * Set or clear a tab's color group.
+ * @param {Map<string, import('./tab-manager-helpers.js').WorkspaceTab>} tabs
+ * @param {string} id
+ * @param {string|null} colorGroupId
+ * @param {() => void} renderTabBar
+ * @param {{ scheduleAutoSave: () => void }} configManager
+ */
+export function setTabColorGroup(tabs, id, colorGroupId, renderTabBar, configManager) {
+  const tab = tabs.get(id);
+  if (!tab) return;
+  tab.colorGroup = colorGroupId;
+  renderTabBar();
+  configManager.scheduleAutoSave();
+}
+
+/**
+ * Toggle the noShortcut flag on a tab.
+ * @param {Map<string, import('./tab-manager-helpers.js').WorkspaceTab>} tabs
+ * @param {string} id
+ * @param {() => void} renderTabBar
+ * @param {{ scheduleAutoSave: () => void }} configManager
+ */
+export function toggleNoShortcut(tabs, id, renderTabBar, configManager) {
+  const tab = tabs.get(id);
+  if (!tab) return;
+  tab.noShortcut = !tab.noShortcut;
+  renderTabBar();
+  configManager.scheduleAutoSave();
+}


### PR DESCRIPTION
## Refactoring

Extracted logic from `tab-manager.js` (332 -> 277 lines) into dedicated helper modules to improve maintainability. The main file now focuses on orchestration only.

Closes #230

## Fichier(s) modifie(s)

- `src/components/tab-manager.js` — reduced from 332 to 277 lines, now pure orchestration
- `src/utils/tab-manager-api.js` — **new** — API adapter factories (`buildPrApi`, `buildWorktreeApi`, `buildViewStore`)
- `src/utils/tab-navigation.js` — **new** — navigation & tab property helpers (`nextTab`, `prevTab`, `goToColorGroup`, `focusDirection`, `setTabColorGroup`, `toggleNoShortcut`)
- `src/utils/tab-color-filter.js` — added `setColorFilter`, `toggleExcludeColor`, `ensureVisibleTabActive`
- `src/utils/tab-facade.js` — updated re-exports for new helpers

## Verifications

- [x] Build OK
- [x] Tests OK (365/365 passed)

---

PR creee automatiquement par l'Agent Refactor