### PR TITLE
refactor: add typed event subscription helpers to reduce implicit coupling

### DIFF
--- a/src/components/file-viewer.js
+++ b/src/components/file-viewer.js
@@ -1,5 +1,5 @@
 import { detectLanguage } from '../utils/file-icons.js';
-import { bus, unsubscribeBus, EVENTS } from '../utils/events.js';
+import { bus, EVENTS } from '../utils/events.js';
 import { _el } from '../utils/dom.js';
 import { EMPTY_MESSAGE, MODE_CONFIG, ALL_STATIC_ELEMENTS, MODE_ACTIVATE, pinnedFiles } from '../utils/editor-helpers.js';
 import { createEditorDOM, bindEditorEvents, updateLineNumbers, updateHighlight, updateStatusBar, saveFile } from '../utils/file-editor-renderer.js';
@@ -290,7 +290,7 @@ export class FileViewer {
   }
 
   dispose() {
-    unsubscribeBus(this._busListeners);
+    for (const unsub of this._busListeners) unsub();
     this._busListeners = [];
     this._webviewMgr.dispose();
   }

--- a/src/utils/events.js
+++ b/src/utils/events.js
@@ -242,3 +242,37 @@ export function subscribeBus(listeners) {
 export function unsubscribeBus(listeners) {
   for (const [event, handler] of listeners) bus.off(event, handler);
 }
+
+// ── Typed subscription helpers ──────────────────────────────────────
+// Narrow, discoverable APIs that make the implicit event contracts explicit.
+// Each returns an unsubscribe function.
+
+/** @param {(data: { id: string, cwd: string }) => void} cb */
+export const onTerminalCwdChanged = (cb) => bus.on(EVENTS.TERMINAL_CWD_CHANGED, cb);
+
+/** @param {(data: { id: string, cwd: string }) => void} cb */
+export const onTerminalCreated = (cb) => bus.on(EVENTS.TERMINAL_CREATED, cb);
+
+/** @param {(data: { id: string }) => void} cb */
+export const onTerminalRemoved = (cb) => bus.on(EVENTS.TERMINAL_REMOVED, cb);
+
+/** @param {(data: { id: string }) => void} cb */
+export const onTerminalExited = (cb) => bus.on(EVENTS.TERMINAL_EXITED, cb);
+
+/** @param {(data: undefined) => void} cb */
+export const onLayoutChanged = (cb) => bus.on(EVENTS.LAYOUT_CHANGED, cb);
+
+/** @param {(data: undefined) => void} cb */
+export const onWorkspaceActivated = (cb) => bus.on(EVENTS.WORKSPACE_ACTIVATED, cb);
+
+/** @param {(data: { cwd: string }) => void} cb */
+export const onWorkspaceOpenFromFolder = (cb) => bus.on(EVENTS.WORKSPACE_OPEN_FROM_FOLDER, cb);
+
+/** @param {(data: { repoCwd: string }) => void} cb */
+export const onWorkspaceCreateWorktree = (cb) => bus.on(EVENTS.WORKSPACE_CREATE_WORKTREE, cb);
+
+/** @param {(data: { repoCwd: string }) => void} cb */
+export const onWorkspaceOpenPr = (cb) => bus.on(EVENTS.WORKSPACE_OPEN_PR, cb);
+
+/** @param {(data: { path: string, name: string }) => void} cb */
+export const onFileOpen = (cb) => bus.on(EVENTS.FILE_OPEN, cb);

--- a/src/utils/file-viewer-listeners.js
+++ b/src/utils/file-viewer-listeners.js
@@ -3,11 +3,11 @@
  * Extracted from file-viewer.js to reduce component size.
  */
 
-import { subscribeBus, EVENTS } from './events.js';
+import { onFileOpen, onTerminalCwdChanged, onWorkspaceActivated } from './events.js';
 
 /**
  * Subscribe to bus events that drive file-viewer behaviour.
- * Returns the listener handles needed for cleanup via `unsubscribeBus`.
+ * Returns an array of unsubscribe functions for cleanup.
  *
  * @param {{ isActive: () => boolean }} guards
  * @param {{
@@ -17,26 +17,23 @@ import { subscribeBus, EVENTS } from './events.js';
  *   getMode: () => string,
  *   loadPinnedFiles: () => void,
  * }} handlers
- * @returns {Array} listener handles for `unsubscribeBus`
+ * @returns {Array<() => void>} unsubscribe functions
  */
 export function setupFileViewerListeners({ isActive }, handlers) {
-  return subscribeBus([
-    /** @listens file:open {{ path: string, name: string }} */
-    [EVENTS.FILE_OPEN, ({ path, name }) => {
+  return [
+    onFileOpen(({ path, name }) => {
       if (!isActive()) return;
       handlers.switchMode('files');
       handlers.openFile(path, name);
-    }],
-    /** @listens terminal:cwdChanged {{ id: string, cwd: string }} */
-    [EVENTS.TERMINAL_CWD_CHANGED, ({ cwd }) => {
+    }),
+    onTerminalCwdChanged(({ cwd }) => {
       if (!isActive()) return;
       handlers.gitChanges.setCwd(cwd);
       if (handlers.getMode() === 'git') handlers.gitChanges.loadChanges();
-    }],
-    /** @listens workspace:activated {undefined} */
-    [EVENTS.WORKSPACE_ACTIVATED, () => {
+    }),
+    onWorkspaceActivated(() => {
       if (!isActive()) return;
       handlers.loadPinnedFiles();
-    }],
-  ]);
+    }),
+  ];
 }


### PR DESCRIPTION
## Refactoring

Ajout d'APIs de souscription typées dans `events.js` pour rendre les contrats événementiels explicites et découvrables. Chaque helper retourne une fonction d'unsubscribe.

Exemple : `onTerminalCreated(cb)` au lieu de `bus.on(EVENTS.TERMINAL_CREATED, cb)`.

Migration de `file-viewer-listeners.js` comme preuve de concept : n'importe plus `subscribeBus`/`EVENTS`, utilise les helpers typés à la place. Les autres consumers peuvent être migrés incrémentalement.

Closes #238

## Fichier(s) modifié(s)

- `src/utils/events.js` — ajout des 10 helpers typés (`onTerminalCreated`, `onLayoutChanged`, etc.)
- `src/utils/file-viewer-listeners.js` — migration vers les helpers typés
- `src/components/file-viewer.js` — adaptation du cleanup (unsubscribe functions au lieu de `unsubscribeBus`)

## Vérifications

- [x] Build OK
- [x] Tests OK (367 tests, 25 fichiers)

---

📂 Path local : `/Users/rekta/projet/coding/refactor-pikagent`
🤖 PR créée automatiquement par l'Agent Refactor