### PR TITLE
refactor: extract setupTerminalAddons to deduplicate addon initialization

### DIFF
--- a/src/components/board-view.js
+++ b/src/components/board-view.js
@@ -1,8 +1,6 @@
-import { WebLinksAddon } from '@xterm/addon-web-links';
 import { subscribeBus, unsubscribeBus } from '../utils/events.js';
-import { FilePathLinkProvider } from '../utils/file-link-provider.js';
 import { _el, renderButtonBar } from '../utils/dom.js';
-import { _safeFit, createTerminal, disposeTerminal, disposeTerminalMap } from '../utils/terminal-factory.js';
+import { _safeFit, createTerminal, disposeTerminal, disposeTerminalMap, setupTerminalAddons } from '../utils/terminal-factory.js';
 import { registerComponent } from '../utils/component-registry.js';
 import { RendererPollingTimer } from '../utils/polling.js';
 import {
@@ -141,14 +139,12 @@ export class BoardView {
   _createBoardTerminal(termContainer, termId) {
     const { term, fitAddon } = createTerminal(termContainer, BOARD_TERMINAL_OPTS);
 
-    term.loadAddon(new WebLinksAddon((e, url) => {
-      e.preventDefault();
-      window.api.shell.openExternal(url);
-    }));
-    term.registerLinkProvider(new FilePathLinkProvider(term, () => null, {
+    setupTerminalAddons(term, {
+      openExternal: (url) => window.api.shell.openExternal(url),
+      getCwd: () => null,
       homedir: window.api.fs.homedir,
       openPath: window.api.shell.openPath,
-    }));
+    });
     term.onData((data) => window.api.pty.write(termId, data));
 
     return { term, fitAddon };

--- a/src/utils/terminal-factory.js
+++ b/src/utils/terminal-factory.js
@@ -1,6 +1,8 @@
 import { Terminal } from '@xterm/xterm';
 import { FitAddon } from '@xterm/addon-fit';
+import { WebLinksAddon } from '@xterm/addon-web-links';
 import { getTerminalTheme } from './terminal-themes.js';
+import { FilePathLinkProvider } from './file-link-provider.js';
 import { disposeResources } from './disposable.js';
 
 /** Safely call fitAddon.fit(), swallowing errors from detached terminals. */
@@ -72,4 +74,19 @@ export function createReadonlyTerminal(container, opts = {}) {
 export function disposeTerminalMap(map) {
   for (const [, data] of map) disposeTerminal(data);
   map.clear();
+}
+
+/**
+ * Load the WebLinksAddon and register the FilePathLinkProvider on a terminal.
+ * Centralises the addon wiring shared by BoardView and TerminalInstance.
+ *
+ * @param {Terminal} term
+ * @param {{ openExternal: (url: string) => void, getCwd: () => string|null, homedir: () => Promise<string>, openPath: (path: string) => void }} opts
+ */
+export function setupTerminalAddons(term, { openExternal, getCwd, homedir, openPath }) {
+  term.loadAddon(new WebLinksAddon((e, url) => {
+    e.preventDefault();
+    openExternal(url);
+  }));
+  term.registerLinkProvider(new FilePathLinkProvider(term, getCwd, { homedir, openPath }));
 }

--- a/src/utils/terminal-instance.js
+++ b/src/utils/terminal-instance.js
@@ -1,8 +1,6 @@
-import { WebLinksAddon } from '@xterm/addon-web-links';
 import { generateId } from './id.js';
 import { bus, EVENTS } from './events.js';
-import { FilePathLinkProvider } from './file-link-provider.js';
-import { createTerminal } from './terminal-factory.js';
+import { createTerminal, setupTerminalAddons } from './terminal-factory.js';
 import { CWD_POLL_MS } from './terminal-panel-helpers.js';
 import { createGuardedDispose } from './disposable.js';
 
@@ -62,11 +60,12 @@ export class TerminalInstance {
     this.terminal = term;
     this.fitAddon = fitAddon;
 
-    this.terminal.loadAddon(new WebLinksAddon((e, url) => {
-      e.preventDefault();
-      openExternal(url);
-    }));
-    this.terminal.registerLinkProvider(new FilePathLinkProvider(this.terminal, () => this.cwd, { homedir, openPath }));
+    setupTerminalAddons(this.terminal, {
+      openExternal,
+      getCwd: () => this.cwd,
+      homedir,
+      openPath,
+    });
 
     // Let Ctrl+Tab / Shift+Ctrl+Tab bubble up to the shortcut manager
     this.terminal.attachCustomKeyEventHandler((e) => {


### PR DESCRIPTION
## Refactoring

Extracted a `setupTerminalAddons(term, opts)` helper to deduplicate the terminal addon initialization pattern (WebLinksAddon + FilePathLinkProvider) that was duplicated between `board-view.js` and `terminal-instance.js`.

Closes #243

## Fichier(s) modifié(s)

- `src/utils/terminal-factory.js` (added helper)
- `src/components/board-view.js` (use helper)
- `src/utils/terminal-instance.js` (use helper)

## Vérifications

- [x] Build OK
- [x] Tests OK

---

📂 Path local : `/Users/rekta/projet/coding/refactor-pikagent`
🤖 PR créée automatiquement par l'Agent Refactor