### PR TITLE
refactor: split events.js into domain-specific event modules

### DIFF
--- a/src/components/file-tree.js
+++ b/src/components/file-tree.js
@@ -8,7 +8,7 @@ import {
 import { registerComponent } from '../utils/component-registry.js';
 import { buildDirContextItems } from '../utils/file-tree-context-menu.js';
 import { attachContextMenu } from '../utils/context-menu.js';
-import { bus, EVENTS } from '../utils/events.js';
+import { emitWorkspaceCreateWorktree, emitWorkspaceOpenPr } from '../utils/workspace-events.js';
 import { renderDirEntry, renderFileEntry, PARSED_ICONS } from '../utils/file-tree-renderer.js';
 import {
   setupDropZone, handleFileDrop,
@@ -157,8 +157,8 @@ export class FileTree {
     const actionDispatcher = {
       newFile:     () => this.promptNewEntry(cwd, contentEl, 0, expandedDirs, 'file'),
       newFolder:   () => this.promptNewEntry(cwd, contentEl, 0, expandedDirs, 'folder'),
-      newWorktree: () => bus.emit(EVENTS.WORKSPACE_CREATE_WORKTREE, { repoCwd: cwd }),
-      openPr:      () => bus.emit(EVENTS.WORKSPACE_OPEN_PR, { repoCwd: cwd }),
+      newWorktree: () => emitWorkspaceCreateWorktree({ repoCwd: cwd }),
+      openPr:      () => emitWorkspaceOpenPr({ repoCwd: cwd }),
       refresh:     () => this.refreshSection(cwd),
     };
     const actionBtns = HEADER_ACTIONS.map(({ key, title, action }) =>

--- a/src/components/file-viewer-webview.js
+++ b/src/components/file-viewer-webview.js
@@ -6,7 +6,7 @@ import { onClickStopped } from '../utils/event-helpers.js';
 import { _el } from '../utils/dom.js';
 import { setupInlineInput } from '../utils/form-helpers.js';
 import { generateId } from '../utils/id.js';
-import { bus, EVENTS } from '../utils/events.js';
+import { emitLayoutChanged } from '../utils/workspace-events.js';
 import { parseWebviewUrl } from '../utils/editor-helpers.js';
 import { registerComponent, getComponent } from '../utils/component-registry.js';
 
@@ -32,7 +32,7 @@ export class WebviewManager {
     this._createWebviewContainer(wt);
     this._switchMode(wt.id);
     /** @fires layout:changed {undefined} — webview added */
-    bus.emit(EVENTS.LAYOUT_CHANGED);
+    emitLayoutChanged();
   }
 
   removeWebview(webviewId) {
@@ -91,7 +91,7 @@ export class WebviewManager {
       if (currentMode === removedId) this._switchMode('files');
       else this._renderModeBar();
       /** @fires layout:changed {undefined} — webview removed */
-      bus.emit(EVENTS.LAYOUT_CHANGED);
+      emitLayoutChanged();
     });
     btn.appendChild(closeBtn);
     btn.addEventListener('click', () => this._switchMode(wt.id));

--- a/src/components/file-viewer.js
+++ b/src/components/file-viewer.js
@@ -1,5 +1,5 @@
 import { detectLanguage } from '../utils/file-icons.js';
-import { bus, EVENTS } from '../utils/events.js';
+import { emitLayoutChanged } from '../utils/workspace-events.js';
 import { _el } from '../utils/dom.js';
 import { EMPTY_MESSAGE, MODE_CONFIG, ALL_STATIC_ELEMENTS, MODE_ACTIVATE, pinnedFiles } from '../utils/editor-helpers.js';
 import { createEditorDOM, bindEditorEvents, updateLineNumbers, updateHighlight, updateStatusBar, saveFile } from '../utils/file-editor-renderer.js';
@@ -278,7 +278,7 @@ export class FileViewer {
     if (this.mode === removedId) this.switchMode('files');
     else this._renderModeBar();
     /** @fires layout:changed {undefined} — webview removed from file-viewer */
-    bus.emit(EVENTS.LAYOUT_CHANGED);
+    emitLayoutChanged();
   }
 
   getWebviewTabs() {

--- a/src/components/git-changes-view.js
+++ b/src/components/git-changes-view.js
@@ -1,4 +1,4 @@
-import { bus, EVENTS } from '../utils/events.js';
+import { emitFileOpen } from '../utils/workspace-events.js';
 import { _el } from '../utils/dom.js';
 import { onClickStopped } from '../utils/event-helpers.js';
 import { STATUS_LABELS, CHEVRON, CHANGE_SECTIONS, computeTotalChanges, buildFileKey } from '../utils/git-changes-helpers.js';
@@ -75,7 +75,7 @@ export class GitChangesView {
     const openBtn = _el('span', { className: 'git-open-btn', textContent: '→', title: 'Open file' });
     onClickStopped(openBtn, () => {
       /** @fires file:open {{ path: string, name: string }} */
-      bus.emit(EVENTS.FILE_OPEN, { path: `${this.gitCwd}/${file.path}`, name: file.path.split('/').pop() });
+      emitFileOpen({ path: `${this.gitCwd}/${file.path}`, name: file.path.split('/').pop() });
     });
 
     const row = _el('div', { className: 'git-file-item', onClick: () => {

--- a/src/components/terminal-panel.js
+++ b/src/components/terminal-panel.js
@@ -1,4 +1,5 @@
-import { bus, EVENTS } from '../utils/events.js';
+import { emitTerminalRemoved } from '../utils/lifecycle-events.js';
+import { emitLayoutChanged } from '../utils/workspace-events.js';
 import { _el } from '../utils/dom.js';
 import { trackMouse } from '../utils/drag-helpers.js';
 import {
@@ -189,7 +190,7 @@ export class TerminalPanel {
       trackMouse(RESIZE_CURSOR[direction],
         (ev) => doResize(ev, handle, splitEl, direction, () => this.fitAll()),
         /** @fires layout:changed {undefined} — resize complete */
-        () => bus.emit(EVENTS.LAYOUT_CHANGED),
+        () => emitLayoutChanged(),
       );
     });
   }
@@ -211,7 +212,7 @@ export class TerminalPanel {
     node.terminal.dispose();
     this.terminals.delete(termId);
     /** @fires terminal:removed {{ id: string }} */
-    bus.emit(EVENTS.TERMINAL_REMOVED, { id: termId });
+    emitTerminalRemoved({ id: termId });
 
     if (this.terminals.size === 0) {
       this.init();

--- a/src/utils/board-helpers.js
+++ b/src/utils/board-helpers.js
@@ -4,7 +4,7 @@
  */
 
 import { findTabForTerminal } from './tab-lifecycle.js';
-import { EVENTS } from './events.js';
+import { LIFECYCLE_EVENTS } from './lifecycle-events.js';
 export { findTabForTerminal };
 
 // Minimum bytes of meaningful output per poll interval to consider agent "working".
@@ -24,9 +24,9 @@ export const STATUS_CONFIG = {
 /** All card-level CSS classes derived from STATUS_CONFIG — single source of truth for class removal. */
 export const ALL_CARD_CLASSES = Object.values(STATUS_CONFIG).map(c => c.cardClass);
 
-export const EVT_CREATED = EVENTS.TERMINAL_CREATED;
-export const EVT_REMOVED = EVENTS.TERMINAL_REMOVED;
-export const EVT_EXITED = EVENTS.TERMINAL_EXITED;
+export const EVT_CREATED = LIFECYCLE_EVENTS.TERMINAL_CREATED;
+export const EVT_REMOVED = LIFECYCLE_EVENTS.TERMINAL_REMOVED;
+export const EVT_EXITED = LIFECYCLE_EVENTS.TERMINAL_EXITED;
 
 /** Terminal options used by board card mini-terminals. */
 export const BOARD_TERMINAL_OPTS = {

--- a/src/utils/events.js
+++ b/src/utils/events.js
@@ -3,6 +3,15 @@
  *
  * EVENT_CATALOG is the single source of truth for all bus events.
  * Adding a new event requires registering it here first.
+ *
+ * ─── Backward-compatibility re-export layer ───
+ *
+ * Domain-specific event modules now own the typed helpers:
+ * - lifecycle-events.js  — terminal lifecycle (created, removed, exited, cwdChanged)
+ * - workspace-events.js  — layout, workspace, and file events
+ *
+ * This file re-exports everything so that existing `import { … } from './events.js'`
+ * statements continue to work during the transition.
  */
 
 /**
@@ -243,36 +252,31 @@ export function unsubscribeBus(listeners) {
   for (const [event, handler] of listeners) bus.off(event, handler);
 }
 
-// ── Typed subscription helpers ──────────────────────────────────────
-// Narrow, discoverable APIs that make the implicit event contracts explicit.
-// Each returns an unsubscribe function.
+// ── Backward-compatible re-exports from domain modules ──────────────
+// New code should import directly from the domain modules instead.
 
-/** @param {(data: { id: string, cwd: string }) => void} cb */
-export const onTerminalCwdChanged = (cb) => bus.on(EVENTS.TERMINAL_CWD_CHANGED, cb);
+export {
+  onTerminalCwdChanged,
+  onTerminalCreated,
+  onTerminalRemoved,
+  onTerminalExited,
+  emitTerminalCwdChanged,
+  emitTerminalCreated,
+  emitTerminalRemoved,
+  emitTerminalExited,
+} from './lifecycle-events.js';
 
-/** @param {(data: { id: string, cwd: string }) => void} cb */
-export const onTerminalCreated = (cb) => bus.on(EVENTS.TERMINAL_CREATED, cb);
-
-/** @param {(data: { id: string }) => void} cb */
-export const onTerminalRemoved = (cb) => bus.on(EVENTS.TERMINAL_REMOVED, cb);
-
-/** @param {(data: { id: string }) => void} cb */
-export const onTerminalExited = (cb) => bus.on(EVENTS.TERMINAL_EXITED, cb);
-
-/** @param {(data: undefined) => void} cb */
-export const onLayoutChanged = (cb) => bus.on(EVENTS.LAYOUT_CHANGED, cb);
-
-/** @param {(data: undefined) => void} cb */
-export const onWorkspaceActivated = (cb) => bus.on(EVENTS.WORKSPACE_ACTIVATED, cb);
-
-/** @param {(data: { cwd: string }) => void} cb */
-export const onWorkspaceOpenFromFolder = (cb) => bus.on(EVENTS.WORKSPACE_OPEN_FROM_FOLDER, cb);
-
-/** @param {(data: { repoCwd: string }) => void} cb */
-export const onWorkspaceCreateWorktree = (cb) => bus.on(EVENTS.WORKSPACE_CREATE_WORKTREE, cb);
-
-/** @param {(data: { repoCwd: string }) => void} cb */
-export const onWorkspaceOpenPr = (cb) => bus.on(EVENTS.WORKSPACE_OPEN_PR, cb);
-
-/** @param {(data: { path: string, name: string }) => void} cb */
-export const onFileOpen = (cb) => bus.on(EVENTS.FILE_OPEN, cb);
+export {
+  onLayoutChanged,
+  onWorkspaceActivated,
+  onWorkspaceOpenFromFolder,
+  onWorkspaceCreateWorktree,
+  onWorkspaceOpenPr,
+  onFileOpen,
+  emitLayoutChanged,
+  emitWorkspaceActivated,
+  emitWorkspaceOpenFromFolder,
+  emitWorkspaceCreateWorktree,
+  emitWorkspaceOpenPr,
+  emitFileOpen,
+} from './workspace-events.js';

--- a/src/utils/file-tree-context-menu.js
+++ b/src/utils/file-tree-context-menu.js
@@ -2,7 +2,7 @@
  * Context menu builders for the file tree.
  * Extracted from FileTree to reduce component size.
  */
-import { bus, EVENTS } from './events.js';
+import { emitWorkspaceOpenFromFolder, emitWorkspaceCreateWorktree } from './workspace-events.js';
 import { getRelativePath, getBaseName } from './file-tree-helpers.js';
 
 /**
@@ -71,11 +71,11 @@ export function buildDirContextItems(dirPath, rootCwd, contentEl, depth, expande
     { separator: true },
     { label: 'Open as Workspace', action: () => {
       /** @fires workspace:openFromFolder {{ cwd: string }} */
-      bus.emit(EVENTS.WORKSPACE_OPEN_FROM_FOLDER, { cwd: dirPath });
+      emitWorkspaceOpenFromFolder({ cwd: dirPath });
     } },
     { label: 'New Worktree…', action: () => {
       /** @fires workspace:createWorktree {{ repoCwd: string }} */
-      bus.emit(EVENTS.WORKSPACE_CREATE_WORKTREE, { repoCwd: dirPath });
+      emitWorkspaceCreateWorktree({ repoCwd: dirPath });
     } },
     { separator: true },
     ...buildCommonContextItems(dirPath, nameEl, rootCwd, promptRenameFn, `Delete folder "${dirName}" and all its contents?`, api),

--- a/src/utils/file-tree-drop.js
+++ b/src/utils/file-tree-drop.js
@@ -3,7 +3,7 @@
  * Extracted from file-tree.js to reduce component size.
  */
 
-import { bus, EVENTS } from './events.js';
+import { emitFileOpen } from './workspace-events.js';
 import { _el } from './dom.js';
 import { setupInlineInput, startInlineRename } from './form-helpers.js';
 import { setupDropZone as _setupDropZone } from './drop-zone-helpers.js';
@@ -114,7 +114,7 @@ export function promptNewEntry(dirPath, parentContentEl, depth, expandedDirs, ty
       } else {
         await writefile(newPath, '');
         /** @fires file:open {{ path: string, name: string }} — newly created file */
-        bus.emit(EVENTS.FILE_OPEN, { path: newPath, name });
+        emitFileOpen({ path: newPath, name });
       }
     },
   });

--- a/src/utils/file-tree-renderer.js
+++ b/src/utils/file-tree-renderer.js
@@ -3,7 +3,7 @@
  * Extracted from file-tree.js to reduce component size.
  */
 
-import { bus, EVENTS } from './events.js';
+import { emitFileOpen } from './workspace-events.js';
 import { _el, buildChevronRow } from './dom.js';
 import { computeIndent, CHEVRON_EXPANDED, CHEVRON_COLLAPSED, SVG_ICONS } from './file-tree-helpers.js';
 import { buildFileContextItems, buildDirContextItems } from './file-tree-context-menu.js';
@@ -108,7 +108,7 @@ export function renderFileEntry(entry, parentEl, depth, callbacks) {
     row.classList.add('active');
     activeRowRef.current = row;
     /** @fires file:open {{ path: string, name: string }} */
-    bus.emit(EVENTS.FILE_OPEN, { path: entry.path, name: entry.name });
+    emitFileOpen({ path: entry.path, name: entry.name });
   });
 
   attachContextMenu(row, () => buildFileContextItems(

--- a/src/utils/file-viewer-listeners.js
+++ b/src/utils/file-viewer-listeners.js
@@ -3,7 +3,8 @@
  * Extracted from file-viewer.js to reduce component size.
  */
 
-import { onFileOpen, onTerminalCwdChanged, onWorkspaceActivated } from './events.js';
+import { onTerminalCwdChanged } from './lifecycle-events.js';
+import { onFileOpen, onWorkspaceActivated } from './workspace-events.js';
 
 /**
  * Subscribe to bus events that drive file-viewer behaviour.

--- a/src/utils/lifecycle-events.js
+++ b/src/utils/lifecycle-events.js
@@ -1,0 +1,51 @@
+/**
+ * Terminal lifecycle events — domain-specific event module.
+ *
+ * Covers terminal creation, removal, exit, and cwd changes.
+ * Each event exposes a typed subscription function (onXxx) and a typed
+ * emit function (emitXxx) so that the event contract is explicit and
+ * discoverable without reaching for the raw bus.
+ *
+ * @module lifecycle-events
+ * @see events.js (thin re-export layer for backward compatibility)
+ */
+
+import { bus } from './events.js';
+
+// ── Event name constants ────────────────────────────────────────────
+
+export const LIFECYCLE_EVENTS = {
+  TERMINAL_CWD_CHANGED: 'terminal:cwdChanged',
+  TERMINAL_CREATED: 'terminal:created',
+  TERMINAL_REMOVED: 'terminal:removed',
+  TERMINAL_EXITED: 'terminal:exited',
+};
+
+// ── Typed subscription helpers ──────────────────────────────────────
+// Each returns an unsubscribe function.
+
+/** @param {(data: { id: string, cwd: string }) => void} cb */
+export const onTerminalCwdChanged = (cb) => bus.on(LIFECYCLE_EVENTS.TERMINAL_CWD_CHANGED, cb);
+
+/** @param {(data: { id: string, cwd: string }) => void} cb */
+export const onTerminalCreated = (cb) => bus.on(LIFECYCLE_EVENTS.TERMINAL_CREATED, cb);
+
+/** @param {(data: { id: string }) => void} cb */
+export const onTerminalRemoved = (cb) => bus.on(LIFECYCLE_EVENTS.TERMINAL_REMOVED, cb);
+
+/** @param {(data: { id: string }) => void} cb */
+export const onTerminalExited = (cb) => bus.on(LIFECYCLE_EVENTS.TERMINAL_EXITED, cb);
+
+// ── Typed emit helpers ──────────────────────────────────────────────
+
+/** @param {{ id: string, cwd: string }} data */
+export const emitTerminalCwdChanged = (data) => bus.emit(LIFECYCLE_EVENTS.TERMINAL_CWD_CHANGED, data);
+
+/** @param {{ id: string, cwd: string }} data */
+export const emitTerminalCreated = (data) => bus.emit(LIFECYCLE_EVENTS.TERMINAL_CREATED, data);
+
+/** @param {{ id: string }} data */
+export const emitTerminalRemoved = (data) => bus.emit(LIFECYCLE_EVENTS.TERMINAL_REMOVED, data);
+
+/** @param {{ id: string }} data */
+export const emitTerminalExited = (data) => bus.emit(LIFECYCLE_EVENTS.TERMINAL_EXITED, data);

--- a/src/utils/tab-lifecycle.js
+++ b/src/utils/tab-lifecycle.js
@@ -18,7 +18,7 @@
 import { generateId } from './id.js';
 import { _el } from './dom.js';
 import { showConfirmDialog } from './dom-dialogs.js';
-import { bus, EVENTS } from './events.js';
+import { emitWorkspaceActivated } from './workspace-events.js';
 import { WorkspaceTab } from './tab-manager-helpers.js';
 import { reattachLayout, syncFileTree } from './workspace-layout.js';
 import { capturePanelWidths } from './workspace-resize.js';
@@ -117,7 +117,7 @@ function _activateTab(deps, tab) {
     reattachLayout({ workspaceContainer: deps.workspaceContainer }, tab);
     syncFileTree(tab);
     /** @emits workspace:activated {undefined} — tab switched */
-    bus.emit(EVENTS.WORKSPACE_ACTIVATED);
+    emitWorkspaceActivated();
   } else {
     // First time rendering this tab
     deps.renderWorkspace(tab);

--- a/src/utils/tab-manager-init.js
+++ b/src/utils/tab-manager-init.js
@@ -6,7 +6,9 @@
  * it can import from fewer modules (issue #130).
  */
 
-import { subscribeBus, EVENTS } from './events.js';
+import { subscribeBus } from './events.js';
+import { LIFECYCLE_EVENTS } from './lifecycle-events.js';
+import { WORKSPACE_EVENTS } from './workspace-events.js';
 import { extractFolderName } from './file-tree-helpers.js';
 import { findTabForTerminal, onTerminalCwdChanged } from './tab-lifecycle.js';
 import { createWorktreeFlow } from './worktree-flow.js';
@@ -73,7 +75,7 @@ export async function initTabManager(deps) {
 export function setupBusListeners(deps) {
   return subscribeBus([
     /** @listens terminal:cwdChanged {{ id: string, cwd: string }} */
-    [EVENTS.TERMINAL_CWD_CHANGED, ({ id, cwd }) => {
+    [LIFECYCLE_EVENTS.TERMINAL_CWD_CHANGED, ({ id, cwd }) => {
       onTerminalCwdChanged(deps.tabs, deps.getActiveTabId(), id, cwd, {
         gitBranch: deps.api.gitBranch,
         renderTabBar: deps.renderTabBar,
@@ -81,27 +83,27 @@ export function setupBusListeners(deps) {
       deps.configManager.scheduleAutoSave();
     }],
     /** @listens terminal:created {{ id: string, cwd: string }} */
-    [EVENTS.TERMINAL_CREATED, ({ id, cwd }) => {
+    [LIFECYCLE_EVENTS.TERMINAL_CREATED, ({ id, cwd }) => {
       const tab = findTabForTerminal(deps.tabs, id)?.tab ?? deps.tabs.get(deps.getActiveTabId());
       if (tab?.fileTree) tab.fileTree.setTerminalRoot(id, cwd);
       deps.configManager.scheduleAutoSave();
     }],
     /** @listens terminal:removed {{ id: string }} */
-    [EVENTS.TERMINAL_REMOVED, ({ id }) => {
+    [LIFECYCLE_EVENTS.TERMINAL_REMOVED, ({ id }) => {
       for (const [, tab] of deps.tabs) {
         if (tab.fileTree) tab.fileTree.removeTerminal(id);
       }
       deps.configManager.scheduleAutoSave();
     }],
     /** @listens layout:changed {undefined} */
-    [EVENTS.LAYOUT_CHANGED, () => deps.configManager.scheduleAutoSave()],
+    [WORKSPACE_EVENTS.LAYOUT_CHANGED, () => deps.configManager.scheduleAutoSave()],
     /** @listens workspace:openFromFolder {{ cwd: string }} */
-    [EVENTS.WORKSPACE_OPEN_FROM_FOLDER, ({ cwd }) => {
+    [WORKSPACE_EVENTS.WORKSPACE_OPEN_FROM_FOLDER, ({ cwd }) => {
       const folderName = extractFolderName(cwd);
       deps.createTab(folderName, cwd);
     }],
     /** @listens workspace:createWorktree {{ repoCwd: string }} */
-    [EVENTS.WORKSPACE_CREATE_WORKTREE, ({ repoCwd }) => {
+    [WORKSPACE_EVENTS.WORKSPACE_CREATE_WORKTREE, ({ repoCwd }) => {
       createWorktreeFlow({
         repoCwd,
         api: deps.api.worktree,
@@ -109,7 +111,7 @@ export function setupBusListeners(deps) {
       }).catch((e) => console.warn('createWorktreeFlow failed:', e));
     }],
     /** @listens workspace:openPr {{ repoCwd: string }} */
-    [EVENTS.WORKSPACE_OPEN_PR, ({ repoCwd }) => {
+    [WORKSPACE_EVENTS.WORKSPACE_OPEN_PR, ({ repoCwd }) => {
       const tab = _findTabByCwd(deps.tabs, repoCwd);
       const baseBranch = tab?.worktree?.baseBranch ?? null;
       openPrFlow({ cwd: repoCwd, baseBranch, api: deps.api.pr })

--- a/src/utils/terminal-instance.js
+++ b/src/utils/terminal-instance.js
@@ -1,6 +1,6 @@
 import { WebLinksAddon } from '@xterm/addon-web-links';
 import { generateId } from './id.js';
-import { bus, EVENTS } from './events.js';
+import { emitTerminalExited, emitTerminalCwdChanged } from './lifecycle-events.js';
 import { FilePathLinkProvider } from './file-link-provider.js';
 import { createTerminal } from './terminal-factory.js';
 import { CWD_POLL_MS } from './terminal-panel-helpers.js';
@@ -91,7 +91,7 @@ export class TerminalInstance {
 
     this.unsubExit = this._api.ptyOnExit(this.id, () => {
       /** @fires terminal:exited {{ id: string }} — PTY process exited */
-      bus.emit(EVENTS.TERMINAL_EXITED, { id: this.id });
+      emitTerminalExited({ id: this.id });
     });
   }
 
@@ -107,7 +107,7 @@ export class TerminalInstance {
       if (cwd && cwd !== this.cwd) {
         this.cwd = cwd;
         /** @fires terminal:cwdChanged {{ id: string, cwd: string }} — cwd changed */
-        bus.emit(EVENTS.TERMINAL_CWD_CHANGED, { id: this.id, cwd });
+        emitTerminalCwdChanged({ id: this.id, cwd });
       }
     }, CWD_POLL_MS);
   }

--- a/src/utils/terminal-node-builder.js
+++ b/src/utils/terminal-node-builder.js
@@ -3,7 +3,7 @@
  * Extracted from terminal-panel.js to reduce component size.
  */
 
-import { bus, EVENTS } from './events.js';
+import { emitTerminalCreated } from './lifecycle-events.js';
 import { _el } from './dom.js';
 import { onClickStopped } from './event-helpers.js';
 import { SplitNode, DRAG_GRIP, createSplitContainer } from './terminal-panel-helpers.js';
@@ -61,7 +61,7 @@ export function createTerminalNode(cwd, defaultCwd, terminals, { buildTopBar: bu
   terminals.set(node.terminal.id, node);
 
   /** @fires terminal:created {{ id: string, cwd: string }} */
-  bus.emit(EVENTS.TERMINAL_CREATED, { id: node.terminal.id, cwd: spawnCwd });
+  emitTerminalCreated({ id: node.terminal.id, cwd: spawnCwd });
 
   wrapper.addEventListener('mousedown', () => onMousedown(node));
 

--- a/src/utils/terminal-split.js
+++ b/src/utils/terminal-split.js
@@ -3,7 +3,7 @@
  * Extracted from terminal-panel.js to reduce component size.
  */
 
-import { bus, EVENTS } from './events.js';
+import { emitLayoutChanged } from './workspace-events.js';
 import { SplitNode, isSameDirectionSplit, createSplitContainer, equalizeChildren } from './terminal-panel-helpers.js';
 import { directionFromSide, isInsertBefore, findClosestInDirection } from './split-primitives.js';
 import { detachElement, moveToCenter, insertIntoSplit, wrapInNewSplit } from './split-layout.js';
@@ -49,7 +49,7 @@ export function moveTerminal(sourceId, targetId, side, terminals, { createSplitH
   fitAll();
   setActive(sourceNode);
   /** @fires layout:changed {undefined} — split operation complete */
-  bus.emit(EVENTS.LAYOUT_CHANGED);
+  emitLayoutChanged();
 }
 
 /**

--- a/src/utils/workspace-events.js
+++ b/src/utils/workspace-events.js
@@ -1,0 +1,66 @@
+/**
+ * Workspace and layout events — domain-specific event module.
+ *
+ * Covers layout changes, workspace activation, folder opening,
+ * worktree creation, PR opening, and file opening.
+ * Each event exposes a typed subscription function (onXxx) and a typed
+ * emit function (emitXxx) so that the event contract is explicit and
+ * discoverable without reaching for the raw bus.
+ *
+ * @module workspace-events
+ * @see events.js (thin re-export layer for backward compatibility)
+ */
+
+import { bus } from './events.js';
+
+// ── Event name constants ────────────────────────────────────────────
+
+export const WORKSPACE_EVENTS = {
+  LAYOUT_CHANGED: 'layout:changed',
+  WORKSPACE_ACTIVATED: 'workspace:activated',
+  WORKSPACE_OPEN_FROM_FOLDER: 'workspace:openFromFolder',
+  WORKSPACE_CREATE_WORKTREE: 'workspace:createWorktree',
+  WORKSPACE_OPEN_PR: 'workspace:openPr',
+  FILE_OPEN: 'file:open',
+};
+
+// ── Typed subscription helpers ──────────────────────────────────────
+// Each returns an unsubscribe function.
+
+/** @param {(data: undefined) => void} cb */
+export const onLayoutChanged = (cb) => bus.on(WORKSPACE_EVENTS.LAYOUT_CHANGED, cb);
+
+/** @param {(data: undefined) => void} cb */
+export const onWorkspaceActivated = (cb) => bus.on(WORKSPACE_EVENTS.WORKSPACE_ACTIVATED, cb);
+
+/** @param {(data: { cwd: string }) => void} cb */
+export const onWorkspaceOpenFromFolder = (cb) => bus.on(WORKSPACE_EVENTS.WORKSPACE_OPEN_FROM_FOLDER, cb);
+
+/** @param {(data: { repoCwd: string }) => void} cb */
+export const onWorkspaceCreateWorktree = (cb) => bus.on(WORKSPACE_EVENTS.WORKSPACE_CREATE_WORKTREE, cb);
+
+/** @param {(data: { repoCwd: string }) => void} cb */
+export const onWorkspaceOpenPr = (cb) => bus.on(WORKSPACE_EVENTS.WORKSPACE_OPEN_PR, cb);
+
+/** @param {(data: { path: string, name: string }) => void} cb */
+export const onFileOpen = (cb) => bus.on(WORKSPACE_EVENTS.FILE_OPEN, cb);
+
+// ── Typed emit helpers ──────────────────────────────────────────────
+
+/** @param {undefined} [data] */
+export const emitLayoutChanged = (data) => bus.emit(WORKSPACE_EVENTS.LAYOUT_CHANGED, data);
+
+/** @param {undefined} [data] */
+export const emitWorkspaceActivated = (data) => bus.emit(WORKSPACE_EVENTS.WORKSPACE_ACTIVATED, data);
+
+/** @param {{ cwd: string }} data */
+export const emitWorkspaceOpenFromFolder = (data) => bus.emit(WORKSPACE_EVENTS.WORKSPACE_OPEN_FROM_FOLDER, data);
+
+/** @param {{ repoCwd: string }} data */
+export const emitWorkspaceCreateWorktree = (data) => bus.emit(WORKSPACE_EVENTS.WORKSPACE_CREATE_WORKTREE, data);
+
+/** @param {{ repoCwd: string }} data */
+export const emitWorkspaceOpenPr = (data) => bus.emit(WORKSPACE_EVENTS.WORKSPACE_OPEN_PR, data);
+
+/** @param {{ path: string, name: string }} data */
+export const emitFileOpen = (data) => bus.emit(WORKSPACE_EVENTS.FILE_OPEN, data);

--- a/src/utils/workspace-layout.js
+++ b/src/utils/workspace-layout.js
@@ -11,7 +11,7 @@
  */
 
 import { getComponent } from './component-registry.js';
-import { bus, EVENTS } from './events.js';
+import { emitWorkspaceActivated } from './workspace-events.js';
 import { _el } from './dom.js';
 import { WORKSPACE_PANELS } from './tab-manager-helpers.js';
 import {
@@ -91,7 +91,7 @@ export async function renderWorkspace({ workspaceContainer, getActiveTabId, getA
   if (branch) tab.branchBadgeEl.textContent = ` ${branch}`;
 
   /** @fires workspace:activated {undefined} — initial workspace render complete */
-  bus.emit(EVENTS.WORKSPACE_ACTIVATED);
+  emitWorkspaceActivated();
 }
 
 // ── Layout helpers ──


### PR DESCRIPTION
## Summary

- Split the monolithic `events.js` hub (15+ importers) into domain-specific event modules with narrow subscription/emit APIs
- Created `lifecycle-events.js` for terminal lifecycle events (created, removed, exited, cwdChanged) and `workspace-events.js` for layout, workspace, and file events
- Retained `events.js` as a thin re-export layer for backward compatibility

Each module exports typed functions (e.g., `onTerminalCreated(cb)`, `emitTerminalCreated(data)`) instead of raw `bus.on()`/`bus.emit()` calls, making the event contracts explicit and discoverable.

Updated all 15+ importing modules to use the domain-specific imports.

Closes #238

## Fichier(s) modifie(s)

- `src/utils/events.js` (slimmed down to re-export layer)
- `src/utils/lifecycle-events.js` (new)
- `src/utils/workspace-events.js` (new)
- `src/components/terminal-panel.js`
- `src/components/file-viewer.js`
- `src/components/file-viewer-webview.js`
- `src/components/file-tree.js`
- `src/components/git-changes-view.js`
- `src/utils/terminal-instance.js`
- `src/utils/terminal-node-builder.js`
- `src/utils/terminal-split.js`
- `src/utils/board-helpers.js`
- `src/utils/file-tree-context-menu.js`
- `src/utils/file-tree-drop.js`
- `src/utils/file-tree-renderer.js`
- `src/utils/file-viewer-listeners.js`
- `src/utils/tab-lifecycle.js`
- `src/utils/tab-manager-init.js`
- `src/utils/workspace-layout.js`

## Test plan

- [x] Build OK (`npm run build`)
- [x] Tests OK (`npm test` — 25 files, 369 tests passing)
- [ ] Manual: verify terminal creation/removal updates board view and file tree
- [ ] Manual: verify layout changes (split, resize, webview add/remove) trigger auto-save
- [ ] Manual: verify file open from tree, drop, and git changes view works
- [ ] Manual: verify workspace open from folder and worktree creation work

---

🤖 PR created automatically by the Agent Refactor