### PR TITLE
refactor: replace loose JSDoc types with precise annotations

### DIFF
--- a/main/usage-helpers.js
+++ b/main/usage-helpers.js
@@ -172,9 +172,9 @@ function getFlowRunDuration(run) {
  * Shared metrics builder — computes rate, duration, and perDay from a list of
  * items and merges any extra fields supplied by the caller.
  *
- * @param {Array} items - The items to compute base metrics for
- * @param {{ durationMapper: (item: any) => number|null,
- *           dateExtractor: (item: any) => string,
+ * @param {Array<{ status?: string, [key: string]: unknown }>} items - The items to compute base metrics for
+ * @param {{ durationMapper: (item: { status?: string, [key: string]: unknown }) => number|null,
+ *           dateExtractor: (item: { status?: string, [key: string]: unknown }) => string,
  *           extra?: Record<string, unknown> }} opts
  * @returns {Record<string, unknown>}
  */

--- a/src/utils/file-viewer-mode-bar.js
+++ b/src/utils/file-viewer-mode-bar.js
@@ -12,7 +12,7 @@ import { STATIC_MODES } from './editor-helpers.js';
  * @param {HTMLElement} modeBar - the mode bar container element
  * @param {string} currentMode - the currently active mode key
  * @param {{ switchMode: (mode: string) => void }} callbacks
- * @param {{ webviewTabs: Array, buildWebviewModeBtn: Function, buildAddWebviewBtn: Function }} webviewMgr
+ * @param {{ webviewTabs: Array<{ id: string, label: string, url: string }>, buildWebviewModeBtn: (wt: { id: string, label: string, url: string }, currentMode: string) => HTMLElement, buildAddWebviewBtn: (modeBar: HTMLElement) => HTMLElement }} webviewMgr
  */
 export function renderModeBar(modeBar, currentMode, { switchMode }, webviewMgr) {
   modeBar.replaceChildren();

--- a/src/utils/tab-manager-api.js
+++ b/src/utils/tab-manager-api.js
@@ -10,8 +10,8 @@
  */
 
 /**
- * @typedef {{ branch: Function, remoteUrl: Function, pushBranch: Function, ghAvailable: Function, ghPrCreate: Function }} GitApi
- * @typedef {{ openExternal: Function }} ShellApi
+ * @typedef {{ branch: (cwd: string) => Promise<string|null>, remoteUrl: (cwd: string) => Promise<string|null>, pushBranch: (cwd: string, branch: string) => Promise<{ ok: boolean, error?: string }>, ghAvailable: () => Promise<boolean>, ghPrCreate: (cwd: string, baseBranch: string|null) => Promise<{ ok: boolean, url?: string, existed?: boolean, code?: string, error?: string }> }} GitApi
+ * @typedef {{ openExternal: (url: string) => void | Promise<unknown> }} ShellApi
  */
 
 /**
@@ -31,7 +31,7 @@ export function buildPrApi(api) {
 }
 
 /**
- * @typedef {{ isRepo: Function, branch: Function, listBranches: Function, worktreeList: Function, worktreeAdd: Function, worktreeRemove: Function }} GitWorktreeIpc
+ * @typedef {{ isRepo: (cwd: string) => Promise<boolean>, branch: (cwd: string) => Promise<string|null>, listBranches: (cwd: string) => Promise<string[]>, worktreeList: (cwd: string) => Promise<Array<{ path: string, branch: string|null }>>, worktreeAdd: (cwd: string, branch: string, targetPath: string, createBranch: boolean, baseBranch: string|null) => Promise<{ ok: boolean, error?: string }>, worktreeRemove: (cwd: string, worktreePath: string, force: boolean) => Promise<{ ok: boolean, error?: string }> }} GitWorktreeIpc
  */
 
 /**
@@ -55,7 +55,7 @@ export function buildWorktreeApi(api) {
 
 /**
  * Build a view store adapter for sidebar-manager.
- * @param {object} self — the TabManager instance (or any object holding side-view properties)
+ * @param {{ [key: string]: unknown }} self — the TabManager instance (or any object holding side-view properties)
  * @returns {import('./sidebar-manager.js').SideViewStore}
  */
 export function buildViewStore(self) {


### PR DESCRIPTION
## Refactoring

Remplace les types JSDoc lâches (`any`, `Function`, `Array`, `object`) par des types précis dans 3 fichiers.

Closes #248

## Fichier(s) modifié(s)

- `main/usage-helpers.js`
- `src/utils/tab-manager-api.js`
- `src/utils/file-viewer-mode-bar.js`

## Vérifications

- [x] Build OK
- [x] Tests OK

---

📂 Path local : `/Users/rekta/projet/coding/refactor-pikagent`
🤖 PR créée automatiquement par l'Agent Refactor