### PR TITLE
refactor: deduplicate chevron row rendering pattern

### DIFF
--- a/src/utils/dom.js
+++ b/src/utils/dom.js
@@ -113,12 +113,31 @@ export function renderButtonBar({ containerClass, configs, handlers }) {
  * Used by file-tree rows and flow-category headers — any place that needs
  * the common "chevron + label" pattern.
  *
- * @param {{ chevronClass: string, nameClass: string, name: string, chevronText?: string }} opts
- * @returns {{ chevron: HTMLElement, name: HTMLElement }}
+ * When `containerClass` is provided, a wrapper `<div>` is returned as `row`.
+ * An optional `depth` + `computeIndent` pair applies padding-left for
+ * tree-style indentation.
+ *
+ * @param {{ chevronClass: string, nameClass: string, name: string,
+ *           chevronText?: string, containerClass?: string,
+ *           depth?: number, computeIndent?: (depth: number) => number,
+ *           extraChildren?: HTMLElement[] }} opts
+ * @returns {{ chevron: HTMLElement, name: HTMLElement, row?: HTMLElement }}
  */
 export function buildChevronRow(opts) {
   const chevron = _el('span', { className: opts.chevronClass, textContent: opts.chevronText || '' });
   const name = _el('span', { className: opts.nameClass, textContent: opts.name });
+
+  if (opts.containerClass) {
+    const style = (opts.depth != null && opts.computeIndent)
+      ? { paddingLeft: `${opts.computeIndent(opts.depth)}px` }
+      : undefined;
+    const row = _el('div', {
+      className: opts.containerClass,
+      ...(style && { style }),
+    }, chevron, name, ...(opts.extraChildren || []));
+    return { chevron, name, row };
+  }
+
   return { chevron, name };
 }
 

--- a/src/utils/file-tree-renderer.js
+++ b/src/utils/file-tree-renderer.js
@@ -29,16 +29,14 @@ export const PARSED_ICONS = Object.fromEntries(
  * @returns {{ row: HTMLElement, chevron: HTMLElement, name: HTMLElement }}
  */
 function buildRow(entry, depth) {
-  const { chevron, name } = buildChevronRow({
+  return buildChevronRow({
     chevronClass: 'file-tree-chevron',
     nameClass: 'file-tree-name',
     name: entry.name,
+    containerClass: 'file-tree-item',
+    depth,
+    computeIndent,
   });
-  const row = _el('div', {
-    className: 'file-tree-item',
-    style: { paddingLeft: `${computeIndent(depth)}px` },
-  }, chevron, name);
-  return { row, chevron, name };
 }
 
 /**

--- a/src/utils/flow-category-renderer.js
+++ b/src/utils/flow-category-renderer.js
@@ -46,16 +46,15 @@ export function createCategoryGroup(params) {
 }
 
 function _buildCategoryHeader(cat, flows, isUncategorized, collapsedCategories, onToggleCollapse, onRenameCategory, onDeleteCategory) {
-  const header = _el('div', 'flow-category-header');
-
-  const { chevron, name } = buildChevronRow({
+  const count = _el('span', 'flow-category-count', `${flows.length}`);
+  const { chevron, name, row: header } = buildChevronRow({
     chevronClass: 'flow-category-chevron',
     nameClass: 'flow-category-name',
     name: cat.name,
     chevronText: '▼',
+    containerClass: 'flow-category-header',
+    extraChildren: [count],
   });
-  const count = _el('span', 'flow-category-count', `${flows.length}`);
-  header.append(chevron, name, count);
 
   if (!isUncategorized) {
     const catHandlers = {


### PR DESCRIPTION
## Refactoring

Étend `buildChevronRow()` dans `dom.js` pour supporter les variations de style et d'indentation, puis migre les 2 renderers vers ce helper partagé.

Closes #251

## Fichier(s) modifié(s)

- `src/utils/dom.js` — `buildChevronRow()` étendu avec `containerClass`, `depth`/`computeIndent`, `extraChildren`
- `src/utils/file-tree-renderer.js` — utilise buildChevronRow avec container + indentation
- `src/utils/flow-category-renderer.js` — utilise buildChevronRow avec container + extraChildren

## Vérifications

- [x] Build OK
- [x] Tests OK (367 tests, 25 suites)

---

🤖 PR créée automatiquement par l'Agent Refactor

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>