### PR TITLE
refactor: remove 20 unused exports across 11 files

### DIFF
--- a/src/components/settings-appearance.js
+++ b/src/components/settings-appearance.js
@@ -14,7 +14,7 @@ import { createAsyncHandler } from '../utils/event-helpers.js';
  * Apply the current terminal theme to all terminal panels across tabs.
  * @param {import('../components/tab-manager.js').TabManager|null} tabManager
  */
-export function applyThemeToTerminals(tabManager) {
+function applyThemeToTerminals(tabManager) {
   if (!tabManager) return;
   const theme = getTerminalTheme();
   for (const [, tab] of tabManager.tabs) {

--- a/src/components/settings-keybindings.js
+++ b/src/components/settings-keybindings.js
@@ -17,7 +17,7 @@ import { registerComponent } from '../utils/component-registry.js';
  * @param {() => void} renderKeybindingsFn - callback to re-render
  * @returns {HTMLElement}
  */
-export function createKeyBadge(binding, index, shortcutManager, startRecordingFn, renderKeybindingsFn) {
+function createKeyBadge(binding, index, shortcutManager, startRecordingFn, renderKeybindingsFn) {
   const wrapper = _el('div', 'keybinding-badge-wrapper');
 
   const badge = _el('span', 'keybinding-badge');

--- a/src/utils/context-menu.js
+++ b/src/utils/context-menu.js
@@ -22,7 +22,7 @@ function positionInViewport(x, y, width, height, padding = 8) {
   };
 }
 
-export class ContextMenu {
+class ContextMenu {
   constructor() {
     this.el = _el('div', { className: 'context-menu' });
     document.body.appendChild(this.el);

--- a/src/utils/drag-helpers.js
+++ b/src/utils/drag-helpers.js
@@ -6,13 +6,13 @@
  */
 
 /** Set cursor and disable text selection on document.body during a drag. */
-export function setDragBodyState(cursor) {
+function setDragBodyState(cursor) {
   document.body.style.cursor = cursor;
   document.body.style.userSelect = 'none';
 }
 
 /** Clear cursor and re-enable text selection on document.body after a drag. */
-export function clearDragBodyState() {
+function clearDragBodyState() {
   document.body.style.cursor = '';
   document.body.style.userSelect = '';
 }

--- a/src/utils/events.js
+++ b/src/utils/events.js
@@ -250,29 +250,8 @@ export function unsubscribeBus(listeners) {
 /** @param {(data: { id: string, cwd: string }) => void} cb */
 export const onTerminalCwdChanged = (cb) => bus.on(EVENTS.TERMINAL_CWD_CHANGED, cb);
 
-/** @param {(data: { id: string, cwd: string }) => void} cb */
-export const onTerminalCreated = (cb) => bus.on(EVENTS.TERMINAL_CREATED, cb);
-
-/** @param {(data: { id: string }) => void} cb */
-export const onTerminalRemoved = (cb) => bus.on(EVENTS.TERMINAL_REMOVED, cb);
-
-/** @param {(data: { id: string }) => void} cb */
-export const onTerminalExited = (cb) => bus.on(EVENTS.TERMINAL_EXITED, cb);
-
-/** @param {(data: undefined) => void} cb */
-export const onLayoutChanged = (cb) => bus.on(EVENTS.LAYOUT_CHANGED, cb);
-
 /** @param {(data: undefined) => void} cb */
 export const onWorkspaceActivated = (cb) => bus.on(EVENTS.WORKSPACE_ACTIVATED, cb);
-
-/** @param {(data: { cwd: string }) => void} cb */
-export const onWorkspaceOpenFromFolder = (cb) => bus.on(EVENTS.WORKSPACE_OPEN_FROM_FOLDER, cb);
-
-/** @param {(data: { repoCwd: string }) => void} cb */
-export const onWorkspaceCreateWorktree = (cb) => bus.on(EVENTS.WORKSPACE_CREATE_WORKTREE, cb);
-
-/** @param {(data: { repoCwd: string }) => void} cb */
-export const onWorkspaceOpenPr = (cb) => bus.on(EVENTS.WORKSPACE_OPEN_PR, cb);
 
 /** @param {(data: { path: string, name: string }) => void} cb */
 export const onFileOpen = (cb) => bus.on(EVENTS.FILE_OPEN, cb);

--- a/src/utils/file-tree-renderer.js
+++ b/src/utils/file-tree-renderer.js
@@ -28,7 +28,7 @@ export const PARSED_ICONS = Object.fromEntries(
  * @param {number} depth
  * @returns {{ row: HTMLElement, chevron: HTMLElement, name: HTMLElement }}
  */
-export function buildRow(entry, depth) {
+function buildRow(entry, depth) {
   const { chevron, name } = buildChevronRow({
     chevronClass: 'file-tree-chevron',
     nameClass: 'file-tree-name',

--- a/src/utils/file-viewer-tabs.js
+++ b/src/utils/file-viewer-tabs.js
@@ -18,7 +18,7 @@ import { createTabElement } from './tab-renderer.js';
  * @param {{ onClose: (filePath: string) => void, onActivate: (filePath: string) => void, onTogglePin: (filePath: string) => void }} callbacks
  * @returns {HTMLElement}
  */
-export function createTabEl(filePath, file, activeFile, isPinned, isModified, callbacks) {
+function createTabEl(filePath, file, activeFile, isPinned, isModified, callbacks) {
   const { onClose, onActivate, onTogglePin, isMarkdown, getViewMode, onToggleViewMode } = callbacks;
   const pinned = isPinned(filePath);
   const modified = isModified(filePath);

--- a/src/utils/flow-card-setup.js
+++ b/src/utils/flow-card-setup.js
@@ -51,7 +51,7 @@ export function setupCardDrag(card, flowId, catId, dragState) {
  * @param {Record<string, string>} runningMap - { [flowId]: ptyId }
  * @returns {HTMLElement|null}
  */
-export function buildCardBody(flow, isRunning, isExpanded, termManager, runningMap) {
+function buildCardBody(flow, isRunning, isExpanded, termManager, runningMap) {
   if (isRunning) {
     const container = termManager.createLiveTerminal(flow.id, runningMap[flow.id]);
     container.style.display = isExpanded ? '' : 'none';
@@ -77,7 +77,7 @@ export function buildCardBody(flow, isRunning, isExpanded, termManager, runningM
  * @param {boolean} isRunning
  * @param {{ expandedCards: Set<string>, onRenderList: () => void, onOpenModal: (flow: FlowDescriptor) => void, termManager: { disposeLogTerminal: (flowId: string) => void } }} callbacks
  */
-export function setupCardHeaderClick(headerRow, flow, isRunning, { expandedCards, onRenderList, onOpenModal, termManager }) {
+function setupCardHeaderClick(headerRow, flow, isRunning, { expandedCards, onRenderList, onOpenModal, termManager }) {
   headerRow.addEventListener('click', () => {
     if (isRunning) {
       toggleInSet(expandedCards, flow.id);

--- a/src/utils/tab-renderer.js
+++ b/src/utils/tab-renderer.js
@@ -121,7 +121,7 @@ export function buildTabElement(deps, id, tab) {
  * @param {import('./tab-manager-helpers.js').WorkspaceTab} tab
  * @param {HTMLElement} nameEl
  */
-export function bindTabContextMenu(deps, tabEl, id, tab, nameEl) {
+function bindTabContextMenu(deps, tabEl, id, tab, nameEl) {
   attachContextMenu(tabEl, () => {
     const colorItems = COLOR_GROUPS.map((cg) => ({
       label: `${tab.colorGroup === cg.id ? '\u2713 ' : ''}${cg.label}`,

--- a/src/utils/workspace-resize.js
+++ b/src/utils/workspace-resize.js
@@ -81,7 +81,7 @@ export function buildCenterPanel(deps, tab, leftPanel, rightPanel) {
  * @param {HTMLElement} panel
  * @param {string} side
  */
-export function setupPanelResize({ getActiveTab, scheduleAutoSave }, handle, panel, side) {
+function setupPanelResize({ getActiveTab, scheduleAutoSave }, handle, panel, side) {
   let startX = 0;
   let startWidth = 0;
 
@@ -109,7 +109,7 @@ export function setupPanelResize({ getActiveTab, scheduleAutoSave }, handle, pan
  * @param {string} side
  * @param {HTMLElement} [arrowEl]
  */
-export function togglePanel({ getActiveTab, scheduleAutoSave }, panel, side, arrowEl) {
+function togglePanel({ getActiveTab, scheduleAutoSave }, panel, side, arrowEl) {
   panel.classList.add('animating');
   panel.classList.toggle('collapsed');
   const isCollapsed = panel.classList.contains('collapsed');

--- a/src/utils/worktree-dialog.js
+++ b/src/utils/worktree-dialog.js
@@ -19,7 +19,7 @@ function sanitizeSegment(name) {
 }
 
 /** Build the default target path for a worktree given the host repo cwd. */
-export function defaultWorktreePath(repoCwd, branch) {
+function defaultWorktreePath(repoCwd, branch) {
   const segment = sanitizeSegment(branch) || 'worktree';
   return `${repoCwd.replace(/\/$/, '')}/.worktrees/${segment}`;
 }


### PR DESCRIPTION
## Refactoring

Retire 20 exports superflus dans 11 fichiers (issue #249) :

- **Groupe A** (7 exports) : fonctions jamais importées ni utilisées localement → supprimées entièrement (`onTerminalCreated`, `onTerminalRemoved`, `onTerminalExited`, `onLayoutChanged`, `onWorkspaceOpenFromFolder`, `onWorkspaceCreateWorktree`, `onWorkspaceOpenPr` dans `events.js`)
- **Groupe A** (8 exports) : fonctions utilisées localement mais jamais importées depuis l'extérieur → mot-clé `export` retiré
- **Groupe B** (5 exports) : fonctions utilisées localement mais export inutile → mot-clé `export` retiré

4 exports initialement ciblés ont été conservés car des tests les importent directement :
- `buildCommonContextItems` (test: `di-injection.test.js`)
- `buildTableRow` (test: `usage-view-helpers.test.js`)
- `parseRemoteUrl` et `buildPrUrl` (test: `open-pr-flow.test.js`)

Closes #249

## Fichiers modifiés

- `src/utils/events.js` — 7 typed helpers supprimés
- `src/utils/worktree-dialog.js` — `defaultWorktreePath`
- `src/utils/tab-renderer.js` — `bindTabContextMenu`
- `src/utils/workspace-resize.js` — `setupPanelResize`, `togglePanel`
- `src/utils/flow-card-setup.js` — `setupCardHeaderClick`, `buildCardBody`
- `src/utils/file-tree-renderer.js` — `buildRow`
- `src/components/settings-appearance.js` — `applyThemeToTerminals`
- `src/components/settings-keybindings.js` — `createKeyBadge`
- `src/utils/context-menu.js` — `ContextMenu` (class)
- `src/utils/file-viewer-tabs.js` — `createTabEl`
- `src/utils/drag-helpers.js` — `setDragBodyState`, `clearDragBodyState`

## Vérifications

- [x] Build OK (`npm run build`)
- [x] Tests OK — 25 test files, 367 tests passed (`npm test`)

---

🤖 PR créée automatiquement par l'Agent Refactor