### PR TITLE
refactor: remove unused re-exports from events.js

### DIFF
--- a/src/utils/events.js
+++ b/src/utils/events.js
@@ -1,15 +1,12 @@
 /**
- * Centralized event bus and backward-compatible re-exports.
+ * Centralized event bus.
  *
- * Domain-specific events now live in their own modules:
+ * Domain-specific events live in their own modules:
  * - terminal-events.js  — terminal lifecycle & state
  * - workspace-events.js — layout, workspace lifecycle, file & user actions
  *
- * This file keeps the EventBus class, the generic subscribe/unsubscribe
- * helpers, and re-exports all constants and typed helpers so that existing
- * imports from './events.js' continue to work.
- *
- * New code should import directly from the domain module instead.
+ * This file provides the EventBus class and the generic subscribe/unsubscribe
+ * helpers.  Import event constants and typed helpers from the domain modules.
  */
 
 /** @internal */
@@ -57,38 +54,3 @@ export function unsubscribeBus(listeners) {
   for (const [event, handler] of listeners) bus.off(event, handler);
 }
 
-// ── Backward-compatible re-exports from domain modules ──────────────
-// New code should import directly from terminal-events.js or workspace-events.js.
-
-import { TERMINAL_EVENTS } from './terminal-events.js';
-import { WORKSPACE_EVENTS } from './workspace-events.js';
-
-/**
- * Backward-compatible aggregate EVENTS constant.
- * @readonly
- * @enum {string}
- */
-export const EVENTS = {
-  TERMINAL_CWD_CHANGED: TERMINAL_EVENTS.CWD_CHANGED,
-  TERMINAL_CREATED: TERMINAL_EVENTS.CREATED,
-  TERMINAL_REMOVED: TERMINAL_EVENTS.REMOVED,
-  TERMINAL_EXITED: TERMINAL_EVENTS.EXITED,
-  LAYOUT_CHANGED: WORKSPACE_EVENTS.LAYOUT_CHANGED,
-  WORKSPACE_ACTIVATED: WORKSPACE_EVENTS.ACTIVATED,
-  WORKSPACE_OPEN_FROM_FOLDER: WORKSPACE_EVENTS.OPEN_FROM_FOLDER,
-  WORKSPACE_CREATE_WORKTREE: WORKSPACE_EVENTS.CREATE_WORKTREE,
-  WORKSPACE_OPEN_PR: WORKSPACE_EVENTS.OPEN_PR,
-  FILE_OPEN: WORKSPACE_EVENTS.FILE_OPEN,
-};
-
-// Re-export domain modules for convenience
-export { TERMINAL_EVENTS } from './terminal-events.js';
-export { WORKSPACE_EVENTS } from './workspace-events.js';
-
-// Re-export typed subscription helpers
-export { onTerminalCwdChanged, onTerminalCreated, onTerminalRemoved, onTerminalExited } from './terminal-events.js';
-export { onLayoutChanged, onWorkspaceActivated, onWorkspaceOpenFromFolder, onWorkspaceCreateWorktree, onWorkspaceOpenPr, onFileOpen } from './workspace-events.js';
-
-// Re-export typed emission helpers
-export { emitTerminalCwdChanged, emitTerminalCreated, emitTerminalRemoved, emitTerminalExited } from './terminal-events.js';
-export { emitLayoutChanged, emitWorkspaceActivated, emitWorkspaceOpenFromFolder, emitWorkspaceCreateWorktree, emitWorkspaceOpenPr, emitFileOpen } from './workspace-events.js';

--- a/src/utils/file-tree-context-menu.js
+++ b/src/utils/file-tree-context-menu.js
@@ -15,6 +15,7 @@ import { getRelativePath, getBaseName } from './file-tree-helpers.js';
  * @param {{ clipboardWrite: (text: string) => void, fsCopy: (path: string) => void, showInFolder: (path: string) => void, fsTrash: (path: string) => void }} api - injected API methods
  * @returns {Array<{ label?: string, separator?: boolean, action?: () => void }>} menu items
  */
+/** @internal — exported for testing only; use buildFileContextItems/buildDirContextItems instead */
 export function buildCommonContextItems(entryPath, nameEl, rootCwd, promptRenameFn, deleteLabel, { clipboardWrite, fsCopy, showInFolder, fsTrash }) {
   const displayName = getBaseName(entryPath);
   return [


### PR DESCRIPTION
## Refactoring

- Suppression des re-exports backward-compatible depuis `events.js` : constante `EVENTS`, helpers de souscription/émission typés. Tous les consommateurs importent déjà directement depuis les modules domaine (`terminal-events.js`, `workspace-events.js`).
- Marquage de `buildCommonContextItems` comme `@internal` dans `file-tree-context-menu.js` (utilisé uniquement en interne + tests).

Closes #249

## Fichier(s) modifié(s)

- `src/utils/events.js` — suppression re-exports et mise à jour du header
- `src/utils/file-tree-context-menu.js` — annotation `@internal`

## Vérifications

- [x] Build OK
- [x] Tests OK (368/368)

---

📂 Path local : `/Users/rekta/projet/coding/refactor-pikagent`
🤖 PR créée automatiquement par l'Agent Refactor