### PR TITLE
refactor: réduire le couplage de terminal-panel via facade

### DIFF
--- a/src/components/terminal-panel.js
+++ b/src/components/terminal-panel.js
@@ -2,20 +2,19 @@ import { emitTerminalRemoved } from '../utils/terminal-events.js';
 import { emitLayoutChanged } from '../utils/workspace-events.js';
 import { _el } from '../utils/dom.js';
 import { trackMouse } from '../utils/drag-helpers.js';
-import {
-  SplitNode, RESIZE_CURSOR,
-  isSameDirectionSplit, createSplitContainer, equalizeChildren, doResize,
-} from '../utils/terminal-panel-helpers.js';
-import { DropIndicatorManager } from '../utils/terminal-drop-indicator.js';
 import { registerComponent } from '../utils/component-registry.js';
-import { serializeLayout, serializeElement } from '../utils/terminal-serializer.js';
-import { detachElement } from '../utils/split-layout.js';
 import {
+  SplitNode, RESIZE_CURSOR, doResize,
+  DropIndicatorManager,
+  serializeLayout, serializeElement,
+  detachElement,
   buildTopBar,
   createTerminalNode as createTerminalNodeHelper,
   buildFromTree as buildFromTreeHelper,
-} from '../utils/terminal-node-builder.js';
-import { moveTerminal as moveTerminalHelper, splitTerminal, focusDirection as focusDirectionHelper } from '../utils/terminal-split.js';
+  moveTerminal as moveTerminalHelper,
+  splitTerminal,
+  focusDirection as focusDirectionHelper,
+} from '../utils/terminal-subsystem.js';
 
 export class TerminalPanel {
   constructor(container, cwd) {

--- a/src/utils/terminal-subsystem.js
+++ b/src/utils/terminal-subsystem.js
@@ -1,0 +1,36 @@
+/**
+ * Terminal subsystem facade — single entry-point for the terminal-panel
+ * component to access the split-layout, serialization, node-building,
+ * drag-drop indicator, and terminal-split APIs.
+ *
+ * Reduces the import surface of terminal-panel.js from 11 modules
+ * down to ~5 (this facade + dom, drag-helpers, component-registry,
+ * and the two event modules).
+ *
+ * @module terminal-subsystem
+ */
+
+// ── terminal-panel-helpers ──────────────────────────────────────────
+export {
+  SplitNode,
+  RESIZE_CURSOR,
+  isSameDirectionSplit,
+  createSplitContainer,
+  equalizeChildren,
+  doResize,
+} from './terminal-panel-helpers.js';
+
+// ── terminal-drop-indicator ─────────────────────────────────────────
+export { DropIndicatorManager } from './terminal-drop-indicator.js';
+
+// ── terminal-serializer ─────────────────────────────────────────────
+export { serializeLayout, serializeElement } from './terminal-serializer.js';
+
+// ── split-layout ────────────────────────────────────────────────────
+export { detachElement } from './split-layout.js';
+
+// ── terminal-node-builder ───────────────────────────────────────────
+export { buildTopBar, createTerminalNode, buildFromTree } from './terminal-node-builder.js';
+
+// ── terminal-split ──────────────────────────────────────────────────
+export { moveTerminal, splitTerminal, focusDirection } from './terminal-split.js';


### PR DESCRIPTION
## Refactoring

Création d'une facade `terminal-subsystem.js` qui regroupe les APIs du sous-système terminal. `terminal-panel.js` passe de 11 à 6 imports directs.

Closes #259

## Fichier(s) modifié(s)

- `src/utils/terminal-subsystem.js` (nouveau) — facade re-exportant les APIs de 6 modules terminal
- `src/components/terminal-panel.js` — imports simplifiés via la facade

## Vérifications

- [x] Build OK
- [x] Tests OK (369/369)

---

📂 Path local : `/Users/rekta/projet/coding/refactor-pikagent`
🤖 PR créée automatiquement par l'Agent Refactor