### PR TITLE
refactor: casser la dépendance circulaire events <-> terminal/workspace-events

### DIFF
--- a/src/utils/event-bus.js
+++ b/src/utils/event-bus.js
@@ -1,0 +1,40 @@
+/**
+ * Singleton event bus instance.
+ *
+ * Extracted from events.js to break the circular dependency:
+ *   events.js → terminal-events.js → events.js
+ *   events.js → workspace-events.js → events.js
+ *
+ * This module has zero imports and can safely be consumed by any event module.
+ *
+ * @module event-bus
+ */
+
+/** @internal */
+class EventBus {
+  constructor() {
+    this.listeners = new Map();
+  }
+
+  on(event, callback) {
+    if (!this.listeners.has(event)) {
+      this.listeners.set(event, new Set());
+    }
+    this.listeners.get(event).add(callback);
+    return () => this.off(event, callback);
+  }
+
+  off(event, callback) {
+    const set = this.listeners.get(event);
+    if (set) set.delete(callback);
+  }
+
+  emit(event, data) {
+    const set = this.listeners.get(event);
+    if (set) {
+      for (const cb of set) cb(data);
+    }
+  }
+}
+
+export const bus = new EventBus();

--- a/src/utils/events.js
+++ b/src/utils/events.js
@@ -1,45 +1,23 @@
 /**
- * Centralized event bus and backward-compatible re-exports.
+ * Backward-compatible re-exports and generic helpers.
  *
- * Domain-specific events now live in their own modules:
+ * The EventBus class and singleton instance now live in event-bus.js
+ * to break the circular dependency between this module and the domain
+ * event modules (terminal-events.js, workspace-events.js).
+ *
+ * Domain-specific events live in their own modules:
  * - terminal-events.js  — terminal lifecycle & state
  * - workspace-events.js — layout, workspace lifecycle, file & user actions
  *
- * This file keeps the EventBus class, the generic subscribe/unsubscribe
- * helpers, and re-exports all constants and typed helpers so that existing
- * imports from './events.js' continue to work.
+ * This file re-exports the bus, the generic subscribe/unsubscribe helpers,
+ * and all constants and typed helpers so that existing imports from
+ * './events.js' continue to work.
  *
  * New code should import directly from the domain module instead.
  */
 
-/** @internal */
-class EventBus {
-  constructor() {
-    this.listeners = new Map();
-  }
-
-  on(event, callback) {
-    if (!this.listeners.has(event)) {
-      this.listeners.set(event, new Set());
-    }
-    this.listeners.get(event).add(callback);
-    return () => this.off(event, callback);
-  }
-
-  off(event, callback) {
-    const set = this.listeners.get(event);
-    if (set) set.delete(callback);
-  }
-
-  emit(event, data) {
-    const set = this.listeners.get(event);
-    if (set) {
-      for (const cb of set) cb(data);
-    }
-  }
-}
-
-export const bus = new EventBus();
+import { bus } from './event-bus.js';
+export { bus };
 
 /**
  * Register an array of [event, handler] pairs on the bus.

--- a/src/utils/terminal-events.js
+++ b/src/utils/terminal-events.js
@@ -8,7 +8,7 @@
  * @see events.js (backward-compat re-exports)
  */
 
-import { bus } from './events.js';
+import { bus } from './event-bus.js';
 
 // ── Event constants ─────────────────────────────────────────────────
 

--- a/src/utils/workspace-events.js
+++ b/src/utils/workspace-events.js
@@ -9,7 +9,7 @@
  * @see events.js (backward-compat re-exports)
  */
 
-import { bus } from './events.js';
+import { bus } from './event-bus.js';
 
 // ── Event constants ─────────────────────────────────────────────────
 


### PR DESCRIPTION
## Refactoring

Extraction du bus d'événements dans `event-bus.js` pour casser la dépendance circulaire entre `events.js`, `terminal-events.js` et `workspace-events.js`.

Closes #263

## Fichier(s) modifié(s)

- `src/utils/event-bus.js` — nouveau fichier contenant la classe `EventBus` et l'instance singleton `bus`
- `src/utils/events.js` — suppression de la classe `EventBus`, import et ré-export du `bus` depuis `event-bus.js`
- `src/utils/terminal-events.js` — import du `bus` depuis `event-bus.js` au lieu de `events.js`
- `src/utils/workspace-events.js` — import du `bus` depuis `event-bus.js` au lieu de `events.js`

## Graphe de dépendances après refactoring

```
event-bus.js (aucune dépendance)
  <- terminal-events.js
  <- workspace-events.js
  <- events.js (agrégation uniquement)
```

## Vérifications

- [x] Build OK
- [x] Tests OK (25 suites, 369 tests)

---

PR créée automatiquement par l'Agent Refactor