### PR TITLE
refactor: factoriser le pattern rendu de lignes avec chevron

### DIFF
--- a/src/utils/dom.js
+++ b/src/utils/dom.js
@@ -108,33 +108,45 @@ export function renderButtonBar({ containerClass, configs, handlers }) {
 }
 
 /**
- * Build a row containing a chevron span and a name span.
+ * Build a row containing an optional chevron span and a name span.
  *
- * Used by file-tree rows and flow-category headers — any place that needs
- * the common "chevron + label" pattern.
+ * Used by file-tree rows, flow-category headers, and tab elements — any
+ * place that needs the common "chevron + label" or "label-only" pattern.
  *
  * When `containerClass` is provided, a wrapper `<div>` is returned as `row`.
  * An optional `depth` + `computeIndent` pair applies padding-left for
  * tree-style indentation.
  *
- * @param {{ chevronClass: string, nameClass: string, name: string,
- *           chevronText?: string, containerClass?: string,
+ * When `chevronClass` is omitted or null, no chevron element is created and
+ * the returned `chevron` field is `null`.
+ *
+ * @param {{ chevronClass?: string|null, nameClass?: string|null,
+ *           name: string, chevronText?: string, containerClass?: string,
  *           depth?: number, computeIndent?: (depth: number) => number,
+ *           prefixChildren?: HTMLElement[],
  *           extraChildren?: HTMLElement[] }} opts
- * @returns {{ chevron: HTMLElement, name: HTMLElement, row?: HTMLElement }}
+ * @returns {{ chevron: HTMLElement|null, name: HTMLElement, row?: HTMLElement }}
  */
 export function buildChevronRow(opts) {
-  const chevron = _el('span', { className: opts.chevronClass, textContent: opts.chevronText || '' });
-  const name = _el('span', { className: opts.nameClass, textContent: opts.name });
+  const chevron = opts.chevronClass
+    ? _el('span', { className: opts.chevronClass, textContent: opts.chevronText || '' })
+    : null;
+  const name = _el('span', { className: opts.nameClass || '', textContent: opts.name });
 
   if (opts.containerClass) {
     const style = (opts.depth != null && opts.computeIndent)
       ? { paddingLeft: `${opts.computeIndent(opts.depth)}px` }
       : undefined;
+    const parts = [
+      ...(opts.prefixChildren || []),
+      ...(chevron ? [chevron] : []),
+      name,
+      ...(opts.extraChildren || []),
+    ];
     const row = _el('div', {
       className: opts.containerClass,
       ...(style && { style }),
-    }, chevron, name, ...(opts.extraChildren || []));
+    }, ...parts);
     return { chevron, name, row };
   }
 

--- a/src/utils/tab-renderer.js
+++ b/src/utils/tab-renderer.js
@@ -7,7 +7,7 @@
  *
  * @typedef {{ activeTabId: string|null, tabs: Map<string, import('./tab-manager-helpers.js').WorkspaceTab>, switchTo: (id: string) => void, closeTab: (id: string) => void, renameTab: (id: string, nameEl: HTMLElement) => void, setTabColorGroup: (id: string, colorGroupId: string|null) => void, toggleNoShortcut: (id: string) => void, dragDeps: import('./tab-drag.js').TabDragDeps }} TabElementDeps
  */
-import { _el } from './dom.js';
+import { _el, buildChevronRow } from './dom.js';
 import { startInlineRename } from './form-helpers.js';
 import { COLOR_GROUPS } from './tab-manager-helpers.js';
 import { setupTabDrag } from './tab-drag.js';
@@ -28,7 +28,22 @@ import { onClickStopped } from './event-helpers.js';
  * @returns {{ tabEl: HTMLElement, nameEl: HTMLElement }}
  */
 export function createTabElement(config) {
-  const tabEl = _el('div', config.className);
+  // Build close button (appended after name via extraChildren)
+  const closeChildren = [];
+  if (config.close) {
+    const closeEl = _el('span', config.close.className, config.close.text);
+    onClickStopped(closeEl, (e) => config.close.onClick(e));
+    closeChildren.push(closeEl);
+  }
+
+  const { name: nameEl, row: tabEl } = buildChevronRow({
+    containerClass: config.className,
+    nameClass: config.nameClass || '',
+    name: config.name,
+    prefixChildren: config.prefixEls || [],
+    extraChildren: closeChildren,
+  });
+
   if (config.isActive) tabEl.classList.add('active');
   if (config.extraClasses) {
     for (const cls of config.extraClasses) tabEl.classList.add(cls);
@@ -41,19 +56,6 @@ export function createTabElement(config) {
       if (k.startsWith('--')) tabEl.style.setProperty(k, v);
       else tabEl.style[k] = v;
     }
-  }
-
-  if (config.prefixEls) {
-    for (const el of config.prefixEls) tabEl.appendChild(el);
-  }
-
-  const nameEl = _el('span', config.nameClass || null, config.name);
-  tabEl.appendChild(nameEl);
-
-  if (config.close) {
-    const closeEl = _el('span', config.close.className, config.close.text);
-    onClickStopped(closeEl, (e) => config.close.onClick(e));
-    tabEl.appendChild(closeEl);
   }
 
   tabEl.addEventListener('click', () => config.onClick(tabEl));


### PR DESCRIPTION
## Refactoring

Enrichissement du helper `buildChevronRow` dans `dom.js` pour supporter un chevron optionnel (`chevronClass` peut être omis) et des `prefixChildren` (éléments insérés avant le name span). Le `tab-renderer.js` utilise maintenant ce helper commun au lieu de reconstruire manuellement le pattern container + name.

Les 3 renderers (tab, file-tree, flow-category) utilisent maintenant `buildChevronRow` :
- `file-tree-renderer.js` et `flow-category-renderer.js` — déjà migrés (inchangés)
- `tab-renderer.js` — migré dans ce PR via `prefixChildren` + `extraChildren`

⚠️ Régression de #240/#151 — cette fois le helper est paramétrique pour couvrir tous les cas d'usage, y compris les tabs sans chevron.

Closes #251

## Fichier(s) modifié(s)

- `src/utils/dom.js` — `buildChevronRow` : chevron optionnel, ajout de `prefixChildren`
- `src/utils/tab-renderer.js` — `createTabElement` utilise `buildChevronRow`

## Vérifications

- [x] Build OK
- [x] Tests OK (368/368)

---

📂 Path local : `/Users/rekta/projet/coding/refactor-pikagent`
🤖 PR créée automatiquement par l'Agent Refactor