### PR TITLE
refactor: découper le hub events.js en modules par domaine

### DIFF
--- a/src/components/board-view.js
+++ b/src/components/board-view.js
@@ -1,11 +1,11 @@
-import { subscribeBus, unsubscribeBus } from '../utils/events.js';
+import { onTerminalCreated, onTerminalRemoved, onTerminalExited } from '../utils/terminal-events.js';
 import { _el, renderButtonBar } from '../utils/dom.js';
 import { _safeFit, createTerminal, disposeTerminal, disposeTerminalMap, setupTerminalAddons } from '../utils/terminal-factory.js';
 import { registerComponent } from '../utils/component-registry.js';
 import { RendererPollingTimer } from '../utils/polling.js';
 import {
   DATA_VOLUME_THRESHOLD, POLL_INTERVAL_MS, FIT_SETTLE_DELAY_MS, FIT_UNHIDE_DELAY_MS,
-  STATUS_CONFIG, ALL_CARD_CLASSES, EVT_CREATED, EVT_REMOVED, EVT_EXITED,
+  STATUS_CONFIG, ALL_CARD_CLASSES,
   BOARD_TERMINAL_OPTS, HEADER_BUTTONS,
   resolveCardStatus, findTabForTerminal, getTabNameForTerminal, computeFocusIndex,
   formatCardLabel,
@@ -212,15 +212,10 @@ export class BoardView {
   _setupListeners() {
     const onTerminalGone = ({ id }) => { this.removeCard(id); this._updateEmptyState(); };
 
-    // Bus event listeners — single declaration drives both subscription and cleanup
-    this._busListeners = subscribeBus([
-      /** @listens terminal:created {{ id: string, cwd: string }} */
-      [EVT_CREATED, () => { if (!this.disposed) this.scanAgents(); }],
-      /** @listens terminal:removed {{ id: string }} */
-      [EVT_REMOVED, onTerminalGone],
-      /** @listens terminal:exited {{ id: string }} */
-      [EVT_EXITED, onTerminalGone],
-    ]);
+    // Typed subscription helpers — each returns an unsubscribe function
+    this._unsubCreated = onTerminalCreated(() => { if (!this.disposed) this.scanAgents(); });
+    this._unsubRemoved = onTerminalRemoved(onTerminalGone);
+    this._unsubExited  = onTerminalExited(onTerminalGone);
   }
 
   focusDirection(dir) {
@@ -260,7 +255,9 @@ export class BoardView {
     this.disposed = true;
     this.pause();
 
-    unsubscribeBus(this._busListeners);
+    this._unsubCreated();
+    this._unsubRemoved();
+    this._unsubExited();
     disposeTerminalMap(this.cards);
   }
 }

--- a/src/components/tab-manager.js
+++ b/src/components/tab-manager.js
@@ -1,6 +1,6 @@
 import {
   initTabManager, setupBusListeners,
-  unsubscribeBus, getComponent,
+  getComponent,
 } from '../utils/tab-manager-init.js';
 import {
   renderWorkspace as doRenderWorkspace, reattachLayout,
@@ -246,7 +246,7 @@ export class TabManager {
   }
 
   dispose() {
-    unsubscribeBus(this._busListeners);
+    for (const unsub of this._busListeners) unsub();
     this._busListeners = [];
     disposeAllSideViews(this._viewStore());
     disposeAllTabs({ tabs: this.tabs, setActiveTabId: (id) => { this.activeTabId = id; } });

--- a/src/utils/board-helpers.js
+++ b/src/utils/board-helpers.js
@@ -4,7 +4,6 @@
  */
 
 import { findTabForTerminal } from './tab-lifecycle.js';
-import { TERMINAL_EVENTS } from './terminal-events.js';
 export { findTabForTerminal };
 
 // Minimum bytes of meaningful output per poll interval to consider agent "working".
@@ -23,10 +22,6 @@ export const STATUS_CONFIG = {
 
 /** All card-level CSS classes derived from STATUS_CONFIG — single source of truth for class removal. */
 export const ALL_CARD_CLASSES = Object.values(STATUS_CONFIG).map(c => c.cardClass);
-
-export const EVT_CREATED = TERMINAL_EVENTS.CREATED;
-export const EVT_REMOVED = TERMINAL_EVENTS.REMOVED;
-export const EVT_EXITED = TERMINAL_EVENTS.EXITED;
 
 /** Terminal options used by board card mini-terminals. */
 export const BOARD_TERMINAL_OPTS = {

--- a/src/utils/tab-manager-init.js
+++ b/src/utils/tab-manager-init.js
@@ -6,15 +6,13 @@
  * it can import from fewer modules (issue #130).
  */
 
-import { subscribeBus } from './events.js';
-import { TERMINAL_EVENTS } from './terminal-events.js';
-import { WORKSPACE_EVENTS } from './workspace-events.js';
+import { onTerminalCwdChanged as onTermCwdEvent, onTerminalCreated, onTerminalRemoved } from './terminal-events.js';
+import { onLayoutChanged, onWorkspaceOpenFromFolder, onWorkspaceCreateWorktree, onWorkspaceOpenPr } from './workspace-events.js';
 import { extractFolderName } from './file-tree-helpers.js';
 import { findTabForTerminal, onTerminalCwdChanged } from './tab-lifecycle.js';
 import { createWorktreeFlow } from './worktree-flow.js';
 import { openPrFlow } from './open-pr-flow.js';
 
-export { unsubscribeBus } from './events.js';
 export { getComponent } from './component-registry.js';
 
 // ── Initialization ──
@@ -67,57 +65,50 @@ export async function initTabManager(deps) {
 
 /**
  * Register bus event listeners for the tab manager.
- * Returns the subscription handle for cleanup.
+ * Returns an array of unsubscribe functions for cleanup.
  *
  * @param {BusListenerDeps} deps
- * @returns {Array<() => void>} subscription handle
+ * @returns {Array<() => void>} unsubscribe functions
  */
 export function setupBusListeners(deps) {
-  return subscribeBus([
-    /** @listens terminal:cwdChanged {{ id: string, cwd: string }} */
-    [TERMINAL_EVENTS.CWD_CHANGED, ({ id, cwd }) => {
+  return [
+    onTermCwdEvent(({ id, cwd }) => {
       onTerminalCwdChanged(deps.tabs, deps.getActiveTabId(), id, cwd, {
         gitBranch: deps.api.gitBranch,
         renderTabBar: deps.renderTabBar,
       });
       deps.configManager.scheduleAutoSave();
-    }],
-    /** @listens terminal:created {{ id: string, cwd: string }} */
-    [TERMINAL_EVENTS.CREATED, ({ id, cwd }) => {
+    }),
+    onTerminalCreated(({ id, cwd }) => {
       const tab = findTabForTerminal(deps.tabs, id)?.tab ?? deps.tabs.get(deps.getActiveTabId());
       if (tab?.fileTree) tab.fileTree.setTerminalRoot(id, cwd);
       deps.configManager.scheduleAutoSave();
-    }],
-    /** @listens terminal:removed {{ id: string }} */
-    [TERMINAL_EVENTS.REMOVED, ({ id }) => {
+    }),
+    onTerminalRemoved(({ id }) => {
       for (const [, tab] of deps.tabs) {
         if (tab.fileTree) tab.fileTree.removeTerminal(id);
       }
       deps.configManager.scheduleAutoSave();
-    }],
-    /** @listens layout:changed {undefined} */
-    [WORKSPACE_EVENTS.LAYOUT_CHANGED, () => deps.configManager.scheduleAutoSave()],
-    /** @listens workspace:openFromFolder {{ cwd: string }} */
-    [WORKSPACE_EVENTS.OPEN_FROM_FOLDER, ({ cwd }) => {
+    }),
+    onLayoutChanged(() => deps.configManager.scheduleAutoSave()),
+    onWorkspaceOpenFromFolder(({ cwd }) => {
       const folderName = extractFolderName(cwd);
       deps.createTab(folderName, cwd);
-    }],
-    /** @listens workspace:createWorktree {{ repoCwd: string }} */
-    [WORKSPACE_EVENTS.CREATE_WORKTREE, ({ repoCwd }) => {
+    }),
+    onWorkspaceCreateWorktree(({ repoCwd }) => {
       createWorktreeFlow({
         repoCwd,
         api: deps.api.worktree,
         createTab: deps.createTab,
       }).catch((e) => console.warn('createWorktreeFlow failed:', e));
-    }],
-    /** @listens workspace:openPr {{ repoCwd: string }} */
-    [WORKSPACE_EVENTS.OPEN_PR, ({ repoCwd }) => {
+    }),
+    onWorkspaceOpenPr(({ repoCwd }) => {
       const tab = _findTabByCwd(deps.tabs, repoCwd);
       const baseBranch = tab?.worktree?.baseBranch ?? null;
       openPrFlow({ cwd: repoCwd, baseBranch, api: deps.api.pr })
         .catch((e) => console.warn('openPrFlow failed:', e));
-    }],
-  ]);
+    }),
+  ];
 }
 
 function _findTabByCwd(tabs, cwd) {


### PR DESCRIPTION
## Refactoring

Suppression des derniers imports directs de `events.js` par les modules consommateurs. Les deux derniers utilisateurs de `subscribeBus`/`unsubscribeBus` (`board-view.js` et `tab-manager-init.js`) migrent vers les helpers de souscription typés des modules domaine (`onTerminalCreated`, `onTerminalRemoved`, `onTerminalExited`, `onLayoutChanged`, etc.).

`events.js` conserve uniquement la classe `EventBus` et le singleton `bus` — toute souscription et émission passe désormais par `terminal-events.js` et `workspace-events.js`.

Closes #238

## Fichier(s) modifié(s)

- `src/components/board-view.js` — remplace `subscribeBus`/`unsubscribeBus` par `onTerminalCreated`/`onTerminalRemoved`/`onTerminalExited`
- `src/components/tab-manager.js` — supprime l'import de `unsubscribeBus`, utilise des fonctions de désinscription directes
- `src/utils/tab-manager-init.js` — remplace `subscribeBus` par les helpers typés des deux modules domaine
- `src/utils/board-helpers.js` — supprime les alias `EVT_CREATED`/`EVT_REMOVED`/`EVT_EXITED` et l'import de `TERMINAL_EVENTS` désormais inutiles

## Vérifications

- [x] Build OK (`npm run build`)
- [x] Tests OK (25 fichiers, 368 tests passent)

---

Path local : `/Users/rekta/projet/coding/refactor-pikagent`
PR créée automatiquement par l'Agent Refactor