### PR TITLE
refactor: supprimer les exports superflus (24 exports dans 13 fichiers)

### DIFF
--- a/src/utils/events.js
+++ b/src/utils/events.js
@@ -64,8 +64,8 @@ export { TERMINAL_EVENTS } from './terminal-events.js';
 export { WORKSPACE_EVENTS } from './workspace-events.js';
 
 // Re-export typed subscription helpers
-export { onTerminalCwdChanged, onTerminalCreated, onTerminalRemoved, onTerminalExited } from './terminal-events.js';
-export { onLayoutChanged, onWorkspaceActivated, onWorkspaceOpenFromFolder, onWorkspaceCreateWorktree, onWorkspaceOpenPr, onFileOpen } from './workspace-events.js';
+export { onTerminalCwdChanged } from './terminal-events.js';
+export { onWorkspaceActivated, onFileOpen } from './workspace-events.js';
 
 // Re-export typed emission helpers
 export { emitTerminalCwdChanged, emitTerminalCreated, emitTerminalRemoved, emitTerminalExited } from './terminal-events.js';

--- a/src/utils/file-tree-context-menu.js
+++ b/src/utils/file-tree-context-menu.js
@@ -15,7 +15,7 @@ import { getRelativePath, getBaseName } from './file-tree-helpers.js';
  * @param {{ clipboardWrite: (text: string) => void, fsCopy: (path: string) => void, showInFolder: (path: string) => void, fsTrash: (path: string) => void }} api - injected API methods
  * @returns {Array<{ label?: string, separator?: boolean, action?: () => void }>} menu items
  */
-export function buildCommonContextItems(entryPath, nameEl, rootCwd, promptRenameFn, deleteLabel, { clipboardWrite, fsCopy, showInFolder, fsTrash }) {
+function buildCommonContextItems(entryPath, nameEl, rootCwd, promptRenameFn, deleteLabel, { clipboardWrite, fsCopy, showInFolder, fsTrash }) {
   const displayName = getBaseName(entryPath);
   return [
     { label: 'Rename', action: () => promptRenameFn(entryPath, nameEl) },
@@ -81,3 +81,6 @@ export function buildDirContextItems(dirPath, rootCwd, contentEl, depth, expande
     ...buildCommonContextItems(dirPath, nameEl, rootCwd, promptRenameFn, `Delete folder "${dirName}" and all its contents?`, api),
   ];
 }
+
+/** @internal Exposed for unit tests only. */
+export const _internals = { buildCommonContextItems };

--- a/src/utils/open-pr-flow.js
+++ b/src/utils/open-pr-flow.js
@@ -17,7 +17,7 @@ import { _el } from './dom.js';
  *   git@github.com:owner/repo.git      → same
  *   ssh://git@github.com/owner/repo    → same
  */
-export function parseRemoteUrl(url) {
+function parseRemoteUrl(url) {
   if (!url) return null;
   const trimmed = url.trim().replace(/\.git$/, '');
   const patterns = [
@@ -33,7 +33,7 @@ export function parseRemoteUrl(url) {
 }
 
 /** Build a provider-specific URL for opening a new PR/MR from `branch`. */
-export function buildPrUrl({ host, owner, repo }, branch, baseBranch) {
+function buildPrUrl({ host, owner, repo }, branch, baseBranch) {
   const b = encodeURIComponent(branch);
   if (host.endsWith('github.com')) {
     const base = baseBranch ? `${encodeURIComponent(baseBranch)}...${b}` : b;
@@ -172,3 +172,6 @@ export async function openPrFlow({ cwd, baseBranch = null, api }) {
 
   await api.openExternal(url);
 }
+
+/** @internal Exposed for unit tests only. */
+export const _internals = { parseRemoteUrl, buildPrUrl };

--- a/src/utils/usage-view-helpers.js
+++ b/src/utils/usage-view-helpers.js
@@ -43,7 +43,7 @@ function _td(text, attrs = {}) {
  * @param {Array<Node | { value: string|number, className?: string, style?: Record<string, string>, title?: string }>} columns
  * @returns {HTMLTableRowElement}
  */
-export function buildTableRow(columns) {
+function buildTableRow(columns) {
   const cells = columns.map((col) => {
     if (col instanceof Node) return col;
     const attrs = {};
@@ -153,6 +153,9 @@ function _tokenTabConfig(metrics) {
     ],
   };
 }
+
+/** @internal Exposed for unit tests only. */
+export const _internals = { buildTableRow };
 
 function _flowTabConfig(metrics) {
   const f = metrics.flow;

--- a/tests/utils/di-injection.test.js
+++ b/tests/utils/di-injection.test.js
@@ -43,7 +43,7 @@ describe('DI: file-tree-context-menu', () => {
     }));
 
     const mod = await import('../../src/utils/file-tree-context-menu.js');
-    buildCommonContextItems = mod.buildCommonContextItems;
+    buildCommonContextItems = mod._internals.buildCommonContextItems;
     buildFileContextItems = mod.buildFileContextItems;
     buildDirContextItems = mod.buildDirContextItems;
   });

--- a/tests/utils/open-pr-flow.test.js
+++ b/tests/utils/open-pr-flow.test.js
@@ -1,5 +1,7 @@
 import { describe, it, expect } from 'vitest';
-import { parseRemoteUrl, buildPrUrl } from '../../src/utils/open-pr-flow.js';
+import { _internals } from '../../src/utils/open-pr-flow.js';
+
+const { parseRemoteUrl, buildPrUrl } = _internals;
 
 describe('parseRemoteUrl', () => {
   it('parses HTTPS github URLs (with and without .git)', () => {

--- a/tests/utils/usage-view-helpers.test.js
+++ b/tests/utils/usage-view-helpers.test.js
@@ -2,7 +2,9 @@
  * @vitest-environment happy-dom
  */
 import { describe, it, expect } from 'vitest';
-import { buildTableRow } from '../../src/utils/usage-view-helpers.js';
+import { _internals } from '../../src/utils/usage-view-helpers.js';
+
+const { buildTableRow } = _internals;
 
 describe('buildTableRow', () => {
   it('creates a <tr> with one <td> for a single column descriptor', () => {


### PR DESCRIPTION
## Refactoring

Suppression des exports superflus : retrait du keyword `export` sur les fonctions/classes qui ne sont jamais importées depuis l'extérieur de leur module.

Closes #249

## Fichier(s) modifié(s)

- `src/utils/events.js` — suppression de 7 re-exports morts (onTerminalCreated, onTerminalRemoved, onTerminalExited, onLayoutChanged, onWorkspaceOpenFromFolder, onWorkspaceCreateWorktree, onWorkspaceOpenPr)
- `src/utils/file-tree-context-menu.js` — buildCommonContextItems rendu privé, exposé via `_internals`
- `src/utils/open-pr-flow.js` — parseRemoteUrl et buildPrUrl rendus privés, exposés via `_internals`
- `src/utils/usage-view-helpers.js` — buildTableRow rendu privé, exposé via `_internals`
- `tests/utils/di-injection.test.js` — mise à jour import via `_internals`
- `tests/utils/open-pr-flow.test.js` — mise à jour import via `_internals`
- `tests/utils/usage-view-helpers.test.js` — mise à jour import via `_internals`

## Note

Parmi les 24 exports listés dans l'issue, 14 étaient déjà privés (sans `export`) dans le code actuel — probablement corrigés par des refactorings précédents. Les 10 restants ont été traités dans ce PR (7 re-exports events.js + 3 fonctions rendues privées avec `_internals` pour les tests).

## Vérifications

- [x] Build OK
- [x] Tests OK (368/368)

---

📂 Path local : `/Users/rekta/projet/coding/refactor-pikagent`
🤖 PR créée automatiquement par l'Agent Refactor