### PR TITLE
refactor: extraire les constantes et types de tab-manager-helpers.js

### DIFF
--- a/src/utils/board-helpers.js
+++ b/src/utils/board-helpers.js
@@ -65,7 +65,7 @@ export function resolveCardStatus(dataBytes) {
 
 /**
  * Get the tab name for a terminal ID.
- * @param {Map<string, import('./tab-manager-helpers.js').WorkspaceTab>} tabs - tabManager.tabs
+ * @param {Map<string, import('./tab-types.js').WorkspaceTab>} tabs - tabManager.tabs
  * @param {string} termId
  * @returns {string|null}
  */

--- a/src/utils/shortcut-helpers.js
+++ b/src/utils/shortcut-helpers.js
@@ -1,4 +1,4 @@
-import { COLOR_GROUPS } from './tab-manager-helpers.js';
+import { COLOR_GROUPS } from './tab-constants.js';
 
 // Derive color-group shortcut metadata once from COLOR_GROUPS
 const COLOR_SHORTCUTS = COLOR_GROUPS.map((cg) => ({

--- a/src/utils/sidebar-manager.js
+++ b/src/utils/sidebar-manager.js
@@ -13,12 +13,12 @@
  *
  * @typedef {{ workspaceContainer: HTMLElement, viewStore: SideViewStore }} SideViewDeps
  *
- * @typedef {{ getActiveTab: () => import('./tab-manager-helpers.js').WorkspaceTab|null, capturePanelWidths: (tab: import('./tab-manager-helpers.js').WorkspaceTab) => void, viewStore: SideViewStore }} DetachDeps
+ * @typedef {{ getActiveTab: () => import('./tab-types.js').WorkspaceTab|null, capturePanelWidths: (tab: import('./tab-types.js').WorkspaceTab) => void, viewStore: SideViewStore }} DetachDeps
  */
 
 import { getComponent } from './component-registry.js';
 import { _el } from './dom.js';
-import { ACTIVITY_BUTTONS, SETTINGS_ICON, SIDE_VIEWS } from './tab-manager-helpers.js';
+import { ACTIVITY_BUTTONS, SETTINGS_ICON, SIDE_VIEWS } from './tab-constants.js';
 import { createAsyncHandler } from './event-helpers.js';
 
 function buildActivityButton(label, iconSvg, extraClass = '') {
@@ -158,7 +158,7 @@ export function activateSideView(deps, mode, extraArgs = {}) {
 /**
  * Switch sidebar mode: detach current view, activate new view (or re-attach work layout).
  *
- * @typedef {{ getActiveTab: () => import('./tab-manager-helpers.js').WorkspaceTab|null, capturePanelWidths: (tab: import('./tab-manager-helpers.js').WorkspaceTab) => void, viewStore: SideViewStore, workspaceContainer: HTMLElement, reattachLayout: (deps: { workspaceContainer: HTMLElement }, tab: import('./tab-manager-helpers.js').WorkspaceTab) => void, renderWorkspace: (tab: import('./tab-manager-helpers.js').WorkspaceTab) => void, tabManager: unknown }} ChangeSidebarModeDeps
+ * @typedef {{ getActiveTab: () => import('./tab-types.js').WorkspaceTab|null, capturePanelWidths: (tab: import('./tab-types.js').WorkspaceTab) => void, viewStore: SideViewStore, workspaceContainer: HTMLElement, reattachLayout: (deps: { workspaceContainer: HTMLElement }, tab: import('./tab-types.js').WorkspaceTab) => void, renderWorkspace: (tab: import('./tab-types.js').WorkspaceTab) => void, tabManager: unknown }} ChangeSidebarModeDeps
  */
 
 /**

--- a/src/utils/tab-bar-renderer.js
+++ b/src/utils/tab-bar-renderer.js
@@ -3,7 +3,7 @@
  *
  * Builds the tab bar UI: color filters, tab elements, and the add-tab button.
  *
- * @typedef {{ tabBar: HTMLElement, tabs: Map<string, import('./tab-manager-helpers.js').WorkspaceTab>, activeTabId: string|null, activeColorFilter: string|null, excludedColors: Set<string>, switchTo: (id: string) => void, closeTab: (id: string) => void, renameTab: (id: string, nameEl: HTMLElement) => void, setTabColorGroup: (id: string, colorGroupId: string|null) => void, toggleNoShortcut: (id: string) => void, setColorFilter: (colorGroupId: string) => void, toggleExcludeColor: (colorGroupId: string) => void, createTab: () => void, reorderTab: (fromId: string, toId: string, before: boolean) => void, isTabVisible: (tab: import('./tab-manager-helpers.js').WorkspaceTab) => boolean, renderTabBar: () => void, clearColorFilters: () => void }} RenderTabBarDeps
+ * @typedef {{ tabBar: HTMLElement, tabs: Map<string, import('./tab-types.js').WorkspaceTab>, activeTabId: string|null, activeColorFilter: string|null, excludedColors: Set<string>, switchTo: (id: string) => void, closeTab: (id: string) => void, renameTab: (id: string, nameEl: HTMLElement) => void, setTabColorGroup: (id: string, colorGroupId: string|null) => void, toggleNoShortcut: (id: string) => void, setColorFilter: (colorGroupId: string) => void, toggleExcludeColor: (colorGroupId: string) => void, createTab: () => void, reorderTab: (fromId: string, toId: string, before: boolean) => void, isTabVisible: (tab: import('./tab-types.js').WorkspaceTab) => boolean, renderTabBar: () => void, clearColorFilters: () => void }} RenderTabBarDeps
  */
 
 import { _el } from './dom.js';

--- a/src/utils/tab-color-filter.js
+++ b/src/utils/tab-color-filter.js
@@ -3,7 +3,7 @@
  * Extracted from tab-manager.js to reduce component size.
  */
 import { _el } from './dom.js';
-import { COLOR_GROUPS } from './tab-manager-helpers.js';
+import { COLOR_GROUPS } from './tab-constants.js';
 import { attachContextMenu } from './context-menu.js';
 
 /**
@@ -17,7 +17,7 @@ export function isTabVisible(tab, activeColorFilter, excludedColors) {
 
 /**
  * Build the color filter bar DOM element.
- * @param {Map<string, import('./tab-manager-helpers.js').WorkspaceTab>} tabs
+ * @param {Map<string, import('./tab-types.js').WorkspaceTab>} tabs
  * @param {string|null} activeColorFilter
  * @param {Set<string>} excludedColors
  * @param {{ onClearFilter: () => void, onSetFilter: (colorGroupId: string) => void, onToggleExclude: (colorGroupId: string) => void }} handlers
@@ -55,8 +55,8 @@ export function toggleExcludeColor(state, colorGroupId, renderTabBar, ensureVisi
 /**
  * If the active tab is not visible under the current filter, switch to
  * the first visible tab.
- * @param {Map<string, import('./tab-manager-helpers.js').WorkspaceTab>} tabs
- * @param {() => import('./tab-manager-helpers.js').WorkspaceTab|undefined} getActiveTab
+ * @param {Map<string, import('./tab-types.js').WorkspaceTab>} tabs
+ * @param {() => import('./tab-types.js').WorkspaceTab|undefined} getActiveTab
  * @param {string|null} activeColorFilter
  * @param {Set<string>} excludedColors
  * @param {(id: string) => void} switchTo
@@ -71,7 +71,7 @@ export function ensureVisibleTabActive(tabs, getActiveTab, activeColorFilter, ex
 
 /**
  * Build the color filter bar DOM element.
- * @param {Map<string, import('./tab-manager-helpers.js').WorkspaceTab>} tabs
+ * @param {Map<string, import('./tab-types.js').WorkspaceTab>} tabs
  * @param {string|null} activeColorFilter
  * @param {Set<string>} excludedColors
  * @param {{ onClearFilter: () => void, onSetFilter: (colorGroupId: string) => void, onToggleExclude: (colorGroupId: string) => void }} handlers

--- a/src/utils/tab-constants.js
+++ b/src/utils/tab-constants.js
@@ -1,0 +1,77 @@
+// ── Layout constants ──
+export const DRAG_THRESHOLD = 5;
+export const PANEL_MIN_WIDTH = 150;
+export const FIT_DELAY_MS = 200;
+
+// ── Side panel configuration (single source of truth for side-specific limits & arrows) ──
+export const SIDE_CONFIG = {
+  left:  { maxWidth: 500,  arrows: { collapsed: '\u2192', expanded: '\u2190' } },
+  right: { maxWidth: 1400, arrows: { collapsed: '\u2190', expanded: '\u2192' } },
+};
+
+/**
+ * Workspace side-panel definitions — single source of truth for panel structure,
+ * content class, optional header title, and serialization keys.
+ * Drives _buildSidePanel, _capturePanelWidths, and _restorePanelSizes in tab-manager.
+ */
+export const WORKSPACE_PANELS = [
+  { side: 'left',  contentCls: 'file-tree',   title: 'Explorer', widthKey: 'leftWidth',  collapsedKey: 'leftCollapsed' },
+  { side: 'right', contentCls: 'file-viewer',                    widthKey: 'rightWidth', collapsedKey: 'rightCollapsed' },
+];
+
+// ── Activity bar buttons ──
+// `icon` uses inline SVG path data, rendered by sidebar-manager.
+export const ACTIVITY_BUTTONS = [
+  {
+    label: 'WORK',
+    mode: 'work',
+    icon: '<rect x="3" y="3" width="7" height="7" rx="1.5"/><rect x="14" y="3" width="7" height="7" rx="1.5"/><rect x="3" y="14" width="7" height="7" rx="1.5"/><rect x="14" y="14" width="7" height="7" rx="1.5"/>',
+  },
+  {
+    label: 'BOARD',
+    mode: 'board',
+    icon: '<rect x="3" y="4" width="18" height="4" rx="1.5"/><rect x="3" y="11" width="18" height="4" rx="1.5"/><rect x="3" y="18" width="18" height="3" rx="1.5"/>',
+  },
+  {
+    label: 'FLOW',
+    mode: 'flow',
+    icon: '<path d="M4 17 L9 12 L13 15 L20 7" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/><circle cx="9" cy="12" r="1.5"/><circle cx="13" cy="15" r="1.5"/>',
+  },
+  {
+    label: 'SKILLS',
+    mode: 'skills',
+    icon: '<path d="M12 2 L3 6 L3 12 C3 16.5 7 20.5 12 22 C17 20.5 21 16.5 21 12 L21 6 Z" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linejoin="round"/><path d="M8 12 L11 15 L16 10" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>',
+  },
+  {
+    label: 'USAGE',
+    mode: 'usage',
+    icon: '<path d="M4 18 L10 12 L14 16 L20 8" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/><path d="M15 8 L20 8 L20 13" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>',
+  },
+];
+
+export const SETTINGS_ICON = '<path d="M12 8.5a3.5 3.5 0 1 0 0 7 3.5 3.5 0 0 0 0-7Z" fill="none" stroke="currentColor" stroke-width="1.8"/><path d="M19.4 13.6a7.7 7.7 0 0 0 0-3.2l2.1-1.7-2-3.4-2.5 1a7.5 7.5 0 0 0-2.8-1.6L13.8 2h-3.6l-.4 2.7a7.5 7.5 0 0 0-2.8 1.6l-2.5-1-2 3.4 2.1 1.7a7.7 7.7 0 0 0 0 3.2l-2.1 1.7 2 3.4 2.5-1a7.5 7.5 0 0 0 2.8 1.6l.4 2.7h3.6l.4-2.7a7.5 7.5 0 0 0 2.8-1.6l2.5 1 2-3.4-2.1-1.7Z" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linejoin="round"/>';
+
+// ── Color groups ──
+export const COLOR_GROUPS = [
+  { id: 'red', label: 'Red', color: '#e94560' },
+  { id: 'blue', label: 'Blue', color: '#74c0fc' },
+  { id: 'green', label: 'Green', color: '#51cf66' },
+  { id: 'yellow', label: 'Yellow', color: '#ffd43b' },
+  { id: 'purple', label: 'Purple', color: '#b197fc' },
+  { id: 'orange', label: 'Orange', color: '#ffa94d' },
+];
+
+// ── Tab disposal ──
+/** Disposable component keys on a WorkspaceTab — drives generic _disposeTab. */
+export const TAB_DISPOSABLES = ['terminalPanel', 'fileViewer', 'fileTree'];
+
+// ── Side-view descriptor table ──
+// Each non-"work" sidebar mode owns a view instance and a container element
+// on the TabManager.  `pauseOnDetach` means the view is kept alive (paused)
+// when switching away, instead of being fully disposed.
+export const SIDE_VIEWS = {
+  board:  { viewKey: 'boardView',  containerKey: '_boardContainerEl', pauseOnDetach: true },
+  flow:   { viewKey: 'flowView',   containerKey: '_flowContainerEl' },
+  skills: { viewKey: 'skillsView', containerKey: '_skillsContainerEl' },
+  usage:  { viewKey: 'usageView',  containerKey: '_usageContainerEl' },
+};

--- a/src/utils/tab-drag.js
+++ b/src/utils/tab-drag.js
@@ -8,7 +8,7 @@
  * @typedef {{ getTabElements: () => Map<string, HTMLElement>, reorderTab: (fromId: string, toId: string, before: boolean) => void }} TabDragDeps
  */
 
-import { DRAG_THRESHOLD } from './tab-manager-helpers.js';
+import { DRAG_THRESHOLD } from './tab-constants.js';
 import { trackMouse, computeInsertionIndex } from './drag-helpers.js';
 
 // ── Internal helpers ────────────────────────────────────────────────

--- a/src/utils/tab-lifecycle.js
+++ b/src/utils/tab-lifecycle.js
@@ -19,7 +19,7 @@ import { generateId } from './id.js';
 import { _el } from './dom.js';
 import { showConfirmDialog } from './dom-dialogs.js';
 import { emitWorkspaceActivated } from './workspace-events.js';
-import { WorkspaceTab } from './tab-manager-helpers.js';
+import { WorkspaceTab } from './tab-types.js';
 import { reattachLayout, syncFileTree } from './workspace-layout.js';
 import { capturePanelWidths } from './workspace-resize.js';
 import { disposeTab } from './workspace-cleanup.js';

--- a/src/utils/tab-manager-helpers.js
+++ b/src/utils/tab-manager-helpers.js
@@ -1,94 +1,17 @@
-// ── Layout constants ──
-export const DRAG_THRESHOLD = 5;
-export const PANEL_MIN_WIDTH = 150;
-export const FIT_DELAY_MS = 200;
-
-// ── Side panel configuration (single source of truth for side-specific limits & arrows) ──
-const SIDE_CONFIG = {
-  left:  { maxWidth: 500,  arrows: { collapsed: '\u2192', expanded: '\u2190' } },
-  right: { maxWidth: 1400, arrows: { collapsed: '\u2190', expanded: '\u2192' } },
-};
-
 /**
- * Workspace side-panel definitions — single source of truth for panel structure,
- * content class, optional header title, and serialization keys.
- * Drives _buildSidePanel, _capturePanelWidths, and _restorePanelSizes in tab-manager.
+ * Tab manager helpers — pure helper functions for tab management.
+ *
+ * Constants have been extracted to ./tab-constants.js
+ * The WorkspaceTab class has been extracted to ./tab-types.js
+ *
+ * This file re-exports everything from both modules for backward compatibility.
  */
-export const WORKSPACE_PANELS = [
-  { side: 'left',  contentCls: 'file-tree',   title: 'Explorer', widthKey: 'leftWidth',  collapsedKey: 'leftCollapsed' },
-  { side: 'right', contentCls: 'file-viewer',                    widthKey: 'rightWidth', collapsedKey: 'rightCollapsed' },
-];
 
-// ── Activity bar buttons ──
-// `icon` uses inline SVG path data, rendered by sidebar-manager.
-export const ACTIVITY_BUTTONS = [
-  {
-    label: 'WORK',
-    mode: 'work',
-    icon: '<rect x="3" y="3" width="7" height="7" rx="1.5"/><rect x="14" y="3" width="7" height="7" rx="1.5"/><rect x="3" y="14" width="7" height="7" rx="1.5"/><rect x="14" y="14" width="7" height="7" rx="1.5"/>',
-  },
-  {
-    label: 'BOARD',
-    mode: 'board',
-    icon: '<rect x="3" y="4" width="18" height="4" rx="1.5"/><rect x="3" y="11" width="18" height="4" rx="1.5"/><rect x="3" y="18" width="18" height="3" rx="1.5"/>',
-  },
-  {
-    label: 'FLOW',
-    mode: 'flow',
-    icon: '<path d="M4 17 L9 12 L13 15 L20 7" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/><circle cx="9" cy="12" r="1.5"/><circle cx="13" cy="15" r="1.5"/>',
-  },
-  {
-    label: 'SKILLS',
-    mode: 'skills',
-    icon: '<path d="M12 2 L3 6 L3 12 C3 16.5 7 20.5 12 22 C17 20.5 21 16.5 21 12 L21 6 Z" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linejoin="round"/><path d="M8 12 L11 15 L16 10" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>',
-  },
-  {
-    label: 'USAGE',
-    mode: 'usage',
-    icon: '<path d="M4 18 L10 12 L14 16 L20 8" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/><path d="M15 8 L20 8 L20 13" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>',
-  },
-];
+import { PANEL_MIN_WIDTH, SIDE_CONFIG } from './tab-constants.js';
 
-export const SETTINGS_ICON = '<path d="M12 8.5a3.5 3.5 0 1 0 0 7 3.5 3.5 0 0 0 0-7Z" fill="none" stroke="currentColor" stroke-width="1.8"/><path d="M19.4 13.6a7.7 7.7 0 0 0 0-3.2l2.1-1.7-2-3.4-2.5 1a7.5 7.5 0 0 0-2.8-1.6L13.8 2h-3.6l-.4 2.7a7.5 7.5 0 0 0-2.8 1.6l-2.5-1-2 3.4 2.1 1.7a7.7 7.7 0 0 0 0 3.2l-2.1 1.7 2 3.4 2.5-1a7.5 7.5 0 0 0 2.8 1.6l.4 2.7h3.6l.4-2.7a7.5 7.5 0 0 0 2.8-1.6l2.5 1 2-3.4-2.1-1.7Z" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linejoin="round"/>';
-
-// ── Color groups ──
-export const COLOR_GROUPS = [
-  { id: 'red', label: 'Red', color: '#e94560' },
-  { id: 'blue', label: 'Blue', color: '#74c0fc' },
-  { id: 'green', label: 'Green', color: '#51cf66' },
-  { id: 'yellow', label: 'Yellow', color: '#ffd43b' },
-  { id: 'purple', label: 'Purple', color: '#b197fc' },
-  { id: 'orange', label: 'Orange', color: '#ffa94d' },
-];
-
-// ── Tab disposal ──
-/** Disposable component keys on a WorkspaceTab — drives generic _disposeTab. */
-export const TAB_DISPOSABLES = ['terminalPanel', 'fileViewer', 'fileTree'];
-
-// ── Pure data model ──
-export class WorkspaceTab {
-  constructor(id, name, cwd) {
-    this.id = id;
-    this.name = name;
-    this.cwd = cwd;
-    this.userNamed = false;
-    this.noShortcut = false;
-    this.colorGroup = null;
-    this.fileTree = null;
-    this.terminalPanel = null;
-    this.fileViewer = null;
-    this.layoutElement = null;
-    this.pathTextEl = null;
-    this.branchBadgeEl = null;
-    this._panelWidths = null;
-    /**
-     * When set, this tab owns a git worktree and should offer cleanup on close.
-     * Shape: { mainRepoCwd: string, worktreePath: string }
-     * @type {{ mainRepoCwd: string, worktreePath: string } | null}
-     */
-    this.worktree = null;
-  }
-}
+// ── Re-exports for backward compatibility ──
+export * from './tab-constants.js';
+export * from './tab-types.js';
 
 // ── Pure helpers ──
 
@@ -131,17 +54,6 @@ export function findCycleTarget(tabs, activeTabId, step) {
   }
   return null;
 }
-
-// ── Side-view descriptor table ──
-// Each non-"work" sidebar mode owns a view instance and a container element
-// on the TabManager.  `pauseOnDetach` means the view is kept alive (paused)
-// when switching away, instead of being fully disposed.
-export const SIDE_VIEWS = {
-  board:  { viewKey: 'boardView',  containerKey: '_boardContainerEl', pauseOnDetach: true },
-  flow:   { viewKey: 'flowView',   containerKey: '_flowContainerEl' },
-  skills: { viewKey: 'skillsView', containerKey: '_skillsContainerEl' },
-  usage:  { viewKey: 'usageView',  containerKey: '_usageContainerEl' },
-};
 
 /** Find the next tab in a given color group (round-robin from current position). */
 export function findColorGroupTarget(tabs, activeTabId, colorGroupId) {

--- a/src/utils/tab-manager-init.js
+++ b/src/utils/tab-manager-init.js
@@ -62,7 +62,7 @@ export async function initTabManager(deps) {
 // ── Bus listeners ──
 
 /**
- * @typedef {{ tabs: Map<string, import('./tab-manager-helpers.js').WorkspaceTab>, getActiveTabId: () => string|null, configManager: { scheduleAutoSave: () => void }, createTab: (name: string, cwd: string) => import('./tab-manager-helpers.js').WorkspaceTab, renderTabBar: () => void, api: { gitBranch: (cwd: string) => Promise<string|null>, worktree: import('./worktree-flow.js').GitWorktreeApi, pr: import('./open-pr-flow.js').OpenPrApi } }} BusListenerDeps
+ * @typedef {{ tabs: Map<string, import('./tab-types.js').WorkspaceTab>, getActiveTabId: () => string|null, configManager: { scheduleAutoSave: () => void }, createTab: (name: string, cwd: string) => import('./tab-types.js').WorkspaceTab, renderTabBar: () => void, api: { gitBranch: (cwd: string) => Promise<string|null>, worktree: import('./worktree-flow.js').GitWorktreeApi, pr: import('./open-pr-flow.js').OpenPrApi } }} BusListenerDeps
  */
 
 /**

--- a/src/utils/tab-navigation.js
+++ b/src/utils/tab-navigation.js
@@ -9,7 +9,7 @@ import { findCycleTarget, findColorGroupTarget } from './tab-manager-helpers.js'
 
 /**
  * Switch to the next tab in the cycle.
- * @param {Map<string, import('./tab-manager-helpers.js').WorkspaceTab>} tabs
+ * @param {Map<string, import('./tab-types.js').WorkspaceTab>} tabs
  * @param {string|null} activeTabId
  * @param {(id: string) => void} switchTo
  */
@@ -20,7 +20,7 @@ export function nextTab(tabs, activeTabId, switchTo) {
 
 /**
  * Switch to the previous tab in the cycle.
- * @param {Map<string, import('./tab-manager-helpers.js').WorkspaceTab>} tabs
+ * @param {Map<string, import('./tab-types.js').WorkspaceTab>} tabs
  * @param {string|null} activeTabId
  * @param {(id: string) => void} switchTo
  */
@@ -31,7 +31,7 @@ export function prevTab(tabs, activeTabId, switchTo) {
 
 /**
  * Navigate to the next tab in a given color group (round-robin).
- * @param {Map<string, import('./tab-manager-helpers.js').WorkspaceTab>} tabs
+ * @param {Map<string, import('./tab-types.js').WorkspaceTab>} tabs
  * @param {string|null} activeTabId
  * @param {string} colorGroupId
  * @param {(id: string) => void} switchTo
@@ -46,7 +46,7 @@ export function goToColorGroup(tabs, activeTabId, colorGroupId, switchTo) {
  * @param {string} direction
  * @param {string} sidebarMode
  * @param {object|null} boardView
- * @param {() => import('./tab-manager-helpers.js').WorkspaceTab|undefined} getActiveTab
+ * @param {() => import('./tab-types.js').WorkspaceTab|undefined} getActiveTab
  */
 export function focusDirection(direction, sidebarMode, boardView, getActiveTab) {
   if (sidebarMode === 'board' && boardView) {
@@ -58,7 +58,7 @@ export function focusDirection(direction, sidebarMode, boardView, getActiveTab) 
 
 /**
  * Set or clear a tab's color group.
- * @param {Map<string, import('./tab-manager-helpers.js').WorkspaceTab>} tabs
+ * @param {Map<string, import('./tab-types.js').WorkspaceTab>} tabs
  * @param {string} id
  * @param {string|null} colorGroupId
  * @param {() => void} renderTabBar
@@ -74,7 +74,7 @@ export function setTabColorGroup(tabs, id, colorGroupId, renderTabBar, configMan
 
 /**
  * Toggle the noShortcut flag on a tab.
- * @param {Map<string, import('./tab-manager-helpers.js').WorkspaceTab>} tabs
+ * @param {Map<string, import('./tab-types.js').WorkspaceTab>} tabs
  * @param {string} id
  * @param {() => void} renderTabBar
  * @param {{ scheduleAutoSave: () => void }} configManager

--- a/src/utils/tab-renderer.js
+++ b/src/utils/tab-renderer.js
@@ -5,11 +5,11 @@
  * Functions receive explicit dependency objects instead of the full
  * TabManager instance.
  *
- * @typedef {{ activeTabId: string|null, tabs: Map<string, import('./tab-manager-helpers.js').WorkspaceTab>, switchTo: (id: string) => void, closeTab: (id: string) => void, renameTab: (id: string, nameEl: HTMLElement) => void, setTabColorGroup: (id: string, colorGroupId: string|null) => void, toggleNoShortcut: (id: string) => void, dragDeps: import('./tab-drag.js').TabDragDeps }} TabElementDeps
+ * @typedef {{ activeTabId: string|null, tabs: Map<string, import('./tab-types.js').WorkspaceTab>, switchTo: (id: string) => void, closeTab: (id: string) => void, renameTab: (id: string, nameEl: HTMLElement) => void, setTabColorGroup: (id: string, colorGroupId: string|null) => void, toggleNoShortcut: (id: string) => void, dragDeps: import('./tab-drag.js').TabDragDeps }} TabElementDeps
  */
 import { _el, buildChevronRow } from './dom.js';
 import { startInlineRename } from './form-helpers.js';
-import { COLOR_GROUPS } from './tab-manager-helpers.js';
+import { COLOR_GROUPS } from './tab-constants.js';
 import { setupTabDrag } from './tab-drag.js';
 import { attachContextMenu } from './context-menu.js';
 import { onClickStopped } from './event-helpers.js';
@@ -71,7 +71,7 @@ export function createTabElement(config) {
  * Build a single tab DOM element.
  * @param {TabElementDeps} deps
  * @param {string} id
- * @param {import('./tab-manager-helpers.js').WorkspaceTab} tab
+ * @param {import('./tab-types.js').WorkspaceTab} tab
  */
 export function buildTabElement(deps, id, tab) {
   const isActive = id === deps.activeTabId;
@@ -120,7 +120,7 @@ export function buildTabElement(deps, id, tab) {
  * @param {TabElementDeps} deps
  * @param {HTMLElement} tabEl
  * @param {string} id
- * @param {import('./tab-manager-helpers.js').WorkspaceTab} tab
+ * @param {import('./tab-types.js').WorkspaceTab} tab
  * @param {HTMLElement} nameEl
  */
 function bindTabContextMenu(deps, tabEl, id, tab, nameEl) {
@@ -149,7 +149,7 @@ function bindTabContextMenu(deps, tabEl, id, tab, nameEl) {
 
 /**
  * Inline rename a tab.
- * @param {import('./tab-manager-helpers.js').WorkspaceTab} tab
+ * @param {import('./tab-types.js').WorkspaceTab} tab
  * @param {HTMLElement} nameEl
  * @param {() => void} onCommit - callback after successful rename (re-render + save)
  * @param {() => void} onCancel - callback on cancel (re-render only, no save)

--- a/src/utils/tab-types.js
+++ b/src/utils/tab-types.js
@@ -1,0 +1,30 @@
+/**
+ * Tab type definitions — JSDoc typedefs extracted from tab-manager-helpers.js.
+ *
+ * This file is the canonical home of the WorkspaceTab class.
+ */
+
+// ── Pure data model ──
+export class WorkspaceTab {
+  constructor(id, name, cwd) {
+    this.id = id;
+    this.name = name;
+    this.cwd = cwd;
+    this.userNamed = false;
+    this.noShortcut = false;
+    this.colorGroup = null;
+    this.fileTree = null;
+    this.terminalPanel = null;
+    this.fileViewer = null;
+    this.layoutElement = null;
+    this.pathTextEl = null;
+    this.branchBadgeEl = null;
+    this._panelWidths = null;
+    /**
+     * When set, this tab owns a git worktree and should offer cleanup on close.
+     * Shape: { mainRepoCwd: string, worktreePath: string }
+     * @type {{ mainRepoCwd: string, worktreePath: string } | null}
+     */
+    this.worktree = null;
+  }
+}

--- a/src/utils/workspace-cleanup.js
+++ b/src/utils/workspace-cleanup.js
@@ -4,10 +4,10 @@
  * Extracted from workspace-layout.js to break the circular dependency
  * between workspace-layout.js and workspace-serializer.js (issue #94).
  *
- * @typedef {{ tabs: Map<string, import('./tab-manager-helpers.js').WorkspaceTab>, setActiveTabId: (id: string|null) => void }} DisposeAllTabsDeps
+ * @typedef {{ tabs: Map<string, import('./tab-types.js').WorkspaceTab>, setActiveTabId: (id: string|null) => void }} DisposeAllTabsDeps
  */
 
-import { TAB_DISPOSABLES } from './tab-manager-helpers.js';
+import { TAB_DISPOSABLES } from './tab-constants.js';
 import { disposeResources } from './disposable.js';
 
 // ── Tab disposal ──
@@ -15,7 +15,7 @@ import { disposeResources } from './disposable.js';
 /**
  * Dispose a single tab — call dispose() on all disposable sub-components
  * and remove the layout element from the DOM.
- * @param {import('./tab-manager-helpers.js').WorkspaceTab} tab
+ * @param {import('./tab-types.js').WorkspaceTab} tab
  */
 export function disposeTab(tab) {
   disposeResources([

--- a/src/utils/workspace-layout.js
+++ b/src/utils/workspace-layout.js
@@ -5,7 +5,7 @@
  * Resize logic lives in workspace-resize.js.
  * Serialization logic lives in workspace-serializer.js.
  *
- * @typedef {{ workspaceContainer: HTMLElement, getActiveTabId: () => string|null, getActiveTab: () => import('./tab-manager-helpers.js').WorkspaceTab|null, scheduleAutoSave: () => void }} RenderWorkspaceDeps
+ * @typedef {{ workspaceContainer: HTMLElement, getActiveTabId: () => string|null, getActiveTab: () => import('./tab-types.js').WorkspaceTab|null, scheduleAutoSave: () => void }} RenderWorkspaceDeps
  *
  * Tab disposal logic lives in workspace-cleanup.js.
  */
@@ -13,7 +13,7 @@
 import { getComponent } from './component-registry.js';
 import { emitWorkspaceActivated } from './workspace-events.js';
 import { _el } from './dom.js';
-import { WORKSPACE_PANELS } from './tab-manager-helpers.js';
+import { WORKSPACE_PANELS } from './tab-constants.js';
 import {
   buildSidePanel, buildCenterPanel,
   capturePanelWidths, restorePanelSizes,
@@ -27,7 +27,7 @@ import {
 /**
  * Instantiate tab sub-components and restore saved state if present.
  *
- * @param {import('./tab-manager-helpers.js').WorkspaceTab} tab
+ * @param {import('./tab-types.js').WorkspaceTab} tab
  * @param {HTMLElement} layout
  * @param {{ left: { content: HTMLElement, panel: HTMLElement }, right: { content: HTMLElement, panel: HTMLElement } }} sides
  * @param {HTMLElement} termContainer
@@ -61,7 +61,7 @@ function _initTabComponents(tab, layout, sides, termContainer, getActiveTabId) {
 /**
  * Render the full workspace layout for a tab.
  * @param {RenderWorkspaceDeps} deps
- * @param {import('./tab-manager-helpers.js').WorkspaceTab} tab
+ * @param {import('./tab-types.js').WorkspaceTab} tab
  * @param {{ gitBranch: (cwd: string) => Promise<string> }} api - injected API methods
  */
 export async function renderWorkspace({ workspaceContainer, getActiveTabId, getActiveTab, scheduleAutoSave }, tab, { gitBranch }) {
@@ -99,7 +99,7 @@ export async function renderWorkspace({ workspaceContainer, getActiveTabId, getA
 /**
  * Re-attach a tab's existing layout element to the workspace container.
  * @param {{ workspaceContainer: HTMLElement }} deps
- * @param {import('./tab-manager-helpers.js').WorkspaceTab} tab
+ * @param {import('./tab-types.js').WorkspaceTab} tab
  */
 export function reattachLayout({ workspaceContainer }, tab) {
   workspaceContainer.replaceChildren();
@@ -115,7 +115,7 @@ export function reattachLayout({ workspaceContainer }, tab) {
 /**
  * Synchronize a tab's file tree with its terminal panel, removing stale
  * entries and updating roots for all active terminals.
- * @param {import('./tab-manager-helpers.js').WorkspaceTab} tab
+ * @param {import('./tab-types.js').WorkspaceTab} tab
  */
 export function syncFileTree(tab) {
   if (tab.fileTree && tab.terminalPanel) {

--- a/src/utils/workspace-resize.js
+++ b/src/utils/workspace-resize.js
@@ -3,16 +3,13 @@
  *
  * Handles panel resize interactions and panel toggle (collapse/expand).
  *
- * @typedef {{ getActiveTab: () => import('./tab-manager-helpers.js').WorkspaceTab|null, scheduleAutoSave: () => void }} PanelInteractionDeps
+ * @typedef {{ getActiveTab: () => import('./tab-types.js').WorkspaceTab|null, scheduleAutoSave: () => void }} PanelInteractionDeps
  */
 
 import { _el } from './dom.js';
 import { trackMouse } from './drag-helpers.js';
-import {
-  PANEL_MIN_WIDTH, FIT_DELAY_MS,
-  WORKSPACE_PANELS,
-  clampPanelWidth, panelArrowState,
-} from './tab-manager-helpers.js';
+import { PANEL_MIN_WIDTH, FIT_DELAY_MS, WORKSPACE_PANELS } from './tab-constants.js';
+import { clampPanelWidth, panelArrowState } from './tab-manager-helpers.js';
 
 // ── Panel building ──
 
@@ -38,7 +35,7 @@ export function buildSidePanel(deps, { side, contentCls, title }) {
 /**
  * Build the center panel with path info, branch badge, and terminal area.
  * @param {PanelInteractionDeps} deps
- * @param {import('./tab-manager-helpers.js').WorkspaceTab} tab
+ * @param {import('./tab-types.js').WorkspaceTab} tab
  * @param {HTMLElement} leftPanel
  * @param {HTMLElement} rightPanel
  */
@@ -131,7 +128,7 @@ function togglePanel({ getActiveTab, scheduleAutoSave }, panel, side, arrowEl) {
 
 /**
  * Snapshot current panel widths and collapsed state into `tab._panelWidths`.
- * @param {import('./tab-manager-helpers.js').WorkspaceTab} tab
+ * @param {import('./tab-types.js').WorkspaceTab} tab
  */
 export function capturePanelWidths(tab) {
   if (!tab.layoutElement) return;

--- a/src/utils/workspace-serializer.js
+++ b/src/utils/workspace-serializer.js
@@ -11,7 +11,7 @@
  */
 
 import { generateId } from './id.js';
-import { WorkspaceTab } from './tab-manager-helpers.js';
+import { WorkspaceTab } from './tab-types.js';
 import { disposeAllSideViews } from './sidebar-manager.js';
 import { capturePanelWidths } from './workspace-resize.js';
 import { disposeAllTabs } from './workspace-cleanup.js';

--- a/src/utils/worktree-flow.js
+++ b/src/utils/worktree-flow.js
@@ -35,7 +35,7 @@ function _availableBranches(allBranches, worktrees) {
 /**
  * Drive the "create a worktree from a repo folder" flow end-to-end.
  *
- * @param {{ repoCwd: string, api: GitWorktreeApi, createTab: (name: string, cwd: string) => import('./tab-manager-helpers.js').WorkspaceTab }} opts
+ * @param {{ repoCwd: string, api: GitWorktreeApi, createTab: (name: string, cwd: string) => import('./tab-types.js').WorkspaceTab }} opts
  * @returns {Promise<void>}
  */
 export async function createWorktreeFlow({ repoCwd, api, createTab }) {

--- a/tests/utils/di-injection-workspace.test.js
+++ b/tests/utils/di-injection-workspace.test.js
@@ -18,7 +18,7 @@ describe('DI: tab-lifecycle onTerminalCwdChanged', () => {
     }));
     vi.doMock('../../src/utils/events.js', () => ({ bus: { emit: vi.fn(), on: vi.fn() } }));
     vi.doMock('../../src/utils/id.js', () => ({ generateId: (prefix) => prefix + '-1' }));
-    vi.doMock('../../src/utils/tab-manager-helpers.js', () => ({
+    vi.doMock('../../src/utils/tab-types.js', () => ({
       WorkspaceTab: class { constructor(id, name, cwd) { this.id = id; this.name = name; this.cwd = cwd; } },
     }));
     vi.doMock('../../src/utils/workspace-layout.js', () => ({


### PR DESCRIPTION
## Refactoring

Extraction des constantes et typedefs de `tab-manager-helpers.js` vers des fichiers dedies (`tab-constants.js`, `tab-types.js`). Mise a jour des imports dans les 17 fichiers consommateurs pour reduire le couplage.

Closes #260

## Fichier(s) modifie(s)

- `src/utils/tab-constants.js` (nouveau) — constantes extraites (DRAG_THRESHOLD, PANEL_MIN_WIDTH, FIT_DELAY_MS, SIDE_CONFIG, WORKSPACE_PANELS, ACTIVITY_BUTTONS, SETTINGS_ICON, COLOR_GROUPS, TAB_DISPOSABLES, SIDE_VIEWS)
- `src/utils/tab-types.js` (nouveau) — classe WorkspaceTab
- `src/utils/tab-manager-helpers.js` — conserve les helpers purs + re-exporte tout pour compatibilite
- `src/utils/shortcut-helpers.js` — import depuis tab-constants
- `src/utils/tab-color-filter.js` — import depuis tab-constants
- `src/utils/tab-drag.js` — import depuis tab-constants
- `src/utils/tab-renderer.js` — import depuis tab-constants
- `src/utils/sidebar-manager.js` — import depuis tab-constants
- `src/utils/workspace-cleanup.js` — import depuis tab-constants
- `src/utils/workspace-layout.js` — import depuis tab-constants
- `src/utils/workspace-resize.js` — imports splits (constants + helpers)
- `src/utils/tab-lifecycle.js` — import WorkspaceTab depuis tab-types
- `src/utils/workspace-serializer.js` — import WorkspaceTab depuis tab-types
- `src/utils/tab-navigation.js` — JSDoc refs mis a jour
- `src/utils/tab-bar-renderer.js` — JSDoc refs mis a jour
- `src/utils/tab-manager-init.js` — JSDoc refs mis a jour
- `src/utils/board-helpers.js` — JSDoc refs mis a jour
- `src/utils/worktree-flow.js` — JSDoc refs mis a jour
- `tests/utils/di-injection-workspace.test.js` — mock mis a jour

## Verifications

- [x] Build OK
- [x] Tests OK (25 fichiers, 370 tests)

---

Path local : `/Users/rekta/projet/coding/refactor-pikagent`
PR creee automatiquement par l'Agent Refactor