### PR TITLE
refactor: factoriser les patterns drag state et cycle navigation

### DIFF
--- a/src/utils/drag-helpers.js
+++ b/src/utils/drag-helpers.js
@@ -45,6 +45,37 @@ export function trackMouse(cursor, onMove, onDone, { bodyClass = 'resizing' } = 
 }
 
 /**
+ * Build dragstart / dragend handlers that toggle a CSS class on the element
+ * and set / clear a key on a shared state object.
+ *
+ * This extracts the repeated pattern found in flow-card-setup and tab-drag:
+ *   dragstart → element.classList.add(dragClass), stateObj[stateKey] = value
+ *   dragend   → element.classList.remove(dragClass), stateObj[stateKey] = null
+ *
+ * @param {HTMLElement} element   — the draggable element
+ * @param {string} dragClass     — CSS class toggled during the drag
+ * @param {Record<string, unknown>} stateObj — mutable state object
+ * @param {string} stateKey      — key to set on stateObj
+ * @param {unknown} value        — value written at dragstart (cleared to null at dragend)
+ * @param {{ onStart?: (e: DragEvent) => void, onEnd?: (e: DragEvent) => void }} [extras]
+ *        — optional extra work to run after the class/state bookkeeping
+ * @returns {{ onDragStart: (e: DragEvent) => void, onDragEnd: (e: DragEvent) => void }}
+ */
+export function setupSimpleDragState(element, dragClass, stateObj, stateKey, value, { onStart, onEnd } = {}) {
+  const onDragStart = (e) => {
+    stateObj[stateKey] = value;
+    element.classList.add(dragClass);
+    if (onStart) onStart(e);
+  };
+  const onDragEnd = (e) => {
+    element.classList.remove(dragClass);
+    stateObj[stateKey] = null;
+    if (onEnd) onEnd(e);
+  };
+  return { onDragStart, onDragEnd };
+}
+
+/**
  * Compute the insertion index for a drag-and-drop operation by comparing
  * the cursor position to the midpoints of the container's child elements.
  *

--- a/src/utils/flow-card-setup.js
+++ b/src/utils/flow-card-setup.js
@@ -13,6 +13,7 @@ import { getLastRun, toggleInSet } from './flow-view-helpers.js';
 import { cleanupAllDragState } from './flow-category-renderer.js';
 import { createCardHeader } from './flow-card-renderer.js';
 import { onDragEvents } from './event-helpers.js';
+import { setupSimpleDragState } from './drag-helpers.js';
 
 /**
  * Attach dragstart / dragend handlers to a flow card element.
@@ -23,21 +24,20 @@ import { onDragEvents } from './event-helpers.js';
  * @param {{ flowId: string|null, catId: string|null }} dragState - mutable drag state object
  */
 export function setupCardDrag(card, flowId, catId, dragState) {
-  onDragEvents(card, {
-    onDragStart: (e) => {
-      dragState.flowId = flowId;
-      dragState.catId = catId;
-      card.classList.add('flow-dragging');
-      e.dataTransfer.effectAllowed = 'move';
-      e.dataTransfer.setData('text/plain', flowId);
+  const { onDragStart: startFlow, onDragEnd: endFlow } = setupSimpleDragState(
+    card, 'flow-dragging', dragState, 'flowId', flowId, {
+      onStart: (e) => {
+        dragState.catId = catId;
+        e.dataTransfer.effectAllowed = 'move';
+        e.dataTransfer.setData('text/plain', flowId);
+      },
+      onEnd: () => {
+        dragState.catId = null;
+        cleanupAllDragState();
+      },
     },
-    onDragEnd: () => {
-      card.classList.remove('flow-dragging');
-      dragState.flowId = null;
-      dragState.catId = null;
-      cleanupAllDragState();
-    },
-  });
+  );
+  onDragEvents(card, { onDragStart: startFlow, onDragEnd: endFlow });
 }
 
 /**

--- a/src/utils/tab-drag.js
+++ b/src/utils/tab-drag.js
@@ -9,7 +9,7 @@
  */
 
 import { DRAG_THRESHOLD } from './tab-constants.js';
-import { trackMouse, computeInsertionIndex } from './drag-helpers.js';
+import { trackMouse, computeInsertionIndex, setupSimpleDragState } from './drag-helpers.js';
 
 // ── Internal helpers ────────────────────────────────────────────────
 
@@ -116,17 +116,10 @@ function initDragState() {
 }
 
 /**
- * Apply visual drag-start effects: add CSS class and create a floating
- * ghost clone of the tab element.
- *
- * Body cursor/userSelect are managed by trackMouse() — not set here.
- *
+ * Create a floating ghost clone of the tab element.
  * @returns {HTMLElement} the ghost element appended to document.body
  */
-function handleDragStart(tabEl) {
-  tabEl.classList.add('tab-dragging');
-
-  // Create floating ghost clone
+function createTabGhost(tabEl) {
   const ghost = tabEl.cloneNode(true);
   ghost.className = 'tab tab-ghost';
   if (tabEl.classList.contains('active')) ghost.classList.add('active');
@@ -135,32 +128,45 @@ function handleDragStart(tabEl) {
   ghost.style.height = `${r.height}px`;
   ghost.style.top = `${r.top}px`;
   document.body.appendChild(ghost);
-
   return ghost;
 }
 
 /**
- * Clean up after a drag operation: remove visual effects, commit the
- * reorder if the tab was dropped on a valid target, and reset state.
+ * Build the paired start / end helpers for a tab drag using the shared
+ * setupSimpleDragState pattern (class toggle + state bookkeeping).
  *
- * Body cursor/userSelect are cleared by trackMouse() — not here.
+ * Body cursor/userSelect are managed by trackMouse() — not set here.
  *
  * @param {TabDragDeps} deps
  * @param {HTMLElement} tabEl
- * @param {HTMLElement|null} ghost
  * @param {{ dropTargetId: string|null, dropBefore: boolean|null }} state
  * @param {string} tabId
+ * @returns {{ startDrag: () => HTMLElement, endDrag: (ghost: HTMLElement|null) => void }}
  */
-function handleDragEnd({ getTabElements, reorderTab }, tabEl, ghost, state, tabId) {
-  tabEl.classList.remove('tab-dragging');
-  if (ghost) { ghost.remove(); }
-  clearTabShifts(getTabElements);
+function buildTabDragHandlers(deps, tabEl, state, tabId) {
+  const { getTabElements, reorderTab } = deps;
 
-  if (state.dropTargetId && state.dropTargetId !== tabId) {
-    reorderTab(tabId, state.dropTargetId, state.dropBefore);
-  }
-  state.dropTargetId = null;
-  state.dropBefore = null;
+  const { onDragStart, onDragEnd } = setupSimpleDragState(
+    tabEl, 'tab-dragging', state, 'dropTargetId', null, {
+      onEnd: () => { state.dropBefore = null; },
+    },
+  );
+
+  return {
+    startDrag() {
+      onDragStart(/** @type {any} */ ({}));
+      return createTabGhost(tabEl);
+    },
+    endDrag(ghost) {
+      if (ghost) { ghost.remove(); }
+      clearTabShifts(getTabElements);
+
+      if (state.dropTargetId && state.dropTargetId !== tabId) {
+        reorderTab(tabId, state.dropTargetId, state.dropBefore);
+      }
+      onDragEnd(/** @type {any} */ ({}));
+    },
+  };
 }
 
 // ── Public API ──────────────────────────────────────────────────────
@@ -170,8 +176,9 @@ function handleDragEnd({ getTabElements, reorderTab }, tabEl, ghost, state, tabI
  * @internal
  */
 function activateDrag(deps, tabEl, tabId, state, ctx, ev) {
-  const { getTabElements, reorderTab } = deps;
-  ctx.ghost = handleDragStart(tabEl);
+  const { getTabElements } = deps;
+  const { startDrag, endDrag } = buildTabDragHandlers(deps, tabEl, state, tabId);
+  ctx.ghost = startDrag();
   ctx.ghost.style.left = `${ev.clientX - ctx.offsetX}px`;
   updateTabDropTarget(getTabElements, state, ev.clientX, tabId);
 
@@ -181,7 +188,7 @@ function activateDrag(deps, tabEl, tabId, state, ctx, ev) {
       updateTabDropTarget(getTabElements, state, mv.clientX, tabId);
     },
     () => {
-      handleDragEnd(deps, tabEl, ctx.ghost, state, tabId);
+      endDrag(ctx.ghost);
       ctx.ghost = null;
     },
     { bodyClass: 'dragging' },

--- a/src/utils/tab-manager-helpers.js
+++ b/src/utils/tab-manager-helpers.js
@@ -39,30 +39,48 @@ export function reorderEntries(entries, fromId, toId, before) {
   return copy;
 }
 
+/**
+ * Walk an array starting from `startIdx`, stepping by `step` (wrapping around),
+ * and return the first element that satisfies `predicate`.
+ *
+ * Shared by findCycleTarget and findColorGroupTarget to eliminate the duplicated
+ * round-robin loop pattern.
+ *
+ * @template T
+ * @param {T[]} items      — the array to walk
+ * @param {number} startIdx — starting index (the current / active position)
+ * @param {number} step     — direction: +1 or -1
+ * @param {(item: T) => boolean} predicate — return true for a match
+ * @returns {T|null} the first matching item, or null if none found
+ */
+export function findCycleMatch(items, startIdx, step, predicate) {
+  const len = items.length;
+  for (let i = 1; i < len; i++) {
+    const item = items[(startIdx + step * i + len) % len];
+    if (predicate(item)) return item;
+  }
+  return null;
+}
+
 /** Find the next tab id to cycle to (skipping noShortcut and mismatched color groups). */
 export function findCycleTarget(tabs, activeTabId, step) {
   const ids = Array.from(tabs.keys());
   if (ids.length < 2) return null;
   const idx = ids.indexOf(activeTabId);
   const activeColor = tabs.get(activeTabId)?.colorGroup ?? null;
-  for (let i = 1; i < ids.length; i++) {
-    const candidate = ids[(idx + step * i + ids.length) % ids.length];
+  return findCycleMatch(ids, idx, step, (candidate) => {
     const tab = tabs.get(candidate);
-    if (tab.noShortcut) continue;
-    if ((tab.colorGroup ?? null) !== activeColor) continue;
-    return candidate;
-  }
-  return null;
+    if (tab.noShortcut) return false;
+    return (tab.colorGroup ?? null) === activeColor;
+  });
 }
 
 /** Find the next tab in a given color group (round-robin from current position). */
 export function findColorGroupTarget(tabs, activeTabId, colorGroupId) {
   const ids = Array.from(tabs.keys());
   const currentIdx = ids.indexOf(activeTabId);
-  for (let i = 1; i <= ids.length; i++) {
-    const candidate = ids[(currentIdx + i) % ids.length];
+  return findCycleMatch(ids, currentIdx, 1, (candidate) => {
     const tab = tabs.get(candidate);
-    if (tab.colorGroup === colorGroupId && !tab.noShortcut) return candidate;
-  }
-  return null;
+    return tab.colorGroup === colorGroupId && !tab.noShortcut;
+  });
 }


### PR DESCRIPTION
## Refactoring

1. Extraction d'un helper `setupSimpleDragState` dans `drag-helpers.js` pour factoriser le pattern dragstart/dragend (toggle CSS class + update state object) dans 2 fichiers.
2. Extraction d'un helper `findCycleMatch` dans `tab-manager-helpers.js` pour factoriser la logique de parcours cyclique (round-robin) utilisée par `findCycleTarget` et `findColorGroupTarget`.

Closes #264

## Fichier(s) modifié(s)

- `src/utils/drag-helpers.js` — ajout de `setupSimpleDragState`
- `src/utils/flow-card-setup.js` — refactoring de `setupCardDrag` pour utiliser `setupSimpleDragState`
- `src/utils/tab-drag.js` — refactoring de `handleDragStart`/`handleDragEnd` en `buildTabDragHandlers` utilisant `setupSimpleDragState`
- `src/utils/tab-manager-helpers.js` — ajout de `findCycleMatch`, refactoring de `findCycleTarget` et `findColorGroupTarget`

## Vérifications

- [x] Build OK
- [x] Tests OK (25 fichiers, 368 tests)

---

📂 Path local : `/Users/rekta/projet/coding/refactor-pikagent`
🤖 PR créée automatiquement par l'Agent Refactor