### PR TITLE
refactor: remove dead ipcHandlers.cleanup() call

### DIFF
--- a/main.js
+++ b/main.js
@@ -26,6 +26,3 @@ app.on('window-all-closed', () => {
   if (process.platform !== 'darwin') app.quit();
 });
 
-app.on('before-quit', () => {
-  ipcHandlers.cleanup();
-});


### PR DESCRIPTION
## Refactoring

Suppression de l'appel `ipcHandlers.cleanup()` dans `main.js` qui référençait une fonction inexistante dans `ipc-handlers.js`. Ce module n'exporte que `{ register }`, donc l'appel provoquait un TypeError silencieux à chaque fermeture de l'application.

Closes #273

## Fichier(s) modifié(s)

- `main.js`

## Vérifications

- [x] Build OK
- [x] Tests OK

---

📂 Path local : `/Users/rekta/projet/coding/refactor-pikagent`
🤖 PR créée automatiquement par l'Agent Refactor