### PR TITLE
refactor: replace duplicate utils in skills-manager

### DIFF
--- a/main/fs-manager-helpers.js
+++ b/main/fs-manager-helpers.js
@@ -67,4 +67,4 @@ function dirFirstCompare(a, b) {
   return a.name.localeCompare(b.name);
 }
 
-module.exports = { MAX_FILE_SIZE, wrapSafe, doCopy, dirFirstCompare };
+module.exports = { MAX_FILE_SIZE, wrapSafe, pathExists, doCopy, dirFirstCompare };

--- a/main/skills-manager.js
+++ b/main/skills-manager.js
@@ -5,6 +5,7 @@ const os = require('os');
 const { BASE_DIR } = require('./paths');
 const { readJson, writeJson, ensureDirOnce } = require('./fs-utils');
 const { createLogger, trySafe } = require('./logger');
+const { pathExists } = require('./fs-manager-helpers');
 
 const log = createLogger('skills-manager');
 
@@ -135,11 +136,11 @@ async function importFrom(srcDir) {
     let destName = baseName;
     let destDir = path.join(root, destName);
     let i = 1;
-    while (await _exists(destDir)) {
+    while (await pathExists(destDir)) {
       destName = `${baseName}-${i++}`;
       destDir = path.join(root, destName);
     }
-    await _copyRecursive(srcDir, destDir);
+    await fsp.cp(srcDir, destDir, { recursive: true });
     return { success: true, id: destName, path: path.join(destDir, 'SKILL.md') };
   }, { success: false, error: 'Import failed' }, { log, label: 'importFrom' });
 }
@@ -172,20 +173,6 @@ async function _isAllowedPath(p) {
   const root = path.resolve(await _loadRoot());
   const resolved = path.resolve(p);
   return resolved === root || resolved.startsWith(root + path.sep);
-}
-
-async function _exists(p) {
-  try { await fsp.access(p); return true; } catch { return false; }
-}
-
-async function _copyRecursive(src, dest) {
-  await fsp.mkdir(dest, { recursive: true });
-  for (const entry of await fsp.readdir(src, { withFileTypes: true })) {
-    const srcPath = path.join(src, entry.name);
-    const destPath = path.join(dest, entry.name);
-    if (entry.isDirectory()) await _copyRecursive(srcPath, destPath);
-    else if (entry.isFile()) await fsp.copyFile(srcPath, destPath);
-  }
 }
 
 module.exports = {


### PR DESCRIPTION
## Refactoring

Remplacement de `_exists()` et `_copyRecursive()` dans `skills-manager.js` par les équivalents existants :
- `_exists(p)` → `pathExists(p)` depuis `fs-manager-helpers.js`
- `_copyRecursive(src, dest)` → `fsp.cp(src, dest, { recursive: true })`

Closes #274

## Fichier(s) modifié(s)

- `main/skills-manager.js`
- `main/fs-manager-helpers.js` (export ajouté pour `pathExists`)

## Vérifications

- [x] Build OK
- [x] Tests OK (25 fichiers, 372 tests)

---

📂 Path local : `/Users/rekta/projet/coding/refactor-pikagent`
🤖 PR créée automatiquement par l'Agent Refactor