### PR TITLE
refactor: extract showErrorAlert helper

### DIFF
--- a/src/utils/dom-dialogs.js
+++ b/src/utils/dom-dialogs.js
@@ -120,3 +120,18 @@ export function showConfirmDialog(message, { confirmLabel = 'OK', cancelLabel = 
     },
   });
 }
+
+/**
+ * Show a simple error alert with a prefix message and an error value in a <code> block.
+ * Factorises the common pattern found in worktree and PR flows.
+ *
+ * @param {string} prefix - human-readable context, e.g. "Push failed: "
+ * @param {string|null|undefined} error - error detail shown inside <code>
+ * @returns {Promise<boolean>}
+ */
+export async function showErrorAlert(prefix, error) {
+  return showConfirmDialog(
+    _el('p', null, prefix, _el('code', null, error || 'unknown error')),
+    { confirmLabel: 'OK', cancelLabel: 'Close' },
+  );
+}

--- a/src/utils/open-pr-flow.js
+++ b/src/utils/open-pr-flow.js
@@ -6,7 +6,7 @@
  * directly on the "Create pull request" form.
  */
 
-import { showConfirmDialog } from './dom-dialogs.js';
+import { showConfirmDialog, showErrorAlert } from './dom-dialogs.js';
 import { _el } from './dom.js';
 
 /**
@@ -130,7 +130,7 @@ export async function openPrFlow({ cwd, baseBranch = null, api }) {
   const [branch, remote] = await Promise.all([api.branch(cwd), api.remoteUrl(cwd)]);
 
   if (!branch) {
-    await _alert(_el('p', null, 'No git branch detected in ', _el('code', null, cwd)));
+    await showErrorAlert('No git branch detected in ', cwd);
     return;
   }
   if (!remote) {
@@ -140,7 +140,7 @@ export async function openPrFlow({ cwd, baseBranch = null, api }) {
 
   const parsed = parseRemoteUrl(remote);
   if (!parsed) {
-    await _alert(_el('p', null, 'Could not parse remote URL: ', _el('code', null, remote)));
+    await showErrorAlert('Could not parse remote URL: ', remote);
     return;
   }
 
@@ -151,7 +151,7 @@ export async function openPrFlow({ cwd, baseBranch = null, api }) {
 
   const url = buildPrUrl(parsed, branch, baseBranch);
   if (!url) {
-    await _alert(_el('p', null, 'Unsupported git provider: ', _el('code', null, parsed.host)));
+    await showErrorAlert('Unsupported git provider: ', parsed.host);
     return;
   }
 
@@ -166,7 +166,7 @@ export async function openPrFlow({ cwd, baseBranch = null, api }) {
 
   const push = await api.pushBranch({ cwd, branch });
   if (!push?.ok) {
-    await _alert(_el('p', null, 'Push failed: ', _el('code', null, push?.error || 'unknown error')));
+    await showErrorAlert('Push failed: ', push?.error);
     return;
   }
 

--- a/src/utils/worktree-flow.js
+++ b/src/utils/worktree-flow.js
@@ -8,7 +8,7 @@
  */
 
 import { showWorktreeDialog } from './worktree-dialog.js';
-import { showConfirmDialog } from './dom-dialogs.js';
+import { showConfirmDialog, showErrorAlert } from './dom-dialogs.js';
 import { _el } from './dom.js';
 
 /**
@@ -72,10 +72,7 @@ export async function createWorktreeFlow({ repoCwd, api, createTab }) {
   });
 
   if (!result?.ok) {
-    await showConfirmDialog(
-      _el('p', null, 'Worktree creation failed: ', _el('code', null, result?.error || 'unknown error')),
-      { confirmLabel: 'OK', cancelLabel: 'Close' },
-    );
+    await showErrorAlert('Worktree creation failed: ', result?.error);
     return;
   }
 
@@ -134,9 +131,6 @@ export async function maybeRemoveWorktree(worktree, tabName, api) {
   }
 
   if (!result?.ok) {
-    await showConfirmDialog(
-      _el('p', null, 'Could not remove worktree: ', _el('code', null, result?.error || 'unknown error')),
-      { confirmLabel: 'OK', cancelLabel: 'Close' },
-    );
+    await showErrorAlert('Could not remove worktree: ', result?.error);
   }
 }


### PR DESCRIPTION
## Refactoring

Extraction d'un helper `showErrorAlert(prefix, error)` dans `dom-dialogs.js` pour factoriser le pattern répété d'affichage d'erreur avec `<code>` dans les flows worktree et PR.

- 2 occurrences remplacées dans `worktree-flow.js`
- 4 occurrences remplacées dans `open-pr-flow.js`

Closes #275

## Fichier(s) modifié(s)

- `src/utils/dom-dialogs.js`
- `src/utils/worktree-flow.js`
- `src/utils/open-pr-flow.js`

## Vérifications

- [x] Build OK
- [x] Tests OK

---

📂 Path local : `/Users/rekta/projet/coding/refactor-pikagent`
🤖 PR créée automatiquement par l'Agent Refactor