### PR TITLE
refactor: centralize agent list in shared/agent-registry

### DIFF
--- a/main/flow-helpers.js
+++ b/main/flow-helpers.js
@@ -2,6 +2,7 @@ const path = require('path');
 const { FLOWS_DIR, LOGS_DIR } = require('./paths');
 const { createStreamParser } = require('./flow-stream-parser');
 const { getLastRun } = require('../shared/flow-utils');
+const { AGENT_IDS } = require('../shared/agent-registry');
 
 const MS_PER_HOUR = 3_600_000;
 const SCHEDULER_INTERVAL_MS = 60_000;
@@ -18,9 +19,9 @@ function logPath(flowId, timestamp) {
   return path.join(LOGS_DIR, `${flowId}_${timestamp}.log`);
 }
 
-/* ── Agent command config (single source of truth) ─────────────── */
+/* ── Agent command config ───────────────────────────────────────── */
 
-const AGENT_CONFIG = {
+const _AGENT_CMD_OVERRIDES = {
   claude: {
     permModes: ['--permission-mode auto', '--dangerously-skip-permissions'],
     flags: '--output-format stream-json',
@@ -34,6 +35,11 @@ const AGENT_CONFIG = {
     promptPrefix: '-p',
   },
 };
+
+/** Derived from the shared agent registry + per-agent command overrides. */
+const AGENT_CONFIG = Object.fromEntries(
+  AGENT_IDS.map((id) => [id, _AGENT_CMD_OVERRIDES[id] || {}]),
+);
 
 function _buildAgentCmd(agent, prompt, opts = {}) {
   const cfg = AGENT_CONFIG[agent] || AGENT_CONFIG.claude;

--- a/main/pty-helpers.js
+++ b/main/pty-helpers.js
@@ -1,10 +1,7 @@
 const os = require('os');
+const { AGENTS } = require('../shared/agent-registry');
 
-const KNOWN_AGENTS = [
-  ['claude', 'Claude'],
-  ['codex', 'Codex'],
-  ['opencode', 'OpenCode'],
-];
+const KNOWN_AGENTS = AGENTS.map((a) => [a.id, a.label]);
 
 const EXEC_TIMEOUT_MS = 1000;
 const CWD_TIMEOUT_MS = 2000;

--- a/shared/agent-registry.js
+++ b/shared/agent-registry.js
@@ -1,0 +1,19 @@
+/**
+ * Canonical agent registry — single source of truth for the list of
+ * supported agents.  CommonJS format so main/ can require() it directly;
+ * esbuild resolves it for the renderer bundle.
+ */
+
+const AGENTS = [
+  { id: 'claude', label: 'Claude' },
+  { id: 'codex', label: 'Codex' },
+  { id: 'opencode', label: 'OpenCode' },
+];
+
+/** @type {string[]} e.g. ['claude', 'codex', 'opencode'] */
+const AGENT_IDS = AGENTS.map((a) => a.id);
+
+/** @type {Record<string, string>} e.g. { claude: 'Claude', … } */
+const AGENT_OPTIONS = Object.fromEntries(AGENTS.map((a) => [a.id, a.label]));
+
+module.exports = { AGENTS, AGENT_IDS, AGENT_OPTIONS };

--- a/src/utils/flow-modal-helpers.js
+++ b/src/utils/flow-modal-helpers.js
@@ -1,5 +1,6 @@
 import { _el } from './dom.js';
 import { SCHEDULE_TYPE_CONFIG } from './flow-schedule-helpers.js';
+import { AGENT_OPTIONS } from '../../shared/agent-registry.js';
 
 /**
  * Create a <select> element from an options map.
@@ -18,11 +19,7 @@ function createSelect({ options, value, className, onChange } = {}) {
 
 // --- Constants ---
 
-export const AGENT_OPTIONS = {
-  claude: 'Claude',
-  codex: 'Codex',
-  opencode: 'OpenCode',
-};
+export { AGENT_OPTIONS };
 
 export const DEFAULT_CWD_LABEL = 'Sélectionner un dossier';
 


### PR DESCRIPTION
## Refactoring

Centralisation de la liste des agents (Claude, Codex, OpenCode) dans `shared/agent-registry.js`. Les 3 fichiers qui définissaient cette liste indépendamment importent désormais depuis la source unique.

Closes #277

## Fichier(s) modifié(s)

- `shared/agent-registry.js` (nouveau)
- `main/flow-helpers.js`
- `src/utils/flow-modal-helpers.js`
- `main/pty-helpers.js`

## Vérifications

- [x] Build OK
- [x] Tests OK

---

📂 Path local : `/Users/rekta/projet/coding/refactor-pikagent`
🤖 PR créée automatiquement par l'Agent Refactor