### PR TITLE
refactor: extract JsonStore to reduce CRUD boilerplate

### DIFF
--- a/main/config-manager.js
+++ b/main/config-manager.js
@@ -1,3 +1,5 @@
+const path = require('path');
+const fs = require('fs/promises');
 const { CONFIG_DIR, META_FILE } = require('./paths');
 const { readJson, writeJson } = require('./fs-utils');
 const { DEFAULT_META, sanitizeName, buildConfigRecord, formatConfigList } = require('./config-helpers');
@@ -9,7 +11,7 @@ const store = new JsonStore(CONFIG_DIR, 'config-manager');
 const _metaCache = new Cache();
 
 // Override the default path builder to apply sanitizeName
-store.path = (name) => require('path').join(CONFIG_DIR, `${sanitizeName(name)}.json`);
+store.path = (name) => path.join(CONFIG_DIR, `${sanitizeName(name)}.json`);
 
 async function readMeta() {
   const cached = _metaCache.get();
@@ -49,7 +51,7 @@ async function list() {
 async function remove(name) {
   return trySafe(
     async () => {
-      await require('fs/promises').unlink(store.path(name));
+      await fs.unlink(store.path(name));
       const meta = await readMeta();
       if (meta.defaultConfig === name) {
         meta.defaultConfig = null;

--- a/main/config-manager.js
+++ b/main/config-manager.js
@@ -1,18 +1,15 @@
-const fsp = require('fs/promises');
-const path = require('path');
 const { CONFIG_DIR, META_FILE } = require('./paths');
-const { readJson, writeJson, ensureDirOnce, readDirJson } = require('./fs-utils');
+const { readJson, writeJson } = require('./fs-utils');
 const { DEFAULT_META, sanitizeName, buildConfigRecord, formatConfigList } = require('./config-helpers');
 const { Cache } = require('./cache');
-const { createLogger, trySafe } = require('./logger');
+const { trySafe } = require('./logger');
+const { JsonStore } = require('./json-store');
 
-const log = createLogger('config-manager');
-const ensureDir = ensureDirOnce(CONFIG_DIR);
+const store = new JsonStore(CONFIG_DIR, 'config-manager');
 const _metaCache = new Cache();
 
-function configPath(name) {
-  return path.join(CONFIG_DIR, `${sanitizeName(name)}.json`);
-}
+// Override the default path builder to apply sanitizeName
+store.path = (name) => require('path').join(CONFIG_DIR, `${sanitizeName(name)}.json`);
 
 async function readMeta() {
   const cached = _metaCache.get();
@@ -23,37 +20,36 @@ async function readMeta() {
 }
 
 async function writeMeta(meta) {
-  await ensureDir();
+  await store.ensureDir();
   _metaCache.set(meta);
   await writeJson(META_FILE, meta);
 }
 
 async function save(name, data) {
-  await ensureDir();
-  const existing = await readJson(configPath(name));
+  await store.ensureDir();
+  const existing = await store.get(name);
   const config = buildConfigRecord(name, data, existing);
-  await writeJson(configPath(name), config);
+  await store.save(name, config);
   return config;
 }
 
 async function load(name) {
-  return readJson(configPath(name));
+  return store.get(name);
 }
 
 async function list() {
-  await ensureDir();
   const meta = await readMeta();
   return trySafe(
-    async () => formatConfigList(await readDirJson(CONFIG_DIR), meta.defaultConfig),
+    async () => formatConfigList(await store.list(), meta.defaultConfig),
     [],
-    { log, label: 'list' },
+    { log: store.log, label: 'list' },
   );
 }
 
 async function remove(name) {
   return trySafe(
     async () => {
-      await fsp.unlink(configPath(name));
+      await require('fs/promises').unlink(store.path(name));
       const meta = await readMeta();
       if (meta.defaultConfig === name) {
         meta.defaultConfig = null;
@@ -62,7 +58,7 @@ async function remove(name) {
       return true;
     },
     false,
-    { log, label: 'remove' },
+    { log: store.log, label: 'remove' },
   );
 }
 

--- a/main/flow-manager.js
+++ b/main/flow-manager.js
@@ -2,20 +2,21 @@ const fsp = require('fs/promises');
 const path = require('path');
 const os = require('os');
 const { FLOWS_DIR, LOGS_DIR, FLOW_CATEGORIES_FILE } = require('./paths');
-const { readJson, writeJson, ensureDirOnce, readDirJson } = require('./fs-utils');
+const { readJson, writeJson, ensureDirOnce } = require('./fs-utils');
 const {
   SCHEDULER_INTERVAL_MS, SHELL_INIT_DELAY_MS, MAX_RUN_HISTORY,
   DEFAULT_PTY_COLS, DEFAULT_PTY_ROWS, MAX_FLOW_RUNTIME_MS,
-  flowPath, logPath,
+  logPath,
   shouldRun, buildFlowCommand, createOutputProcessor,
 } = require('./flow-helpers');
 const { safeSend } = require('./ipc-helpers');
 const { createPollingManager } = require('../shared/polling-manager');
 const { buildRecord } = require('./record-helpers');
-const { createLogger, trySafe } = require('./logger');
+const { trySafe } = require('./logger');
+const { JsonStore } = require('./json-store');
 
-const log = createLogger('flow-manager');
-const ensureDir = ensureDirOnce(LOGS_DIR);
+const store = new JsonStore(FLOWS_DIR, 'flow-manager');
+const ensureLogsDir = ensureDirOnce(LOGS_DIR);
 
 class FlowManager {
   constructor() {
@@ -53,34 +54,33 @@ class FlowManager {
   // --- CRUD ---
 
   async save(flow) {
-    await ensureDir();
+    await ensureLogsDir();
     const existing = await this.get(flow.id);
     const now = new Date().toISOString();
     const data = buildRecord(flow, { createdAt: existing?.createdAt || now, updatedAt: now });
     if (!data.runs) data.runs = [];
     if (data.enabled === undefined) data.enabled = true;
-    await writeJson(flowPath(flow.id), data);
+    await store.save(flow.id, data);
     return data;
   }
 
   async get(id) {
-    return readJson(flowPath(id));
+    return store.get(id);
   }
 
   async list() {
-    await ensureDir();
-    return readDirJson(FLOWS_DIR);
+    return store.list();
   }
 
   async remove(id) {
     return trySafe(
       async () => {
-        await fsp.unlink(flowPath(id));
+        await fsp.unlink(store.path(id));
         await this._cleanLogs(id);
         return true;
       },
       false,
-      { log, label: 'remove' },
+      { log: store.log, label: 'remove' },
     );
   }
 
@@ -101,20 +101,20 @@ class FlowManager {
     return trySafe(
       () => fsp.readFile(logPath(flowId, timestamp), 'utf-8'),
       null,
-      { log, label: 'getRunLog' },
+      { log: store.log, label: 'getRunLog' },
     );
   }
 
   // --- Categories ---
 
   async getCategories() {
-    await ensureDir();
+    await store.ensureDir();
     const data = await readJson(FLOW_CATEGORIES_FILE);
     return data || { categories: [], order: {} };
   }
 
   async saveCategories(data) {
-    await ensureDir();
+    await store.ensureDir();
     await writeJson(FLOW_CATEGORIES_FILE, data);
     return data;
   }
@@ -126,7 +126,7 @@ class FlowManager {
         await Promise.all(files.map((f) => fsp.unlink(path.join(LOGS_DIR, f))));
       },
       undefined,
-      { log, label: 'cleanLogs' },
+      { log: store.log, label: 'cleanLogs' },
     );
   }
 
@@ -148,11 +148,11 @@ class FlowManager {
   // --- Execution ---
 
   async _saveLog(flowId, runTimestamp, output) {
-    await ensureDir();
+    await ensureLogsDir();
     await trySafe(
       () => fsp.writeFile(logPath(flowId, runTimestamp), output, 'utf-8'),
       undefined,
-      { log, label: 'saveLog' },
+      { log: store.log, label: 'saveLog' },
     );
   }
 
@@ -219,7 +219,7 @@ class FlowManager {
         this._ptyManager.write(ptyId, cmd);
       }, SHELL_INIT_DELAY_MS);
     } catch (err) {
-      log.error('execution failed', err);
+      store.log.error('execution failed', err);
       this._recordRun(flow.id, 'error', runTimestamp);
     }
   }

--- a/main/json-store.js
+++ b/main/json-store.js
@@ -1,0 +1,55 @@
+const fsp = require('fs/promises');
+const path = require('path');
+const { readJson, writeJson, ensureDirOnce, readDirJson } = require('./fs-utils');
+const { createLogger, trySafe } = require('./logger');
+
+/**
+ * Generic JSON file store — encapsulates the common CRUD pattern
+ * shared across config-manager, flow-manager, and skills-manager.
+ *
+ * Each instance manages a single directory of `<id>.json` files.
+ */
+class JsonStore {
+  /**
+   * @param {string} dir       — directory that holds the JSON files
+   * @param {string} logLabel  — label used for the createLogger prefix
+   */
+  constructor(dir, logLabel) {
+    this.dir = dir;
+    this.log = createLogger(logLabel);
+    this.ensureDir = ensureDirOnce(dir);
+  }
+
+  /** Build the full path for a given id. */
+  path(id) {
+    return path.join(this.dir, `${id}.json`);
+  }
+
+  /** Read a single JSON file by id. Returns `null` when missing. */
+  async get(id) {
+    return readJson(this.path(id));
+  }
+
+  /** Ensure directory exists, then return all parsed JSON files in it. */
+  async list() {
+    await this.ensureDir();
+    return readDirJson(this.dir);
+  }
+
+  /** Ensure directory exists, then write `data` as JSON at `<id>.json`. */
+  async save(id, data) {
+    await this.ensureDir();
+    await writeJson(this.path(id), data);
+  }
+
+  /** Delete a JSON file by id. Returns `true` on success, `false` on error. */
+  async remove(id) {
+    return trySafe(
+      () => fsp.unlink(this.path(id)),
+      false,
+      { log: this.log, label: 'remove' },
+    );
+  }
+}
+
+module.exports = { JsonStore };

--- a/main/skills-manager.js
+++ b/main/skills-manager.js
@@ -3,14 +3,14 @@ const fsp = fs.promises;
 const path = require('path');
 const os = require('os');
 const { BASE_DIR } = require('./paths');
-const { readJson, writeJson, ensureDirOnce } = require('./fs-utils');
-const { createLogger, trySafe } = require('./logger');
+const { readJson, writeJson } = require('./fs-utils');
+const { trySafe } = require('./logger');
+const { JsonStore } = require('./json-store');
 
-const log = createLogger('skills-manager');
+const store = new JsonStore(BASE_DIR, 'skills-manager');
 
 const DEFAULT_SKILLS_DIR = path.join(os.homedir(), '.claude', 'skills');
 const SETTINGS_FILE = path.join(BASE_DIR, 'skills-settings.json');
-const ensureBaseDir = ensureDirOnce(BASE_DIR);
 
 let _rootCache = null;
 
@@ -35,7 +35,7 @@ async function _loadRoot() {
 }
 
 async function _saveRoot(newRoot) {
-  await ensureBaseDir();
+  await store.ensureDir();
   await writeJson(SETTINGS_FILE, { root: newRoot });
   _rootCache = newRoot;
 }
@@ -56,7 +56,7 @@ async function _readSkillDir(rootDir, skillName) {
       path: skillPath,
       source: 'user',
     };
-  }, null, { log, label: 'readSkillDir' });
+  }, null, { log: store.log, label: 'readSkillDir' });
 }
 
 async function list() {
@@ -66,7 +66,7 @@ async function list() {
     const dirs = entries.filter((e) => e.isDirectory()).map((e) => e.name);
     const skills = await Promise.all(dirs.map((name) => _readSkillDir(root, name)));
     return skills.filter(Boolean).sort((a, b) => a.name.localeCompare(b.name));
-  }, [], { log, label: 'list' });
+  }, [], { log: store.log, label: 'list' });
 }
 
 async function read(filePath) {
@@ -74,7 +74,7 @@ async function read(filePath) {
   return trySafe(
     () => fsp.readFile(filePath, 'utf-8'),
     null,
-    { log, label: 'read' },
+    { log: store.log, label: 'read' },
   );
 }
 
@@ -84,7 +84,7 @@ async function write({ filePath, content }) {
     await fsp.mkdir(path.dirname(filePath), { recursive: true });
     await fsp.writeFile(filePath, content, 'utf-8');
     return { success: true };
-  }, { success: false }, { log, label: 'write' });
+  }, { success: false }, { log: store.log, label: 'write' });
 }
 
 async function create({ id, description }) {
@@ -103,7 +103,7 @@ async function create({ id, description }) {
     const body = `---\nname: ${safeId}\ndescription: ${desc}\n---\n\n# ${safeId}\n\nDécris ici ce que fait ce skill.\n`;
     await fsp.writeFile(filePath, body, 'utf-8');
     return { success: true, id: safeId, path: filePath };
-  }, { success: false }, { log, label: 'create' });
+  }, { success: false }, { log: store.log, label: 'create' });
 }
 
 async function remove(id) {
@@ -115,7 +115,7 @@ async function remove(id) {
   return trySafe(async () => {
     await fsp.rm(dir, { recursive: true, force: true });
     return true;
-  }, false, { log, label: 'remove' });
+  }, false, { log: store.log, label: 'remove' });
 }
 
 async function importFrom(srcDir) {
@@ -141,7 +141,7 @@ async function importFrom(srcDir) {
     }
     await _copyRecursive(srcDir, destDir);
     return { success: true, id: destName, path: path.join(destDir, 'SKILL.md') };
-  }, { success: false, error: 'Import failed' }, { log, label: 'importFrom' });
+  }, { success: false, error: 'Import failed' }, { log: store.log, label: 'importFrom' });
 }
 
 async function getRoot() {
@@ -155,7 +155,7 @@ async function setRoot(newRoot) {
     await fsp.mkdir(resolved, { recursive: true });
     await _saveRoot(resolved);
     return { success: true, root: resolved };
-  }, { success: false, error: 'Could not set path' }, { log, label: 'setRoot' });
+  }, { success: false, error: 'Could not set path' }, { log: store.log, label: 'setRoot' });
 }
 
 async function resetRoot() {
@@ -164,7 +164,7 @@ async function resetRoot() {
     _rootCache = null;
     const root = await _loadRoot();
     return { success: true, root };
-  }, { success: false }, { log, label: 'resetRoot' });
+  }, { success: false }, { log: store.log, label: 'resetRoot' });
 }
 
 async function _isAllowedPath(p) {


### PR DESCRIPTION
## Refactoring

Extraction d'une classe `JsonStore` dans `main/json-store.js` pour factoriser le boilerplate CRUD (get/list/save/remove) commun aux 3 managers. Chaque manager délègue les opérations fichier au store et conserve sa logique métier spécifique.

Closes #276

## Fichier(s) modifié(s)

- `main/json-store.js` (nouveau)
- `main/config-manager.js`
- `main/flow-manager.js`
- `main/skills-manager.js`

## Vérifications

- [x] Build OK
- [x] Tests OK (25 files, 372 tests)

---

PR créée automatiquement par l'Agent Refactor