### PR TITLE
refactor: extract tab constants from tab-manager-helpers

### DIFF
--- a/tests/utils/tab-manager-helpers.test.js
+++ b/tests/utils/tab-manager-helpers.test.js
@@ -1,7 +1,10 @@
 import { describe, it, expect } from 'vitest';
 import {
   DRAG_THRESHOLD, PANEL_MIN_WIDTH,
-  ACTIVITY_BUTTONS, COLOR_GROUPS, SIDE_VIEWS, WorkspaceTab,
+  ACTIVITY_BUTTONS, COLOR_GROUPS, SIDE_VIEWS,
+} from '../../src/utils/tab-constants.js';
+import { WorkspaceTab } from '../../src/utils/tab-types.js';
+import {
   clampPanelWidth, panelArrowState, reorderEntries,
   findCycleTarget, findColorGroupTarget,
 } from '../../src/utils/tab-manager-helpers.js';


### PR DESCRIPTION
## Refactoring

Extraction des constantes (types de tabs, événements, clés de stockage) de `tab-manager-helpers.js` vers `tab-constants.js` pour réduire le couplage. Les modules qui n'utilisent que des constantes importent désormais depuis le fichier dédié.

Closes #260

## Fichier(s) modifié(s)

- `src/utils/tab-constants.js` (nouveau)
- `src/utils/tab-manager-helpers.js`
- Modules consommateurs mis à jour

## Vérifications

- [x] Build OK
- [x] Tests OK

---

📂 Path local : `/Users/rekta/projet/coding/refactor-pikagent`
🤖 PR créée automatiquement par l'Agent Refactor