### PR TITLE
refactor: replace any casts with unknown in tab-drag.js

### DIFF
--- a/src/utils/tab-drag.js
+++ b/src/utils/tab-drag.js
@@ -154,7 +154,7 @@ function buildTabDragHandlers(deps, tabEl, state, tabId) {
 
   return {
     startDrag() {
-      onDragStart(/** @type {any} */ ({}));
+      onDragStart(/** @type {unknown} */ ({}));
       return createTabGhost(tabEl);
     },
     endDrag(ghost) {
@@ -164,7 +164,7 @@ function buildTabDragHandlers(deps, tabEl, state, tabId) {
       if (state.dropTargetId && state.dropTargetId !== tabId) {
         reorderTab(tabId, state.dropTargetId, state.dropBefore);
       }
-      onDragEnd(/** @type {any} */ ({}));
+      onDragEnd(/** @type {unknown} */ ({}));
     },
   };
 }


### PR DESCRIPTION
## Refactoring

Remplace les 2 occurrences de `/** @type {any} */` par `/** @type {unknown} */` dans `tab-drag.js` (lignes 157, 167) pour éliminer les derniers types `any` du codebase.

Closes #288

## Fichier(s) modifié(s)

- `src/utils/tab-drag.js`

## Vérifications

- [x] Build OK
- [x] Tests OK

---

📂 Path local : `/Users/rekta/projet/coding/refactor-pikagent`
🤖 PR créée automatiquement par l'Agent Refactor