### PR TITLE
refactor: fix ipcHandlers.cleanup() call in main.js

### DIFF
--- a/main/ipc-handlers.js
+++ b/main/ipc-handlers.js
@@ -1,6 +1,12 @@
 const { ipcMain } = require('electron');
-const { registerManagerHandlers, safeSend } = require('./ipc-helpers');
+const { registerManagerHandlers, safeSend, getRegisteredChannels } = require('./ipc-helpers');
 const { createSafeHandler } = require('./safe-handler');
+
+/**
+ * Channels with custom handlers (registered manually in `register()`).
+ * Kept at module scope so `cleanup()` can reference them.
+ */
+const CUSTOM_CHANNELS = ['pty:create', 'fs:watch', 'fs:trash', 'dialog:openFolder'];
 
 /**
  * Register all IPC handlers.
@@ -14,11 +20,10 @@ const { createSafeHandler } = require('./safe-handler');
 function register(getWindow, { targets, ptyManager, sessionManager }) {
   const { shell, dialog } = require('electron');
 
-  // Channels with custom handlers (registered below) — skip declarative registration.
-  const customChannels = new Set(['pty:create', 'fs:watch', 'fs:trash', 'dialog:openFolder']);
+  const customSet = new Set(CUSTOM_CHANNELS);
 
   // Register all declarative forward/spread handlers in one pass.
-  registerManagerHandlers(ipcMain, targets, customChannels);
+  registerManagerHandlers(ipcMain, targets, customSet);
 
   // -- Custom handlers that cannot be expressed declaratively --
 
@@ -57,4 +62,22 @@ function register(getWindow, { targets, ptyManager, sessionManager }) {
   });
 }
 
-module.exports = { register };
+/**
+ * Remove all IPC handlers registered by `register()`.
+ *
+ * Called during `before-quit` to ensure a clean shutdown and avoid
+ * stale handler references.
+ */
+function cleanup() {
+  // Remove custom handlers
+  for (const channel of CUSTOM_CHANNELS) {
+    ipcMain.removeHandler(channel);
+  }
+
+  // Remove declaratively registered handlers
+  for (const channel of getRegisteredChannels()) {
+    ipcMain.removeHandler(channel);
+  }
+}
+
+module.exports = { register, cleanup };

--- a/main/ipc-helpers.js
+++ b/main/ipc-helpers.js
@@ -43,6 +43,24 @@ function buildTablesFromSchema(schema) {
 const { forward: FORWARD_TABLE, spread: SPREAD_TABLE } = buildTablesFromSchema(API_SCHEMA);
 
 /**
+ * Return the list of all declaratively registered IPC channel names.
+ * Used by `ipc-handlers.cleanup()` to remove handlers on shutdown.
+ *
+ * @param {Set<string>} [skip] - Channels to exclude (custom handlers managed separately)
+ * @returns {string[]}
+ */
+function getRegisteredChannels(skip = new Set()) {
+  const channels = [];
+  for (const [channel] of FORWARD_TABLE) {
+    if (!skip.has(channel)) channels.push(channel);
+  }
+  for (const [channel] of SPREAD_TABLE) {
+    if (!skip.has(channel)) channels.push(channel);
+  }
+  return channels;
+}
+
+/**
  * @internal
  * Register forward-style handlers on ipcMain for a given target.
  * @param {Electron.IpcMain} ipc - Electron ipcMain
@@ -95,7 +113,7 @@ function registerManagerHandlers(ipc, targets, skip = new Set()) {
   }
 }
 
-module.exports = { safeSend, registerManagerHandlers };
+module.exports = { safeSend, registerManagerHandlers, getRegisteredChannels };
 
 /** @internal — exposed for unit tests only; not part of the public API. */
 module.exports._internals = { buildTablesFromSchema, registerForward, registerSpread };


### PR DESCRIPTION
## Refactoring

`main.js` (line 30) called `ipcHandlers.cleanup()` in the `before-quit` handler, but `ipc-handlers.js` only exported `{ register }` — the `cleanup` function did not exist, causing a runtime error on quit.

Rather than removing the dead call (since IPC cleanup is a valuable shutdown step consistent with the existing cleanup pattern in fs-manager, pty-manager, session-manager, and flow-manager), the missing `cleanup()` function was implemented. It calls `ipcMain.removeHandler()` for every registered channel — both the 4 custom handlers and all declaratively registered handlers derived from `API_SCHEMA`.

A new `getRegisteredChannels()` helper was added to `ipc-helpers.js` to enumerate all declarative channel names from the schema tables, keeping the logic DRY and centralized.

Closes #273

## Fichier(s) modifié(s)

- `main/ipc-handlers.js` — added `cleanup()` function, exported it alongside `register`, extracted `CUSTOM_CHANNELS` to module scope
- `main/ipc-helpers.js` — added `getRegisteredChannels()` helper, exported it

## Vérifications

- [x] Build OK
- [x] Tests OK (25 files, 363 tests passed)

---

📂 Path local : `/Users/rekta/projet/coding/refactor-pikagent`
🤖 PR créée automatiquement par l'Agent Refactor