### PR TITLE
refactor: break circular dependency and decouple events system

### DIFF
--- a/src/components/board-view.js
+++ b/src/components/board-view.js
@@ -1,11 +1,11 @@
 import { WebLinksAddon } from '@xterm/addon-web-links';
-import { bus } from '../utils/events.js';
+import { onTerminalCreated, onTerminalRemoved, onTerminalExited } from '../utils/terminal-events.js';
 import { FilePathLinkProvider } from '../utils/file-link-provider.js';
 import { _el, _safeFit } from '../utils/dom.js';
 import { createTerminal, disposeTerminal } from '../utils/terminal-factory.js';
 import {
   DATA_VOLUME_THRESHOLD, POLL_INTERVAL_MS, FIT_SETTLE_DELAY_MS, FIT_UNHIDE_DELAY_MS,
-  STATUS_CONFIG, ALL_CARD_CLASSES, EVT_CREATED, EVT_REMOVED, EVT_EXITED,
+  STATUS_CONFIG, ALL_CARD_CLASSES,
   BOARD_TERMINAL_OPTS, HEADER_BUTTONS,
   resolveCardStatus, findTabForTerminal, getTabNameForTerminal, computeFocusIndex,
   formatCardLabel,
@@ -212,13 +212,10 @@ export class BoardView {
   _setupListeners() {
     const onTerminalGone = ({ id }) => { this.removeCard(id); this._updateEmptyState(); };
 
-    // Bus event listeners — single declaration drives both subscription and cleanup
-    this._busListeners = [
-      [EVT_CREATED, () => { if (!this.disposed) this.scanAgents(); }],
-      [EVT_REMOVED, onTerminalGone],
-      [EVT_EXITED, onTerminalGone],
-    ];
-    for (const [event, handler] of this._busListeners) bus.on(event, handler);
+    // Typed subscription helpers -- each returns an unsubscribe function
+    this._unsubCreated = onTerminalCreated(() => { if (!this.disposed) this.scanAgents(); });
+    this._unsubRemoved = onTerminalRemoved(onTerminalGone);
+    this._unsubExited  = onTerminalExited(onTerminalGone);
   }
 
   focusDirection(dir) {
@@ -259,7 +256,9 @@ export class BoardView {
     this.disposed = true;
     this.pause();
 
-    for (const [event, handler] of this._busListeners) bus.off(event, handler);
+    this._unsubCreated();
+    this._unsubRemoved();
+    this._unsubExited();
 
     for (const [, data] of this.cards) {
       disposeTerminal(data);

--- a/src/components/file-tree.js
+++ b/src/components/file-tree.js
@@ -1,4 +1,4 @@
-import { bus } from '../utils/events.js';
+import { emitWorkspaceOpenFromFolder, emitFileOpen } from '../utils/workspace-events.js';
 import { contextMenu } from './context-menu.js';
 import { _el, setupInlineInput } from '../utils/dom.js';
 import {
@@ -215,7 +215,7 @@ export class FileTree {
       { label: 'New File', action: () => this.promptNewEntry(dirPath, contentEl, depth, expandedDirs, 'file') },
       { label: 'New Folder', action: () => this.promptNewEntry(dirPath, contentEl, depth, expandedDirs, 'folder') },
       { separator: true },
-      { label: 'Open as Workspace', action: () => bus.emit('workspace:openFromFolder', { cwd: dirPath }) },
+      { label: 'Open as Workspace', action: () => emitWorkspaceOpenFromFolder({ cwd: dirPath }) },
       { separator: true },
       ...this._commonContextItems(dirPath, nameEl, `Delete folder "${dirName}" and all its contents?`),
     ]);
@@ -271,7 +271,7 @@ export class FileTree {
           await window.api.fs.mkdir(newPath);
         } else {
           await window.api.fs.writefile(newPath, '');
-          bus.emit('file:open', { path: newPath, name });
+          emitFileOpen({ path: newPath, name });
         }
       },
     });
@@ -380,7 +380,7 @@ export class FileTree {
       if (this._activeRow) this._activeRow.classList.remove('active');
       row.classList.add('active');
       this._activeRow = row;
-      bus.emit('file:open', { path: entry.path, name: entry.name });
+      emitFileOpen({ path: entry.path, name: entry.name });
     });
 
     row.addEventListener('contextmenu', (e) => {

--- a/src/components/file-viewer.js
+++ b/src/components/file-viewer.js
@@ -1,5 +1,6 @@
 import { detectLanguage } from '../utils/file-icons.js';
-import { bus } from '../utils/events.js';
+import { onTerminalCwdChanged } from '../utils/terminal-events.js';
+import { onFileOpen, onWorkspaceActivated, emitLayoutChanged } from '../utils/workspace-events.js';
 import { GitChangesView } from './git-changes-view.js';
 import { WebviewInstance } from './webview-panel.js';
 import { contextMenu } from './context-menu.js';
@@ -62,24 +63,23 @@ export class FileViewer {
   }
 
   _setupListeners() {
-    // Bus event listeners — single declaration drives both subscription and cleanup
-    this._busListeners = [
-      ['file:open', ({ path, name }) => {
+    // Typed subscription helpers -- each returns an unsubscribe function
+    this._unsubs = [
+      onFileOpen(({ path, name }) => {
         if (!this.isActive()) return;
         this.switchMode('files');
         this.openFile(path, name);
-      }],
-      ['terminal:cwdChanged', ({ cwd }) => {
+      }),
+      onTerminalCwdChanged(({ cwd }) => {
         if (!this.isActive()) return;
         this.gitChanges.setCwd(cwd);
         if (this.mode === 'git') this.gitChanges.loadChanges();
-      }],
-      ['workspace:activated', () => {
+      }),
+      onWorkspaceActivated(() => {
         if (!this.isActive()) return;
         this.loadPinnedFiles();
-      }],
+      }),
     ];
-    for (const [event, handler] of this._busListeners) bus.on(event, handler);
   }
 
   async loadPinnedFiles() {
@@ -422,7 +422,7 @@ export class FileViewer {
     this.webviewTabs.push(wt);
     this._createWebviewContainer(wt);
     this.switchMode(wt.id);
-    bus.emit('layout:changed');
+    emitLayoutChanged();
   }
 
   removeWebview(webviewId) {
@@ -439,7 +439,7 @@ export class FileViewer {
 
     if (this.mode === webviewId) this.switchMode('files');
     else this._renderModeBar();
-    bus.emit('layout:changed');
+    emitLayoutChanged();
   }
 
   _createWebviewContainer(wt) {
@@ -465,8 +465,8 @@ export class FileViewer {
   }
 
   dispose() {
-    for (const [event, handler] of this._busListeners) bus.off(event, handler);
-    this._busListeners = [];
+    for (const unsub of this._unsubs) unsub();
+    this._unsubs = [];
 
     for (const [, wvData] of this._webviewEls) {
       if (wvData.instance) wvData.instance.dispose();

--- a/src/components/git-changes-view.js
+++ b/src/components/git-changes-view.js
@@ -1,4 +1,4 @@
-import { bus } from '../utils/events.js';
+import { emitFileOpen } from '../utils/workspace-events.js';
 import { DiffViewer } from './diff-viewer.js';
 import { _el } from '../utils/dom.js';
 import { STATUS_LABELS, CHEVRON, CHANGE_SECTIONS, computeTotalChanges, buildFileKey } from '../utils/git-changes-helpers.js';
@@ -80,7 +80,7 @@ export class GitChangesView {
       _el('span', { className: 'git-file-name-label', textContent: file.path, title: file.path }),
       _el('span', { className: 'git-open-btn', textContent: '→', title: 'Open file', onClick: (e) => {
         e.stopPropagation();
-        bus.emit('file:open', { path: `${this.gitCwd}/${file.path}`, name: file.path.split('/').pop() });
+        emitFileOpen({ path: `${this.gitCwd}/${file.path}`, name: file.path.split('/').pop() });
       }}),
     );
 

--- a/src/components/tab-manager.js
+++ b/src/components/tab-manager.js
@@ -5,7 +5,8 @@ import { FileViewer } from './file-viewer.js';
 import { BoardView } from './board-view.js';
 import { FlowView } from './flow-view.js';
 import { UsageView } from './usage-view.js';
-import { bus } from '../utils/events.js';
+import { onTerminalCwdChanged, onTerminalCreated, onTerminalRemoved } from '../utils/terminal-events.js';
+import { onLayoutChanged, onWorkspaceOpenFromFolder, emitWorkspaceActivated } from '../utils/workspace-events.js';
 import { contextMenu } from './context-menu.js';
 import { ConfigManager } from './config-manager.js';
 import { _el, showConfirmDialog, setupInlineInput } from '../utils/dom.js';
@@ -92,30 +93,29 @@ export class TabManager {
       this.createTab('Workspace 1');
     }
 
-    // Bus event listeners — single declaration drives both registration and cleanup
-    this._busListeners = [
-      ['terminal:cwdChanged', ({ id, cwd }) => {
+    // Typed subscription helpers -- each returns an unsubscribe function
+    this._unsubs = [
+      onTerminalCwdChanged(({ id, cwd }) => {
         this._onTerminalCwdChanged(id, cwd);
         this.configManager.scheduleAutoSave();
-      }],
-      ['terminal:created', ({ id, cwd }) => {
+      }),
+      onTerminalCreated(({ id, cwd }) => {
         const tab = this._findTabForTerminal(id) || this.tabs.get(this.activeTabId);
         if (tab?.fileTree) tab.fileTree.setTerminalRoot(id, cwd);
         this.configManager.scheduleAutoSave();
-      }],
-      ['terminal:removed', ({ id }) => {
+      }),
+      onTerminalRemoved(({ id }) => {
         for (const [, tab] of this.tabs) {
           if (tab.fileTree) tab.fileTree.removeTerminal(id);
         }
         this.configManager.scheduleAutoSave();
-      }],
-      ['layout:changed', () => this.configManager.scheduleAutoSave()],
-      ['workspace:openFromFolder', ({ cwd }) => {
+      }),
+      onLayoutChanged(() => this.configManager.scheduleAutoSave()),
+      onWorkspaceOpenFromFolder(({ cwd }) => {
         const folderName = cwd.split('/').filter(Boolean).pop() || '/';
         this.createTab(folderName, cwd);
-      }],
+      }),
     ];
-    for (const [event, handler] of this._busListeners) bus.on(event, handler);
   }
 
   // Find which tab owns a terminal
@@ -337,7 +337,7 @@ export class TabManager {
         if (tab.layoutElement) {
           this._reattachLayout(tab);
           this._syncFileTree(tab);
-          bus.emit('workspace:activated');
+          emitWorkspaceActivated();
         }
         this.renderTabBar();
         return;
@@ -362,7 +362,7 @@ export class TabManager {
     if (tab.layoutElement) {
       this._reattachLayout(tab);
       this._syncFileTree(tab);
-      bus.emit('workspace:activated');
+      emitWorkspaceActivated();
     } else {
       // First time rendering this tab
       this.renderWorkspace(tab);
@@ -785,7 +785,7 @@ export class TabManager {
     const branch = await window.api.git.branch(tab.cwd);
     if (branch) tab.branchBadgeEl.textContent = ` ${branch}`;
 
-    bus.emit('workspace:activated');
+    emitWorkspaceActivated();
   }
 
   togglePanel(panel, side, arrowEl) {
@@ -910,10 +910,8 @@ export class TabManager {
   }
 
   dispose() {
-    for (const [event, handler] of this._busListeners) {
-      bus.off(event, handler);
-    }
-    this._busListeners = [];
+    for (const unsub of this._unsubs) unsub();
+    this._unsubs = [];
     this._disposeAllSideViews();
     this._disposeAllTabs();
   }

--- a/src/components/terminal-panel.js
+++ b/src/components/terminal-panel.js
@@ -1,4 +1,5 @@
-import { bus } from '../utils/events.js';
+import { emitTerminalCreated, emitTerminalRemoved } from '../utils/terminal-events.js';
+import { emitLayoutChanged } from '../utils/workspace-events.js';
 import { _el } from '../utils/dom.js';
 import { trackMouse } from '../utils/drag-helpers.js';
 import { TerminalInstance } from '../utils/terminal-instance.js';
@@ -173,7 +174,7 @@ export class TerminalPanel {
     node.terminal = new TerminalInstance(termContainer, spawnCwd);
     this.terminals.set(node.terminal.id, node);
 
-    bus.emit('terminal:created', { id: node.terminal.id, cwd: spawnCwd });
+    emitTerminalCreated({ id: node.terminal.id, cwd: spawnCwd });
 
     wrapper.addEventListener('mousedown', () => {
       this.setActive(node);
@@ -287,7 +288,7 @@ export class TerminalPanel {
 
     this.fitAll();
     this.setActive(sourceNode);
-    bus.emit('layout:changed');
+    emitLayoutChanged();
   }
 
   _moveToCenter(sourceEl, targetEl) {
@@ -446,7 +447,7 @@ export class TerminalPanel {
       e.preventDefault();
       trackMouse(RESIZE_CURSOR[direction],
         (ev) => this._doResize(ev, handle, splitEl, direction),
-        () => bus.emit('layout:changed'),
+        () => emitLayoutChanged(),
       );
     });
   }
@@ -485,7 +486,7 @@ export class TerminalPanel {
 
     node.terminal.dispose();
     this.terminals.delete(termId);
-    bus.emit('terminal:removed', { id: termId });
+    emitTerminalRemoved({ id: termId });
 
     if (this.terminals.size === 0) {
       this.init();

--- a/src/utils/board-helpers.js
+++ b/src/utils/board-helpers.js
@@ -20,10 +20,6 @@ export const STATUS_CONFIG = {
 /** All card-level CSS classes derived from STATUS_CONFIG — single source of truth for class removal. */
 export const ALL_CARD_CLASSES = Object.values(STATUS_CONFIG).map(c => c.cardClass);
 
-export const EVT_CREATED = 'terminal:created';
-export const EVT_REMOVED = 'terminal:removed';
-export const EVT_EXITED = 'terminal:exited';
-
 /** Terminal options used by board card mini-terminals. */
 export const BOARD_TERMINAL_OPTS = {
   fontSize: 11,

--- a/src/utils/event-bus.js
+++ b/src/utils/event-bus.js
@@ -1,0 +1,40 @@
+/**
+ * Singleton event bus instance.
+ *
+ * Extracted from events.js to break the circular dependency:
+ *   events.js -> terminal-events.js -> events.js
+ *   events.js -> workspace-events.js -> events.js
+ *
+ * This module has zero imports and can safely be consumed by any event module.
+ *
+ * @module event-bus
+ */
+
+/** @internal */
+class EventBus {
+  constructor() {
+    this.listeners = new Map();
+  }
+
+  on(event, callback) {
+    if (!this.listeners.has(event)) {
+      this.listeners.set(event, new Set());
+    }
+    this.listeners.get(event).add(callback);
+    return () => this.off(event, callback);
+  }
+
+  off(event, callback) {
+    const set = this.listeners.get(event);
+    if (set) set.delete(callback);
+  }
+
+  emit(event, data) {
+    const set = this.listeners.get(event);
+    if (set) {
+      for (const cb of set) cb(data);
+    }
+  }
+}
+
+export const bus = new EventBus();

--- a/src/utils/events.js
+++ b/src/utils/events.js
@@ -1,27 +1,72 @@
-export class EventBus {
-  constructor() {
-    this.listeners = new Map();
-  }
+/**
+ * Backward-compatible re-exports and generic helpers.
+ *
+ * The EventBus class and singleton instance now live in event-bus.js
+ * to break the circular dependency between this module and the domain
+ * event modules (terminal-events.js, workspace-events.js).
+ *
+ * Domain-specific events live in their own modules:
+ * - terminal-events.js  -- terminal lifecycle & state
+ * - workspace-events.js -- layout, workspace lifecycle, file & user actions
+ *
+ * This file re-exports the bus, the generic subscribe/unsubscribe helpers,
+ * and all constants and typed helpers so that existing imports from
+ * './events.js' continue to work.
+ *
+ * New code should import directly from the domain module instead.
+ */
 
-  on(event, callback) {
-    if (!this.listeners.has(event)) {
-      this.listeners.set(event, new Set());
-    }
-    this.listeners.get(event).add(callback);
-    return () => this.off(event, callback);
-  }
+import { bus } from './event-bus.js';
+export { bus };
 
-  off(event, callback) {
-    const set = this.listeners.get(event);
-    if (set) set.delete(callback);
-  }
-
-  emit(event, data) {
-    const set = this.listeners.get(event);
-    if (set) {
-      for (const cb of set) cb(data);
-    }
-  }
+/**
+ * Register an array of [event, handler] pairs on the bus.
+ * Returns the array for later cleanup with unsubscribeBus().
+ */
+export function subscribeBus(listeners) {
+  for (const [event, handler] of listeners) bus.on(event, handler);
+  return listeners;
 }
 
-export const bus = new EventBus();
+/**
+ * Unregister an array of [event, handler] pairs from the bus.
+ */
+export function unsubscribeBus(listeners) {
+  for (const [event, handler] of listeners) bus.off(event, handler);
+}
+
+// -- Backward-compatible re-exports from domain modules --
+// New code should import directly from terminal-events.js or workspace-events.js.
+
+import { TERMINAL_EVENTS } from './terminal-events.js';
+import { WORKSPACE_EVENTS } from './workspace-events.js';
+
+/**
+ * Backward-compatible aggregate EVENTS constant.
+ * @readonly
+ * @enum {string}
+ */
+export const EVENTS = {
+  TERMINAL_CWD_CHANGED: TERMINAL_EVENTS.CWD_CHANGED,
+  TERMINAL_CREATED: TERMINAL_EVENTS.CREATED,
+  TERMINAL_REMOVED: TERMINAL_EVENTS.REMOVED,
+  TERMINAL_EXITED: TERMINAL_EVENTS.EXITED,
+  LAYOUT_CHANGED: WORKSPACE_EVENTS.LAYOUT_CHANGED,
+  WORKSPACE_ACTIVATED: WORKSPACE_EVENTS.ACTIVATED,
+  WORKSPACE_OPEN_FROM_FOLDER: WORKSPACE_EVENTS.OPEN_FROM_FOLDER,
+  WORKSPACE_CREATE_WORKTREE: WORKSPACE_EVENTS.CREATE_WORKTREE,
+  WORKSPACE_OPEN_PR: WORKSPACE_EVENTS.OPEN_PR,
+  FILE_OPEN: WORKSPACE_EVENTS.FILE_OPEN,
+};
+
+// Re-export domain modules for convenience
+export { TERMINAL_EVENTS } from './terminal-events.js';
+export { WORKSPACE_EVENTS } from './workspace-events.js';
+
+// Re-export typed subscription helpers
+export { onTerminalCwdChanged, onTerminalCreated, onTerminalRemoved, onTerminalExited } from './terminal-events.js';
+export { onLayoutChanged, onWorkspaceActivated, onWorkspaceOpenFromFolder, onWorkspaceCreateWorktree, onWorkspaceOpenPr, onFileOpen } from './workspace-events.js';
+
+// Re-export typed emission helpers
+export { emitTerminalCwdChanged, emitTerminalCreated, emitTerminalRemoved, emitTerminalExited } from './terminal-events.js';
+export { emitLayoutChanged, emitWorkspaceActivated, emitWorkspaceOpenFromFolder, emitWorkspaceCreateWorktree, emitWorkspaceOpenPr, emitFileOpen } from './workspace-events.js';

--- a/src/utils/terminal-events.js
+++ b/src/utils/terminal-events.js
@@ -1,0 +1,58 @@
+/**
+ * Terminal domain events -- lifecycle and state changes for terminal instances.
+ *
+ * Provides typed event constants and narrow subscription/emission APIs
+ * so that the implicit event contracts are discoverable and traceable.
+ *
+ * @module terminal-events
+ * @see events.js (backward-compat re-exports)
+ */
+
+import { bus } from './event-bus.js';
+
+// -- Event constants --
+
+/**
+ * Terminal-domain event name constants.
+ * @readonly
+ * @enum {string}
+ */
+export const TERMINAL_EVENTS = {
+  /** Terminal working directory changed (user ran `cd`). */
+  CWD_CHANGED: 'terminal:cwdChanged',
+  /** New terminal spawned in a tab. */
+  CREATED: 'terminal:created',
+  /** Terminal closed and removed from panel. */
+  REMOVED: 'terminal:removed',
+  /** Terminal PTY process exited on its own. */
+  EXITED: 'terminal:exited',
+};
+
+// -- Typed subscription helpers --
+// Each returns an unsubscribe function.
+
+/** @param {(data: { id: string, cwd: string }) => void} cb */
+export const onTerminalCwdChanged = (cb) => bus.on(TERMINAL_EVENTS.CWD_CHANGED, cb);
+
+/** @param {(data: { id: string, cwd: string }) => void} cb */
+export const onTerminalCreated = (cb) => bus.on(TERMINAL_EVENTS.CREATED, cb);
+
+/** @param {(data: { id: string }) => void} cb */
+export const onTerminalRemoved = (cb) => bus.on(TERMINAL_EVENTS.REMOVED, cb);
+
+/** @param {(data: { id: string }) => void} cb */
+export const onTerminalExited = (cb) => bus.on(TERMINAL_EVENTS.EXITED, cb);
+
+// -- Typed emission helpers --
+
+/** @param {{ id: string, cwd: string }} data */
+export const emitTerminalCwdChanged = (data) => bus.emit(TERMINAL_EVENTS.CWD_CHANGED, data);
+
+/** @param {{ id: string, cwd: string }} data */
+export const emitTerminalCreated = (data) => bus.emit(TERMINAL_EVENTS.CREATED, data);
+
+/** @param {{ id: string }} data */
+export const emitTerminalRemoved = (data) => bus.emit(TERMINAL_EVENTS.REMOVED, data);
+
+/** @param {{ id: string }} data */
+export const emitTerminalExited = (data) => bus.emit(TERMINAL_EVENTS.EXITED, data);

--- a/src/utils/terminal-instance.js
+++ b/src/utils/terminal-instance.js
@@ -1,6 +1,6 @@
 import { WebLinksAddon } from '@xterm/addon-web-links';
 import { generateId } from './id.js';
-import { bus } from './events.js';
+import { emitTerminalExited, emitTerminalCwdChanged } from './terminal-events.js';
 import { FilePathLinkProvider } from './file-link-provider.js';
 import { createTerminal } from './terminal-factory.js';
 import { CWD_POLL_MS } from './terminal-panel-helpers.js';
@@ -49,7 +49,7 @@ export class TerminalInstance {
     });
 
     this.unsubExit = window.api.pty.onExit(this.id, () => {
-      bus.emit('terminal:exited', { id: this.id });
+      emitTerminalExited({ id: this.id });
     });
 
     this.resizeObserver = new ResizeObserver(() => this.fit());
@@ -71,7 +71,7 @@ export class TerminalInstance {
       const cwd = await window.api.pty.getCwd({ id: this.id });
       if (cwd && cwd !== this.cwd) {
         this.cwd = cwd;
-        bus.emit('terminal:cwdChanged', { id: this.id, cwd });
+        emitTerminalCwdChanged({ id: this.id, cwd });
       }
     }, CWD_POLL_MS);
   }

--- a/src/utils/workspace-events.js
+++ b/src/utils/workspace-events.js
@@ -1,0 +1,75 @@
+/**
+ * Workspace domain events -- layout coordination, workspace lifecycle,
+ * and user-action events for workspace/file operations.
+ *
+ * Provides typed event constants and narrow subscription/emission APIs
+ * so that the implicit event contracts are discoverable and traceable.
+ *
+ * @module workspace-events
+ * @see events.js (backward-compat re-exports)
+ */
+
+import { bus } from './event-bus.js';
+
+// -- Event constants --
+
+/**
+ * Workspace-domain event name constants.
+ * @readonly
+ * @enum {string}
+ */
+export const WORKSPACE_EVENTS = {
+  /** Workspace layout changed (panel resize, split, webview). */
+  LAYOUT_CHANGED: 'layout:changed',
+  /** Workspace tab activated or re-shown. */
+  ACTIVATED: 'workspace:activated',
+  /** User requested to open a folder as a new workspace tab. */
+  OPEN_FROM_FOLDER: 'workspace:openFromFolder',
+  /** User requested to create a git worktree from a folder. */
+  CREATE_WORKTREE: 'workspace:createWorktree',
+  /** User requested to push current branch and open a PR. */
+  OPEN_PR: 'workspace:openPr',
+  /** User requested to open a file in the editor. */
+  FILE_OPEN: 'file:open',
+};
+
+// -- Typed subscription helpers --
+// Each returns an unsubscribe function.
+
+/** @param {(data: undefined) => void} cb */
+export const onLayoutChanged = (cb) => bus.on(WORKSPACE_EVENTS.LAYOUT_CHANGED, cb);
+
+/** @param {(data: undefined) => void} cb */
+export const onWorkspaceActivated = (cb) => bus.on(WORKSPACE_EVENTS.ACTIVATED, cb);
+
+/** @param {(data: { cwd: string }) => void} cb */
+export const onWorkspaceOpenFromFolder = (cb) => bus.on(WORKSPACE_EVENTS.OPEN_FROM_FOLDER, cb);
+
+/** @param {(data: { repoCwd: string }) => void} cb */
+export const onWorkspaceCreateWorktree = (cb) => bus.on(WORKSPACE_EVENTS.CREATE_WORKTREE, cb);
+
+/** @param {(data: { repoCwd: string }) => void} cb */
+export const onWorkspaceOpenPr = (cb) => bus.on(WORKSPACE_EVENTS.OPEN_PR, cb);
+
+/** @param {(data: { path: string, name: string }) => void} cb */
+export const onFileOpen = (cb) => bus.on(WORKSPACE_EVENTS.FILE_OPEN, cb);
+
+// -- Typed emission helpers --
+
+/** Emit layout:changed (no payload). */
+export const emitLayoutChanged = () => bus.emit(WORKSPACE_EVENTS.LAYOUT_CHANGED);
+
+/** Emit workspace:activated (no payload). */
+export const emitWorkspaceActivated = () => bus.emit(WORKSPACE_EVENTS.ACTIVATED);
+
+/** @param {{ cwd: string }} data */
+export const emitWorkspaceOpenFromFolder = (data) => bus.emit(WORKSPACE_EVENTS.OPEN_FROM_FOLDER, data);
+
+/** @param {{ repoCwd: string }} data */
+export const emitWorkspaceCreateWorktree = (data) => bus.emit(WORKSPACE_EVENTS.CREATE_WORKTREE, data);
+
+/** @param {{ repoCwd: string }} data */
+export const emitWorkspaceOpenPr = (data) => bus.emit(WORKSPACE_EVENTS.OPEN_PR, data);
+
+/** @param {{ path: string, name: string }} data */
+export const emitFileOpen = (data) => bus.emit(WORKSPACE_EVENTS.FILE_OPEN, data);


### PR DESCRIPTION
## Summary

- Extract `EventBus` class and singleton `bus` instance into `src/utils/event-bus.js` (zero dependencies) to break the circular dependency where `events.js` imports from domain modules that import back from `events.js`.
- Create `src/utils/terminal-events.js` with terminal-domain event constants (`TERMINAL_EVENTS`) and typed subscription/emission helpers (`onTerminalCreated`, `emitTerminalCreated`, etc.).
- Create `src/utils/workspace-events.js` with workspace-domain event constants (`WORKSPACE_EVENTS`) and typed helpers (`onLayoutChanged`, `emitFileOpen`, etc.).
- Refactor `src/utils/events.js` into a backward-compatible re-export aggregator (no bus definition, re-exports from `event-bus.js`, `terminal-events.js`, `workspace-events.js`).
- Migrate all 7 consumer files from raw `bus.emit()`/`bus.on()` with string literals to typed domain helpers, making event contracts explicit and traceable.
- Remove dead `EVT_CREATED`/`EVT_REMOVED`/`EVT_EXITED` constants from `board-helpers.js` (superseded by `TERMINAL_EVENTS`).

Closes #263
Closes #238

## Fichiers modifies

| Fichier | Nature |
|---------|--------|
| `src/utils/event-bus.js` | **Nouveau** -- singleton bus (zero imports) |
| `src/utils/terminal-events.js` | **Nouveau** -- constantes + helpers terminal |
| `src/utils/workspace-events.js` | **Nouveau** -- constantes + helpers workspace |
| `src/utils/events.js` | Refactored into re-export aggregator |
| `src/utils/board-helpers.js` | Removed dead `EVT_*` constants |
| `src/utils/terminal-instance.js` | Migrated to `terminal-events.js` |
| `src/components/tab-manager.js` | Migrated to typed domain helpers |
| `src/components/board-view.js` | Migrated to typed domain helpers |
| `src/components/file-viewer.js` | Migrated to typed domain helpers |
| `src/components/file-tree.js` | Migrated to `workspace-events.js` |
| `src/components/terminal-panel.js` | Migrated to typed domain helpers |
| `src/components/git-changes-view.js` | Migrated to `workspace-events.js` |

## Architecture finale

```
event-bus.js           <-- singleton bus (zero imports)
  ^          ^
  |          |
terminal-events.js   workspace-events.js
  (domaine terminal)   (domaine workspace)
  ^          ^
  |          |
events.js  (re-export aggregator, backward compat)
```

## Verifications

- [x] Build OK (`npm run build`)
- [x] Tests OK (16 fichiers, 200 tests, 0 echecs)
- [x] Zero consumer imports `bus` directly -- all use typed domain helpers
- [x] No circular dependency: `event-bus.js` has zero imports

---

> Path local : `/Users/rekta/projet/coding/refactor-pikagent`

> PR creee automatiquement par l'Agent Refactor