### PR TITLE
refactor: remove any type casts in tab-drag.js

### DIFF
--- a/src/utils/drag-helpers.js
+++ b/src/utils/drag-helpers.js
@@ -57,9 +57,9 @@ export function trackMouse(cursor, onMove, onDone, { bodyClass = 'resizing' } = 
  * @param {Record<string, unknown>} stateObj — mutable state object
  * @param {string} stateKey      — key to set on stateObj
  * @param {unknown} value        — value written at dragstart (cleared to null at dragend)
- * @param {{ onStart?: (e: DragEvent) => void, onEnd?: (e: DragEvent) => void }} [extras]
+ * @param {{ onStart?: (e?: DragEvent) => void, onEnd?: (e?: DragEvent) => void }} [extras]
  *        — optional extra work to run after the class/state bookkeeping
- * @returns {{ onDragStart: (e: DragEvent) => void, onDragEnd: (e: DragEvent) => void }}
+ * @returns {{ onDragStart: (e?: DragEvent) => void, onDragEnd: (e?: DragEvent) => void }}
  */
 export function setupSimpleDragState(element, dragClass, stateObj, stateKey, value, { onStart, onEnd } = {}) {
   const onDragStart = (e) => {

--- a/src/utils/tab-drag.js
+++ b/src/utils/tab-drag.js
@@ -154,7 +154,7 @@ function buildTabDragHandlers(deps, tabEl, state, tabId) {
 
   return {
     startDrag() {
-      onDragStart(/** @type {unknown} */ ({}));
+      onDragStart();
       return createTabGhost(tabEl);
     },
     endDrag(ghost) {
@@ -164,7 +164,7 @@ function buildTabDragHandlers(deps, tabEl, state, tabId) {
       if (state.dropTargetId && state.dropTargetId !== tabId) {
         reorderTab(tabId, state.dropTargetId, state.dropBefore);
       }
-      onDragEnd(/** @type {unknown} */ ({}));
+      onDragEnd();
     },
   };
 }


### PR DESCRIPTION
## Refactoring

Remplacement des 2 casts `/** @type {any} */` dans `tab-drag.js` par une approche type-safe.

Au lieu de passer un objet vide casté, les paramètres `e` de `onDragStart`/`onDragEnd` dans `setupSimpleDragState` sont rendus optionnels (`e?: DragEvent`), permettant un appel sans argument depuis `tab-drag.js`.

Closes #288

## Fichier(s) modifié(s)

- `src/utils/tab-drag.js` — suppression des casts, appels sans argument
- `src/utils/drag-helpers.js` — paramètres `e` rendus optionnels dans les JSDoc

## Vérifications

- [x] Build OK
- [x] Tests OK (371/371)

---

📂 Path local : `/Users/rekta/projet/coding/refactor-pikagent`
🤖 PR créée automatiquement par l'Agent Refactor