### PR TITLE
refactor: remove leftover _alert helper in open-pr-flow

### DIFF
--- a/src/utils/open-pr-flow.js
+++ b/src/utils/open-pr-flow.js
@@ -65,10 +65,6 @@ function buildPrUrl({ host, owner, repo }, branch, baseBranch) {
  * }} OpenPrApi
  */
 
-async function _alert(msg) {
-  await showConfirmDialog(msg, { confirmLabel: 'OK', cancelLabel: 'Close' });
-}
-
 /**
  * Try to create a PR via the `gh` CLI. Returns true when handled (success
  * or a clean failure already surfaced to the user); returns false when the
@@ -134,7 +130,10 @@ export async function openPrFlow({ cwd, baseBranch = null, api }) {
     return;
   }
   if (!remote) {
-    await _alert(_el('p', null, 'No ', _el('code', null, 'origin'), ' remote configured.'));
+    await showConfirmDialog(
+      _el('p', null, 'No ', _el('code', null, 'origin'), ' remote configured.'),
+      { confirmLabel: 'OK', cancelLabel: 'Close' },
+    );
     return;
   }
 


### PR DESCRIPTION
## Summary

- Removes the `_alert(msg)` helper from `open-pr-flow.js` and inlines its single call site
- The main error-dialog deduplication was already done in #280 (`showErrorAlert` in `dom-dialogs.js`); this PR cleans up the last leftover wrapper that couldn't use `showErrorAlert` (different DOM structure with trailing text after `<code>`)

Closes #275

## Test plan

- [x] `npm run build` passes
- [x] `npm test` passes (371 tests)
- [ ] Manual: trigger the "no origin remote" error path in the PR flow to verify the inlined dialog still displays correctly

Generated with [Claude Code](https://claude.com/claude-code)