### PR TITLE
refactor: remove hub re-exports from tab-manager-helpers.js

### DIFF
--- a/src/utils/tab-manager-helpers.js
+++ b/src/utils/tab-manager-helpers.js
@@ -1,17 +1,14 @@
 /**
  * Tab manager helpers — pure helper functions for tab management.
  *
- * Constants have been extracted to ./tab-constants.js
- * The WorkspaceTab class has been extracted to ./tab-types.js
+ * Constants live in ./tab-constants.js
+ * The WorkspaceTab class lives in ./tab-types.js
  *
- * This file re-exports everything from both modules for backward compatibility.
+ * This file contains ONLY the pure helpers (clampPanelWidth, panelArrowState,
+ * reorderEntries, findCycleMatch, findCycleTarget, findColorGroupTarget).
  */
 
 import { PANEL_MIN_WIDTH, SIDE_CONFIG } from './tab-constants.js';
-
-// ── Re-exports for backward compatibility ──
-export * from './tab-constants.js';
-export * from './tab-types.js';
 
 // ── Pure helpers ──
 

--- a/src/utils/tab-types.js
+++ b/src/utils/tab-types.js
@@ -1,5 +1,5 @@
 /**
- * Tab type definitions — JSDoc typedefs extracted from tab-manager-helpers.js.
+ * Tab type definitions — canonical home of the WorkspaceTab class.
  *
  * This file is the canonical home of the WorkspaceTab class.
  */


### PR DESCRIPTION
## Summary
- Remove `export * from './tab-constants.js'` and `export * from './tab-types.js'` re-exports from `tab-manager-helpers.js`
- These backward-compatibility re-exports were dead code: all consumers already import constants from `tab-constants.js` and `WorkspaceTab` from `tab-types.js` directly
- Update module header comments to reflect the clean separation of concerns

## Context
The codebase had already evolved (via #285 and other PRs) to extract constants and types into their own files. However `tab-manager-helpers.js` still acted as a hub by re-exporting everything. This PR completes the split by removing those re-exports.

## Test plan
- [x] All 371 tests pass (25 test files) — `npx vitest run`
- [x] No file imports constants or types through `tab-manager-helpers.js`
- [x] Only pure helper functions remain in `tab-manager-helpers.js`

Closes #260

🤖 Generated with [Claude Code](https://claude.com/claude-code)