### PR TITLE
refactor: extract JsonStore from duplicated CRUD boilerplate

### DIFF
--- a/main/config-manager.js
+++ b/main/config-manager.js
@@ -1,18 +1,14 @@
-const fsp = require('fs/promises');
-const path = require('path');
 const { CONFIG_DIR, META_FILE } = require('./paths');
-const { readJson, writeJson, ensureDirOnce, readDirJson } = require('./fs-utils');
+const { readJson, writeJson } = require('./fs-utils');
 const { DEFAULT_META, sanitizeName, buildConfigRecord, formatConfigList } = require('./config-helpers');
 const { Cache } = require('./cache');
-const { createLogger, trySafe } = require('./logger');
+const { trySafe } = require('./logger');
+const { JsonStore } = require('./json-store');
 
-const log = createLogger('config-manager');
-const ensureDir = ensureDirOnce(CONFIG_DIR);
+const store = new JsonStore(CONFIG_DIR, 'config-manager', {
+  idToFile: (name) => `${sanitizeName(name)}.json`,
+});
 const _metaCache = new Cache();
-
-function configPath(name) {
-  return path.join(CONFIG_DIR, `${sanitizeName(name)}.json`);
-}
 
 async function readMeta() {
   const cached = _metaCache.get();
@@ -23,37 +19,36 @@ async function readMeta() {
 }
 
 async function writeMeta(meta) {
-  await ensureDir();
+  await store.ensureDir();
   _metaCache.set(meta);
   await writeJson(META_FILE, meta);
 }
 
 async function save(name, data) {
-  await ensureDir();
-  const existing = await readJson(configPath(name));
+  await store.ensureDir();
+  const existing = await store.get(name);
   const config = buildConfigRecord(name, data, existing);
-  await writeJson(configPath(name), config);
+  await store.save(name, config);
   return config;
 }
 
 async function load(name) {
-  return readJson(configPath(name));
+  return store.get(name);
 }
 
 async function list() {
-  await ensureDir();
   const meta = await readMeta();
   return trySafe(
-    async () => formatConfigList(await readDirJson(CONFIG_DIR), meta.defaultConfig),
+    async () => formatConfigList(await store.list(), meta.defaultConfig),
     [],
-    { log, label: 'list' },
+    { log: store.log, label: 'list' },
   );
 }
 
 async function remove(name) {
   return trySafe(
     async () => {
-      await fsp.unlink(configPath(name));
+      await store.remove(name);
       const meta = await readMeta();
       if (meta.defaultConfig === name) {
         meta.defaultConfig = null;
@@ -62,7 +57,7 @@ async function remove(name) {
       return true;
     },
     false,
-    { log, label: 'remove' },
+    { log: store.log, label: 'remove' },
   );
 }
 

--- a/main/config-manager.js
+++ b/main/config-manager.js
@@ -48,7 +48,7 @@ async function list() {
 async function remove(name) {
   return trySafe(
     async () => {
-      await store.remove(name);
+      await store.removeOrThrow(name);
       const meta = await readMeta();
       if (meta.defaultConfig === name) {
         meta.defaultConfig = null;

--- a/main/flow-manager.js
+++ b/main/flow-manager.js
@@ -75,7 +75,7 @@ class FlowManager {
   async remove(id) {
     return trySafe(
       async () => {
-        await store.remove(id);
+        await store.removeOrThrow(id);
         await this._cleanLogs(id);
         return true;
       },

--- a/main/flow-manager.js
+++ b/main/flow-manager.js
@@ -2,20 +2,21 @@ const fsp = require('fs/promises');
 const path = require('path');
 const os = require('os');
 const { FLOWS_DIR, LOGS_DIR, FLOW_CATEGORIES_FILE } = require('./paths');
-const { readJson, writeJson, ensureDirOnce, readDirJson } = require('./fs-utils');
+const { readJson, writeJson, ensureDirOnce } = require('./fs-utils');
 const {
   SCHEDULER_INTERVAL_MS, SHELL_INIT_DELAY_MS, MAX_RUN_HISTORY,
   DEFAULT_PTY_COLS, DEFAULT_PTY_ROWS, MAX_FLOW_RUNTIME_MS,
-  flowPath, logPath,
+  logPath,
   shouldRun, buildFlowCommand, createOutputProcessor,
 } = require('./flow-helpers');
 const { safeSend } = require('./ipc-helpers');
 const { createPollingManager } = require('../shared/polling-manager');
 const { buildRecord } = require('./record-helpers');
-const { createLogger, trySafe } = require('./logger');
+const { trySafe } = require('./logger');
+const { JsonStore } = require('./json-store');
 
-const log = createLogger('flow-manager');
-const ensureDir = ensureDirOnce(LOGS_DIR);
+const store = new JsonStore(FLOWS_DIR, 'flow-manager');
+const ensureLogsDir = ensureDirOnce(LOGS_DIR);
 
 class FlowManager {
   constructor() {
@@ -53,34 +54,33 @@ class FlowManager {
   // --- CRUD ---
 
   async save(flow) {
-    await ensureDir();
+    await ensureLogsDir();
     const existing = await this.get(flow.id);
     const now = new Date().toISOString();
     const data = buildRecord(flow, { createdAt: existing?.createdAt || now, updatedAt: now });
     if (!data.runs) data.runs = [];
     if (data.enabled === undefined) data.enabled = true;
-    await writeJson(flowPath(flow.id), data);
+    await store.save(flow.id, data);
     return data;
   }
 
   async get(id) {
-    return readJson(flowPath(id));
+    return store.get(id);
   }
 
   async list() {
-    await ensureDir();
-    return readDirJson(FLOWS_DIR);
+    return store.list();
   }
 
   async remove(id) {
     return trySafe(
       async () => {
-        await fsp.unlink(flowPath(id));
+        await store.remove(id);
         await this._cleanLogs(id);
         return true;
       },
       false,
-      { log, label: 'remove' },
+      { log: store.log, label: 'remove' },
     );
   }
 
@@ -101,20 +101,20 @@ class FlowManager {
     return trySafe(
       () => fsp.readFile(logPath(flowId, timestamp), 'utf-8'),
       null,
-      { log, label: 'getRunLog' },
+      { log: store.log, label: 'getRunLog' },
     );
   }
 
   // --- Categories ---
 
   async getCategories() {
-    await ensureDir();
+    await store.ensureDir();
     const data = await readJson(FLOW_CATEGORIES_FILE);
     return data || { categories: [], order: {} };
   }
 
   async saveCategories(data) {
-    await ensureDir();
+    await store.ensureDir();
     await writeJson(FLOW_CATEGORIES_FILE, data);
     return data;
   }
@@ -126,7 +126,7 @@ class FlowManager {
         await Promise.all(files.map((f) => fsp.unlink(path.join(LOGS_DIR, f))));
       },
       undefined,
-      { log, label: 'cleanLogs' },
+      { log: store.log, label: 'cleanLogs' },
     );
   }
 
@@ -148,11 +148,11 @@ class FlowManager {
   // --- Execution ---
 
   async _saveLog(flowId, runTimestamp, output) {
-    await ensureDir();
+    await ensureLogsDir();
     await trySafe(
       () => fsp.writeFile(logPath(flowId, runTimestamp), output, 'utf-8'),
       undefined,
-      { log, label: 'saveLog' },
+      { log: store.log, label: 'saveLog' },
     );
   }
 
@@ -219,7 +219,7 @@ class FlowManager {
         this._ptyManager.write(ptyId, cmd);
       }, SHELL_INIT_DELAY_MS);
     } catch (err) {
-      log.error('execution failed', err);
+      store.log.error('execution failed', err);
       this._recordRun(flow.id, 'error', runTimestamp);
     }
   }

--- a/main/json-store.js
+++ b/main/json-store.js
@@ -1,0 +1,71 @@
+const path = require('path');
+const fsp = require('fs/promises');
+const { readJson, writeJson, readDirJson, ensureDirOnce } = require('./fs-utils');
+const { createLogger, trySafe } = require('./logger');
+
+/**
+ * Reusable JSON-file CRUD store.
+ *
+ * Encapsulates the boilerplate shared by config-manager and flow-manager:
+ *   ensureDir  → readJson / writeJson / readDirJson / fsp.unlink
+ *
+ * Each manager composes a JsonStore and layers its own business logic on top.
+ */
+class JsonStore {
+  /**
+   * @param {string} dir       - directory that holds the JSON files
+   * @param {string} logLabel  - label forwarded to createLogger
+   * @param {{ idToFile?: (id: string) => string }} [opts]
+   *   idToFile – optional function that maps an id to its filename (without
+   *              the directory prefix). Defaults to `${id}.json`.
+   */
+  constructor(dir, logLabel, opts = {}) {
+    this._dir = dir;
+    this._log = createLogger(logLabel);
+    this._ensureDir = ensureDirOnce(dir);
+    this._idToFile = opts.idToFile || ((id) => `${id}.json`);
+  }
+
+  /** Resolve the full path for a given id. */
+  _path(id) {
+    return path.join(this._dir, this._idToFile(id));
+  }
+
+  /** Read a single record by id (returns null when missing). */
+  async get(id) {
+    return readJson(this._path(id));
+  }
+
+  /** List every JSON record in the directory. */
+  async list() {
+    await this._ensureDir();
+    return readDirJson(this._dir);
+  }
+
+  /** Persist `data` under the given id. */
+  async save(id, data) {
+    await this._ensureDir();
+    return writeJson(this._path(id), data);
+  }
+
+  /** Delete the file for the given id. Returns true on success, false on error. */
+  async remove(id) {
+    return trySafe(
+      () => fsp.unlink(this._path(id)),
+      false,
+      { log: this._log, label: 'remove' },
+    );
+  }
+
+  /** Ensure the backing directory exists (idempotent). */
+  async ensureDir() {
+    return this._ensureDir();
+  }
+
+  /** Expose the logger so the owning manager can reuse it. */
+  get log() {
+    return this._log;
+  }
+}
+
+module.exports = { JsonStore };

--- a/main/json-store.js
+++ b/main/json-store.js
@@ -57,6 +57,17 @@ class JsonStore {
     );
   }
 
+  /**
+   * Delete the file for the given id, throwing on error.
+   *
+   * Use this instead of `remove()` when the caller wraps the call in its own
+   * `trySafe` and needs errors to propagate (e.g. to skip follow-up cleanup
+   * when the file deletion fails).
+   */
+  async removeOrThrow(id) {
+    await fsp.unlink(this._path(id));
+  }
+
   /** Ensure the backing directory exists (idempotent). */
   async ensureDir() {
     return this._ensureDir();

--- a/main/skills-manager.js
+++ b/main/skills-manager.js
@@ -3,15 +3,16 @@ const fsp = fs.promises;
 const path = require('path');
 const os = require('os');
 const { BASE_DIR } = require('./paths');
-const { readJson, writeJson, ensureDirOnce } = require('./fs-utils');
-const { createLogger, trySafe } = require('./logger');
+const { readJson, writeJson } = require('./fs-utils');
+const { trySafe } = require('./logger');
 const { pathExists } = require('./fs-manager-helpers');
+const { JsonStore } = require('./json-store');
 
-const log = createLogger('skills-manager');
+const store = new JsonStore(BASE_DIR, 'skills-manager');
+const log = store.log;
 
 const DEFAULT_SKILLS_DIR = path.join(os.homedir(), '.claude', 'skills');
 const SETTINGS_FILE = path.join(BASE_DIR, 'skills-settings.json');
-const ensureBaseDir = ensureDirOnce(BASE_DIR);
 
 let _rootCache = null;
 
@@ -36,7 +37,7 @@ async function _loadRoot() {
 }
 
 async function _saveRoot(newRoot) {
-  await ensureBaseDir();
+  await store.ensureDir();
   await writeJson(SETTINGS_FILE, { root: newRoot });
   _rootCache = newRoot;
 }


### PR DESCRIPTION
## Refactoring

Extract common CRUD boilerplate (get/list/save/remove with ensureDir, readJson, writeJson, trySafe) into a shared `JsonStore` class. The 3 managers now compose with JsonStore for CRUD and retain their specific business logic.

Closes #276

## Fichier(s) modifié(s)

- `main/json-store.js` (new)
- `main/config-manager.js` (simplified CRUD)
- `main/flow-manager.js` (simplified CRUD)
- `main/skills-manager.js` (simplified CRUD)

## Vérifications

- [x] Build OK
- [x] Tests OK

---

📂 Path local : `/Users/rekta/projet/coding/refactor-pikagent`
🤖 PR créée automatiquement par l'Agent Refactor