### PR TITLE
refactor: extract shared settings section builder from 3 components

### DIFF
--- a/src/components/settings-appearance.js
+++ b/src/components/settings-appearance.js
@@ -6,7 +6,7 @@ import { TERMINAL_THEMES, getTerminalThemeName, setTerminalTheme, getTerminalThe
 import { getAppTheme, setAppTheme } from '../utils/app-theme.js';
 import { _el, createActionButton } from '../utils/dom.js';
 import { MODE_BUTTONS, THEME_PREVIEW_LINES, COLOR_DOT_KEYS } from '../utils/settings-helpers.js';
-import { createSettingsSection } from '../utils/settings-section-builder.js';
+import { buildSettingsSection } from '../utils/settings-section-builder.js';
 import { registerComponent } from '../utils/component-registry.js';
 import { createAsyncHandler } from '../utils/event-helpers.js';
 
@@ -95,16 +95,14 @@ export function renderAppearance(contentEl, tabManager, renderAppearanceFn) {
 
   // Terminal theme grid
   const subHeading = _el('h4', 'theme-sub-heading', 'Terminal Theme');
-
   const currentThemeName = getTerminalThemeName();
-  const grid = _el('div', 'theme-grid');
-  for (const [name, theme] of Object.entries(TERMINAL_THEMES)) {
-    grid.appendChild(_createThemeCard(name, theme, name === currentThemeName, tabManager, renderAppearanceFn));
-  }
 
-  createSettingsSection(contentEl, {
+  buildSettingsSection(contentEl, {
     heading: 'Appearance',
-    content: [modeRow, subHeading, grid],
+    items: Object.entries(TERMINAL_THEMES),
+    renderItem: ([name, theme]) => _createThemeCard(name, theme, name === currentThemeName, tabManager, renderAppearanceFn),
+    listClass: 'theme-grid',
+    before: [modeRow, subHeading],
   });
 }
 

--- a/src/components/settings-configs.js
+++ b/src/components/settings-configs.js
@@ -2,31 +2,24 @@
  * Workspace Configs section renderer for SettingsModal.
  * Extracted from settings-modal.js to reduce component size.
  */
-import { _el, renderButtonBar } from '../utils/dom.js';
+import { _el } from '../utils/dom.js';
 import { CONFIG_ACTIONS, BOTTOM_CONFIG_BUTTONS, formatConfigMeta } from '../utils/settings-helpers.js';
-import { createSettingsSection } from '../utils/settings-section-builder.js';
+import { buildSettingsSection, createActionBar } from '../utils/settings-section-builder.js';
 import { registerComponent } from '../utils/component-registry.js';
 import { createAsyncHandler } from '../utils/event-helpers.js';
 
 function _createConfigActions(config, tabManager, renderConfigsFn) {
-  const handlers = {
-    setDefault: createAsyncHandler(
-      { onSuccess: renderConfigsFn },
-      () => window.api.config.setDefault(config.name),
-    ),
-    overwrite: createAsyncHandler(
-      { guard: () => !!tabManager, onSuccess: renderConfigsFn },
-      () => window.api.config.save(config.name, tabManager.serialize()),
-    ),
-    delete: createAsyncHandler(
-      { onSuccess: renderConfigsFn },
-      () => window.api.config.delete(config.name),
-    ),
-  };
-
-  const configs = CONFIG_ACTIONS
-    .filter(desc => !(desc.hideWhen && config[desc.hideWhen]));
-  return renderButtonBar({ containerClass: 'config-actions', configs, handlers });
+  return createActionBar({
+    containerClass: 'config-actions',
+    actions: CONFIG_ACTIONS,
+    handlerDefs: {
+      setDefault: { apiCall: () => window.api.config.setDefault(config.name) },
+      overwrite: { apiCall: () => window.api.config.save(config.name, tabManager.serialize()), guard: () => !!tabManager },
+      delete: { apiCall: () => window.api.config.delete(config.name) },
+    },
+    onSuccess: renderConfigsFn,
+    filter: (desc) => !(desc.hideWhen && config[desc.hideWhen]),
+  });
 }
 
 function _buildConfigRowLeft(config) {
@@ -63,24 +56,26 @@ function _createConfigRow(config, currentName, tabManager, renderConfigsFn) {
 }
 
 function _createBottomActions(currentName, tabManager, renderConfigsFn) {
-  const handlers = {
-    new: () => {
-      if (!tabManager) return;
-      tabManager.configManager.promptConfigName('', async (name) => {
-        await tabManager.configManager.newConfig(name);
-        renderConfigsFn();
-      });
+  return createActionBar({
+    containerClass: 'config-bottom-actions',
+    actions: BOTTOM_CONFIG_BUTTONS.map(({ label, action }) => ({ label, action, cls: 'config-bottom-btn' })),
+    handlerDefs: {
+      new: () => {
+        if (!tabManager) return;
+        tabManager.configManager.promptConfigName('', async (name) => {
+          await tabManager.configManager.newConfig(name);
+          renderConfigsFn();
+        });
+      },
+      duplicate: () => {
+        if (!tabManager) return;
+        tabManager.configManager.promptConfigName(`${currentName} (copy)`, async (name) => {
+          await tabManager.configManager.duplicateConfig(name);
+          renderConfigsFn();
+        });
+      },
     },
-    duplicate: () => {
-      if (!tabManager) return;
-      tabManager.configManager.promptConfigName(`${currentName} (copy)`, async (name) => {
-        await tabManager.configManager.duplicateConfig(name);
-        renderConfigsFn();
-      });
-    },
-  };
-  const configs = BOTTOM_CONFIG_BUTTONS.map(({ label, action }) => ({ label, action, cls: 'config-bottom-btn' }));
-  return renderButtonBar({ containerClass: 'config-bottom-actions', configs, handlers });
+  });
 }
 
 /**
@@ -99,14 +94,14 @@ export async function renderConfigs(contentEl, tabManager, renderConfigsFn) {
 
   // Config list
   const configs = await window.api.config.list();
-  const list = _el('div', 'config-list');
-  for (const config of configs) {
-    list.appendChild(_createConfigRow(config, currentName, tabManager, renderConfigsFn));
-  }
 
-  createSettingsSection(contentEl, {
+  buildSettingsSection(contentEl, {
     heading: 'Workspace Configs',
-    content: [currentBar, list, _createBottomActions(currentName, tabManager, renderConfigsFn)],
+    items: configs,
+    renderItem: (config) => _createConfigRow(config, currentName, tabManager, renderConfigsFn),
+    listClass: 'config-list',
+    before: [currentBar],
+    after: [_createBottomActions(currentName, tabManager, renderConfigsFn)],
   });
 }
 

--- a/src/components/settings-keybindings.js
+++ b/src/components/settings-keybindings.js
@@ -5,7 +5,7 @@
 import { formatCombo } from '../utils/shortcut-helpers.js';
 import { _el, createActionButton } from '../utils/dom.js';
 import { onClickStopped } from '../utils/event-helpers.js';
-import { createSettingsSection } from '../utils/settings-section-builder.js';
+import { buildSettingsSection } from '../utils/settings-section-builder.js';
 import { registerComponent } from '../utils/component-registry.js';
 
 /**
@@ -44,6 +44,34 @@ function createKeyBadge(binding, index, shortcutManager, startRecordingFn, rende
 }
 
 /**
+ * Build a single keybinding row with badge elements and an add button.
+ */
+function _renderBindingRow(binding, shortcutManager, startRecordingFn, renderKeybindingsFn) {
+  const row = _el('div', 'keybinding-row');
+  row.appendChild(_el('div', 'keybinding-label', binding.label));
+
+  const keysContainer = _el('div', 'keybinding-keys');
+  for (let i = 0; i < binding.keys.length; i++) {
+    keysContainer.appendChild(createKeyBadge(binding, i, shortcutManager, startRecordingFn, renderKeybindingsFn));
+  }
+
+  const addBtn = createActionButton({
+    text: '+',
+    title: 'Add keybinding',
+    cls: 'keybinding-add-btn',
+    onClick: () => {
+      binding.keys.push('');
+      shortcutManager.updateBinding(binding.id, binding.keys);
+      renderKeybindingsFn();
+    },
+  });
+  keysContainer.appendChild(addBtn);
+
+  row.appendChild(keysContainer);
+  return row;
+}
+
+/**
  * Render the Keybindings section into the given content element.
  * @param {HTMLElement} contentEl - the settings content container
  * @param {{ updateBinding: (id: string, keys: string[]) => void, getBindingsList: () => Array<{ id: string, label: string, keys: string[] }>, resetToDefaults: () => void }} shortcutManager
@@ -60,37 +88,12 @@ export function renderKeybindings(contentEl, shortcutManager, startRecordingFn, 
     },
   });
 
-  const list = _el('div', 'keybinding-list');
-
-  for (const binding of shortcutManager.getBindingsList()) {
-    const row = _el('div', 'keybinding-row');
-    row.appendChild(_el('div', 'keybinding-label', binding.label));
-
-    const keysContainer = _el('div', 'keybinding-keys');
-    for (let i = 0; i < binding.keys.length; i++) {
-      keysContainer.appendChild(createKeyBadge(binding, i, shortcutManager, startRecordingFn, renderKeybindingsFn));
-    }
-
-    const addBtn = createActionButton({
-      text: '+',
-      title: 'Add keybinding',
-      cls: 'keybinding-add-btn',
-      onClick: () => {
-        binding.keys.push('');
-        shortcutManager.updateBinding(binding.id, binding.keys);
-        renderKeybindingsFn();
-      },
-    });
-    keysContainer.appendChild(addBtn);
-
-    row.appendChild(keysContainer);
-    list.appendChild(row);
-  }
-
-  createSettingsSection(contentEl, {
+  buildSettingsSection(contentEl, {
     heading: 'Keyboard Shortcuts',
+    items: shortcutManager.getBindingsList(),
+    renderItem: (binding) => _renderBindingRow(binding, shortcutManager, startRecordingFn, renderKeybindingsFn),
+    listClass: 'keybinding-list',
     actions: [resetBtn],
-    content: [list],
   });
 }
 

--- a/src/utils/settings-section-builder.js
+++ b/src/utils/settings-section-builder.js
@@ -3,7 +3,8 @@
  * Abstracts the heading + content + action buttons pattern
  * shared across settings-appearance, settings-configs, and settings-keybindings.
  */
-import { _el } from './dom.js';
+import { _el, renderButtonBar } from './dom.js';
+import { createAsyncHandler } from './event-helpers.js';
 
 /**
  * Build a settings section and populate the given container.
@@ -23,4 +24,77 @@ export function createSettingsSection(contentEl, { heading, actions = [], conten
   for (const el of content) contentEl.appendChild(el);
 
   return headingEl;
+}
+
+/**
+ * Higher-level settings section builder that iterates an items array through
+ * a renderItem callback, then delegates to {@link createSettingsSection}.
+ *
+ * This extracts the repeated pattern found across settings-keybindings and
+ * settings-configs where a list of domain objects is mapped to DOM rows
+ * inside a wrapper element.
+ *
+ * @param {HTMLElement} contentEl - the settings content container (will be cleared)
+ * @param {{
+ *   heading: string,
+ *   items: unknown[],
+ *   renderItem: (item: unknown) => HTMLElement,
+ *   listClass?: string,
+ *   actions?: HTMLElement[],
+ *   before?: HTMLElement[],
+ *   after?: HTMLElement[],
+ * }} opts
+ * @returns {HTMLElement} the heading element
+ */
+export function buildSettingsSection(contentEl, { heading, items, renderItem, listClass, actions, before = [], after = [] }) {
+  const list = _el('div', listClass || null);
+  for (const item of items) {
+    list.appendChild(renderItem(item));
+  }
+
+  return createSettingsSection(contentEl, {
+    heading,
+    actions,
+    content: [...before, list, ...after],
+  });
+}
+
+/**
+ * Create action handler maps from declarative action descriptors.
+ *
+ * Extracts the repeated pattern in settings-configs where both
+ * `_createConfigActions` and `_createBottomActions` build a handlers object
+ * mapping action keys to async-wrapped callbacks, then feed it to
+ * `renderButtonBar`.
+ *
+ * Each entry in `actions` must have an `action` key. The corresponding
+ * handler is looked up in `handlerDefs`. When a `handlerDefs` entry is
+ * a plain function it is used as-is; when it is an object with `apiCall`
+ * (and optional `guard`) it is wrapped via `createAsyncHandler` with the
+ * shared `onSuccess` callback.
+ *
+ * @param {{
+ *   containerClass: string,
+ *   actions: Array<{ action: string, label?: string, title?: string, cls?: string, hideWhen?: string }>,
+ *   handlerDefs: Record<string, Function | { apiCall: Function, guard?: () => boolean }>,
+ *   onSuccess?: () => void,
+ *   filter?: (desc: object) => boolean,
+ * }} opts
+ * @returns {HTMLElement}
+ */
+export function createActionBar({ containerClass, actions, handlerDefs, onSuccess, filter }) {
+  const handlers = {};
+  for (const [key, def] of Object.entries(handlerDefs)) {
+    if (typeof def === 'function') {
+      handlers[key] = def;
+    } else {
+      handlers[key] = createAsyncHandler(
+        { guard: def.guard, onSuccess },
+        def.apiCall,
+      );
+    }
+  }
+
+  const configs = filter ? actions.filter(filter) : actions;
+  return renderButtonBar({ containerClass, configs, handlers });
 }


### PR DESCRIPTION
## Refactoring

Extract duplicated settings section building pattern into shared helpers. All 3 settings components now use a common `buildSettingsSection()` factory, and the duplicated action handler creation in settings-configs uses a new `createActionBar()` factory.

Closes #307

## Fichier(s) modifié(s)

- `src/utils/settings-section-builder.js` (extended with `buildSettingsSection` + `createActionBar`)
- `src/components/settings-appearance.js`
- `src/components/settings-keybindings.js`
- `src/components/settings-configs.js`

## Vérifications

- [x] Build OK
- [x] Tests OK (371/371)

---

📂 Path local : `/Users/rekta/projet/coding/refactor-pikagent`
🤖 PR créée automatiquement par l'Agent Refactor