### PR TITLE
refactor: extract shared patterns from main process modules

### DIFF
--- a/main/cache.js
+++ b/main/cache.js
@@ -42,4 +42,30 @@ class Cache {
   }
 }
 
-module.exports = { Cache };
+/**
+ * Returns an async function that checks the cache first, and only calls `fn`
+ * on a cache miss. The result is stored in the cache before being returned.
+ *
+ * Eliminates the repetitive pattern:
+ *   const cached = cache.get();
+ *   if (cached) return cached;
+ *   const result = await computeExpensive();
+ *   cache.set(result);
+ *   return result;
+ *
+ * @param {Cache} cache - Cache instance to use
+ * @param {() => Promise<T>} fn - Async function to compute the value on cache miss
+ * @returns {() => Promise<T>}
+ * @template T
+ */
+function cachedAsync(cache, fn) {
+  return async () => {
+    const cached = cache.get();
+    if (cached) return cached;
+    const result = await fn();
+    cache.set(result);
+    return result;
+  };
+}
+
+module.exports = { Cache, cachedAsync };

--- a/main/config-manager.js
+++ b/main/config-manager.js
@@ -1,7 +1,7 @@
 const { CONFIG_DIR, META_FILE } = require('./paths');
 const { readJson, writeJson } = require('./fs-utils');
 const { DEFAULT_META, sanitizeName, buildConfigRecord, formatConfigList } = require('./config-helpers');
-const { Cache } = require('./cache');
+const { Cache, cachedAsync } = require('./cache');
 const { trySafe } = require('./logger');
 const { JsonStore } = require('./json-store');
 
@@ -10,13 +10,7 @@ const store = new JsonStore(CONFIG_DIR, 'config-manager', {
 });
 const _metaCache = new Cache();
 
-async function readMeta() {
-  const cached = _metaCache.get();
-  if (cached) return cached;
-  const meta = (await readJson(META_FILE)) || { ...DEFAULT_META };
-  _metaCache.set(meta);
-  return meta;
-}
+const readMeta = cachedAsync(_metaCache, async () => (await readJson(META_FILE)) || { ...DEFAULT_META });
 
 async function writeMeta(meta) {
   await store.ensureDir();

--- a/main/usage-manager.js
+++ b/main/usage-manager.js
@@ -1,4 +1,4 @@
-const { Cache } = require('./cache');
+const { Cache, cachedAsync } = require('./cache');
 const { createLogger } = require('./logger');
 const {
   getAllFlows,
@@ -22,10 +22,7 @@ function init(sessionMgr) {
 
 // ===== Aggregation =====
 
-async function getMetrics() {
-  const cached = _metricsCache.get();
-  if (cached) return cached;
-
+const getMetrics = cachedAsync(_metricsCache, async () => {
   const flows = await getAllFlows();
   const flowRuns = getFlowRuns(flows);
 
@@ -40,17 +37,13 @@ async function getMetrics() {
     getMostModifiedFiles(collectUniqueCwds(flowRuns, allSessions)),
   ]);
 
-  const result = {
+  return {
     tokens,
     flow: buildFlowMetrics(flows, flowRuns),
     agent: agentMetrics,
     mostModifiedFiles,
     hasData: flows.length > 0 || allSessions.length > 0 || tokens.total > 0,
   };
-
-  _metricsCache.set(result);
-
-  return result;
-}
+});
 
 module.exports = { init, getMetrics };

--- a/tests/main/cache.test.js
+++ b/tests/main/cache.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-const { Cache } = require('../../main/cache');
+const { Cache, cachedAsync } = require('../../main/cache');
 
 describe('Cache', () => {
   describe('without TTL', () => {
@@ -64,5 +64,54 @@ describe('Cache', () => {
       vi.advanceTimersByTime(800);
       expect(cache.get()).toBe('second');
     });
+  });
+});
+
+describe('cachedAsync', () => {
+  it('calls fn on first invocation and caches result', async () => {
+    const cache = new Cache();
+    const fn = vi.fn().mockResolvedValue({ data: 42 });
+    const wrapped = cachedAsync(cache, fn);
+
+    const result = await wrapped();
+    expect(result).toEqual({ data: 42 });
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns cached value on subsequent calls without calling fn', async () => {
+    const cache = new Cache();
+    const fn = vi.fn().mockResolvedValue('expensive');
+    const wrapped = cachedAsync(cache, fn);
+
+    await wrapped();
+    const result = await wrapped();
+    expect(result).toBe('expensive');
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('recomputes after cache expires (TTL)', async () => {
+    vi.useFakeTimers();
+    const cache = new Cache(500);
+    let counter = 0;
+    const fn = vi.fn().mockImplementation(async () => ++counter);
+    const wrapped = cachedAsync(cache, fn);
+
+    expect(await wrapped()).toBe(1);
+    vi.advanceTimersByTime(500);
+    expect(await wrapped()).toBe(2);
+    expect(fn).toHaveBeenCalledTimes(2);
+    vi.useRealTimers();
+  });
+
+  it('recomputes after cache.clear()', async () => {
+    const cache = new Cache();
+    let counter = 0;
+    const fn = vi.fn().mockImplementation(async () => ++counter);
+    const wrapped = cachedAsync(cache, fn);
+
+    expect(await wrapped()).toBe(1);
+    cache.clear();
+    expect(await wrapped()).toBe(2);
+    expect(fn).toHaveBeenCalledTimes(2);
   });
 });


### PR DESCRIPTION
## Refactoring

Factorise le pattern "cache check-then-use" dupliqué dans le main process via un nouveau helper `cachedAsync(cache, fn)`.

### Patterns traités

- **Pattern 3 (Cache check-then-use)** : Extrait `cachedAsync(cache, fn)` dans `cache.js` — une fonction d'ordre supérieur qui encapsule le pattern répétitif "vérifier le cache / calculer si miss / stocker le résultat". Appliqué à `config-manager.js` (readMeta) et `usage-manager.js` (getMetrics).

### Patterns déjà résolus (skip)

- **Pattern 1** (Error-wrapped git commands) : `executeGitCommand` déjà extrait dans `git-manager.js`
- **Pattern 2** (PTY listener setup) : déjà factorisé en `_setupPtyListeners` dans flow-manager
- **Pattern 4** (Manager lifecycle) : déjà géré par `shared/polling-manager.js`
- **Pattern 5** (IPC handler wrapping) : déjà consolidé via `registerHandlers` dans ipc-helpers
- **Pattern 6** (Channel aliasing) : trivial (1-liners), une factory ajouterait de l'indirection inutile

Closes #305

## Fichier(s) modifié(s)

- `main/cache.js` — ajout de `cachedAsync(cache, fn)`
- `main/config-manager.js` — utilise `cachedAsync` pour `readMeta`
- `main/usage-manager.js` — utilise `cachedAsync` pour `getMetrics`
- `tests/main/cache.test.js` — tests unitaires pour `cachedAsync`

## Vérifications

- [x] Build OK
- [x] Tests OK (382 tests passing)

---

📂 Path local : `/Users/rekta/projet/coding/refactor-pikagent`
🤖 PR créée automatiquement par l'Agent Refactor