### PR TITLE
refactor: extract ComponentBase class for shared lifecycle pattern

### DIFF
--- a/src/components/board-view.js
+++ b/src/components/board-view.js
@@ -3,6 +3,7 @@ import { _el, renderButtonBar } from '../utils/dom.js';
 import { _safeFit, createTerminal, disposeTerminal, disposeTerminalMap, setupTerminalAddons } from '../utils/terminal-factory.js';
 import { registerComponent } from '../utils/component-registry.js';
 import { RendererPollingTimer } from '../utils/polling.js';
+import { ComponentBase } from '../utils/component-base.js';
 import {
   DATA_VOLUME_THRESHOLD, POLL_INTERVAL_MS, FIT_SETTLE_DELAY_MS, FIT_UNHIDE_DELAY_MS,
   STATUS_CONFIG, ALL_CARD_CLASSES,
@@ -11,12 +12,11 @@ import {
   formatCardLabel,
 } from '../utils/board-helpers.js';
 
-export class BoardView {
+export class BoardView extends ComponentBase {
   constructor(container, tabManager) {
-    this.container = container;
+    super(container);
     this.tabManager = tabManager;
     this.cards = new Map();
-    this.disposed = false;
     this._hiddenTerms = new Set();
 
     this.render();
@@ -213,9 +213,9 @@ export class BoardView {
     const onTerminalGone = ({ id }) => { this.removeCard(id); this._updateEmptyState(); };
 
     // Typed subscription helpers — each returns an unsubscribe function
-    this._unsubCreated = onTerminalCreated(() => { if (!this.disposed) this.scanAgents(); });
-    this._unsubRemoved = onTerminalRemoved(onTerminalGone);
-    this._unsubExited  = onTerminalExited(onTerminalGone);
+    this._track(onTerminalCreated(() => { if (!this.disposed) this.scanAgents(); }));
+    this._track(onTerminalRemoved(onTerminalGone));
+    this._track(onTerminalExited(onTerminalGone));
   }
 
   focusDirection(dir) {
@@ -252,12 +252,8 @@ export class BoardView {
   }
 
   dispose() {
-    this.disposed = true;
+    super.dispose();
     this.pause();
-
-    this._unsubCreated();
-    this._unsubRemoved();
-    this._unsubExited();
     disposeTerminalMap(this.cards);
   }
 }

--- a/src/components/file-tree.js
+++ b/src/components/file-tree.js
@@ -16,10 +16,11 @@ import {
   promptRename as doPromptRename,
   promptNewEntry as doPromptNewEntry,
 } from '../utils/file-tree-drop.js';
+import { ComponentBase } from '../utils/component-base.js';
 
-export class FileTree {
+export class FileTree extends ComponentBase {
   constructor(container) {
-    this.container = container;
+    super(container);
     this.termCwds = new Map();
     this.sections = new Map();
     this.debounceTimers = new Map();
@@ -55,7 +56,7 @@ export class FileTree {
   }
 
   listenForChanges() {
-    this.unsubFs = window.api.fs.onChanged(({ id }) => {
+    this._track(window.api.fs.onChanged(({ id }) => {
       if (this.debounceTimers.has(id)) {
         clearTimeout(this.debounceTimers.get(id));
       }
@@ -66,7 +67,7 @@ export class FileTree {
           this.refreshSection(id).catch(() => {});
         }, DEBOUNCE_DELAY)
       );
-    });
+    }));
   }
 
   async setTerminalRoot(termId, dirPath) {
@@ -288,7 +289,7 @@ export class FileTree {
   }
 
   dispose() {
-    if (this.unsubFs) this.unsubFs();
+    super.dispose();
     for (const [, section] of this.sections) {
       window.api.fs.unwatch(section.watchId);
     }

--- a/src/components/file-viewer.js
+++ b/src/components/file-viewer.js
@@ -8,10 +8,11 @@ import { renderTabs as renderTabsHelper } from '../utils/file-viewer-tabs.js';
 import { renderModeBar } from '../utils/file-viewer-mode-bar.js';
 import { setupFileViewerListeners } from '../utils/file-viewer-listeners.js';
 import { registerComponent, getComponent } from '../utils/component-registry.js';
+import { ComponentBase } from '../utils/component-base.js';
 
-export class FileViewer {
+export class FileViewer extends ComponentBase {
   constructor(container, isActive) {
-    this.container = container;
+    super(container);
     this.isActive = isActive || (() => true);
     this.openFiles = new Map(); // path -> { name, content, savedContent, lang }
     this.activeFile = null;
@@ -28,7 +29,7 @@ export class FileViewer {
       () => this._renderModeBar(),
     );
     this._renderModeBar();
-    this._busListeners = setupFileViewerListeners(
+    const busListeners = setupFileViewerListeners(
       { isActive: () => this.isActive() },
       {
         switchMode: (m) => this.switchMode(m),
@@ -38,6 +39,7 @@ export class FileViewer {
         loadPinnedFiles: () => this.loadPinnedFiles(),
       },
     );
+    for (const unsub of busListeners) this._track(unsub);
   }
 
   static get pinnedFiles() { return pinnedFiles; }
@@ -290,8 +292,7 @@ export class FileViewer {
   }
 
   dispose() {
-    for (const unsub of this._busListeners) unsub();
-    this._busListeners = [];
+    super.dispose();
     this._webviewMgr.dispose();
   }
 }

--- a/src/components/flow-view.js
+++ b/src/components/flow-view.js
@@ -3,6 +3,7 @@ import { _el, renderButtonBar } from '../utils/flow-dom.js';
 import { showPromptDialog } from '../utils/dom-dialogs.js';
 import { generateId } from '../utils/id.js';
 import { registerComponent, getComponent } from '../utils/component-registry.js';
+import { ComponentBase } from '../utils/component-base.js';
 import {
   EMPTY_LIST_MESSAGE, UNCATEGORIZED, HEADER_BUTTONS,
   getFlowsForCategory, getUncategorizedFlows,
@@ -12,13 +13,12 @@ import { createCategoryGroup } from '../utils/flow-category-renderer.js';
 import { createFlowCard } from '../utils/flow-card-setup.js';
 
 
-export class FlowView {
+export class FlowView extends ComponentBase {
   constructor(container, tabManager) {
-    this.container = container;
+    super(container);
     this.tabManager = tabManager;
     this.flows = [];
     this.catData = { categories: [], order: {} };
-    this.disposed = false;
     const FlowCardTerminalManager = getComponent('FlowCardTerminalManager');
     this._termManager = new FlowCardTerminalManager();
     this._expandedCards = new Set();
@@ -28,17 +28,17 @@ export class FlowView {
     // Drag state (shared mutable object for use with setupCardDrag)
     this._drag = { flowId: null, catId: null };
 
-    this._unsubStarted = window.api.flow.onRunStarted(({ flowId, ptyId }) => {
+    this._track(window.api.flow.onRunStarted(({ flowId, ptyId }) => {
       this._runningMap[flowId] = ptyId;
       this._expandedCards.add(flowId);
       this.refresh();
-    });
+    }));
 
-    this._unsubComplete = window.api.flow.onRunComplete(({ flowId }) => {
+    this._track(window.api.flow.onRunComplete(({ flowId }) => {
       this._termManager.disposeLiveTerminal(flowId);
       delete this._runningMap[flowId];
       this.refresh();
-    });
+    }));
 
     this.render();
     this._initRunning();
@@ -265,9 +265,7 @@ export class FlowView {
   }
 
   dispose() {
-    this.disposed = true;
-    if (this._unsubStarted) this._unsubStarted();
-    if (this._unsubComplete) this._unsubComplete();
+    super.dispose();
     this._termManager.disposeAll();
   }
 }

--- a/src/components/git-changes-view.js
+++ b/src/components/git-changes-view.js
@@ -3,10 +3,11 @@ import { _el } from '../utils/dom.js';
 import { onClickStopped } from '../utils/event-helpers.js';
 import { STATUS_LABELS, CHEVRON, CHANGE_SECTIONS, computeTotalChanges, buildFileKey } from '../utils/git-changes-helpers.js';
 import { registerComponent, getComponent } from '../utils/component-registry.js';
+import { ComponentBase } from '../utils/component-base.js';
 
-export class GitChangesView {
+export class GitChangesView extends ComponentBase {
   constructor(container) {
-    this.container = container;
+    super(container);
     this.gitCwd = null;
     this.expandedFile = null;
   }
@@ -16,6 +17,7 @@ export class GitChangesView {
   }
 
   dispose() {
+    super.dispose();
     this.container.replaceChildren();
   }
 

--- a/src/components/skills-view.js
+++ b/src/components/skills-view.js
@@ -1,16 +1,16 @@
 import { _el } from '../utils/dom.js';
 import { showPromptDialog, showConfirmDialog } from '../utils/dom-dialogs.js';
 import { registerComponent } from '../utils/component-registry.js';
+import { ComponentBase } from '../utils/component-base.js';
 
-export class SkillsView {
+export class SkillsView extends ComponentBase {
   constructor(container) {
-    this.container = container;
+    super(container);
     this.skills = [];
     this.selectedId = null;
     this.rootPath = '';
     this.editorDirty = false;
     this.editorValue = '';
-    this.disposed = false;
 
     this.el = _el('div', 'skills-container');
     container.appendChild(this.el);
@@ -278,7 +278,7 @@ export class SkillsView {
   }
 
   dispose() {
-    this.disposed = true;
+    super.dispose();
     this.el.remove();
   }
 }

--- a/src/components/usage-view.js
+++ b/src/components/usage-view.js
@@ -1,12 +1,13 @@
 import { _el } from '../utils/dom.js';
 import { TABS, getTabConfig, createSection } from '../utils/usage-view-helpers.js';
 import { registerComponent } from '../utils/component-registry.js';
+import { ComponentBase } from '../utils/component-base.js';
 
 // --- Component ---
 
-export class UsageView {
+export class UsageView extends ComponentBase {
   constructor(container) {
-    this.container = container;
+    super(container);
     this.el = _el('div', { className: 'usage-container' });
     container.appendChild(this.el);
     this.activeTab = 'agents';
@@ -79,6 +80,7 @@ export class UsageView {
   }
 
   dispose() {
+    super.dispose();
     this.el.remove();
   }
 

--- a/src/utils/component-base.js
+++ b/src/utils/component-base.js
@@ -1,0 +1,45 @@
+/**
+ * Base class for UI components that share a common lifecycle pattern:
+ * container assignment, disposed guard, and tracked disposables.
+ *
+ * Subclasses should:
+ * - Call `super(container)` in their constructor
+ * - Use `this._track(unsub)` in listener setup to register disposables
+ * - Use `this._guardDisposed(fn)` to skip work when disposed
+ * - Override `dispose()` calling `super.dispose()` if extra cleanup is needed
+ */
+export class ComponentBase {
+  constructor(container) {
+    this.container = container;
+    this.disposed = false;
+    this._disposables = [];
+  }
+
+  /**
+   * Register an unsubscribe function (or any teardown callback) to be called on dispose.
+   * @param {Function} unsub
+   * @returns {Function} the same unsub, for chaining
+   */
+  _track(unsub) {
+    this._disposables.push(unsub);
+    return unsub;
+  }
+
+  /**
+   * Execute `fn` only if the component has not been disposed.
+   * @param {Function} fn
+   */
+  _guardDisposed(fn) {
+    if (!this.disposed) fn();
+  }
+
+  /**
+   * Mark the component as disposed and call all tracked disposables.
+   * Subclasses that override this should call `super.dispose()`.
+   */
+  dispose() {
+    this.disposed = true;
+    this._disposables.forEach(fn => fn?.());
+    this._disposables = [];
+  }
+}


### PR DESCRIPTION
## Refactoring

Extrait une classe `ComponentBase` dans `src/utils/component-base.js` qui factorise le pattern lifecycle (constructor/render/dispose/listeners) dupliqué dans 7 composants classes.

Closes #314

## Fichier(s) modifié(s)

- **Nouveau** : `src/utils/component-base.js`
- **Modifiés** : 7 composants dans `src/components/`
  - `board-view.js`
  - `flow-view.js`
  - `skills-view.js`
  - `file-tree.js`
  - `file-viewer.js`
  - `usage-view.js`
  - `git-changes-view.js`

## Non modifiés

Les fichiers `settings-appearance.js`, `settings-keybindings.js` et `settings-configs.js` sont des fonctions de rendu pures (pas des classes) et ne correspondent pas au pattern lifecycle — ils sont laissés en l'état.

## Vérifications

- [x] Build OK
- [x] Tests OK (379 tests, 25 suites)

---

Path local : `/Users/rekta/projet/coding/refactor-pikagent`
PR créée automatiquement par l'Agent Refactor