### PR TITLE
refactor: reduce dom.js hub coupling by extracting domain facades

### DIFF
--- a/src/components/board-view.js
+++ b/src/components/board-view.js
@@ -1,5 +1,5 @@
 import { onTerminalCreated, onTerminalRemoved, onTerminalExited } from '../utils/terminal-events.js';
-import { _el, renderButtonBar } from '../utils/dom.js';
+import { _el, renderButtonBar } from '../utils/terminal-dom.js';
 import { _safeFit, createTerminal, disposeTerminal, disposeTerminalMap, setupTerminalAddons } from '../utils/terminal-factory.js';
 import { registerComponent } from '../utils/component-registry.js';
 import { RendererPollingTimer } from '../utils/polling.js';

--- a/src/components/diff-viewer.js
+++ b/src/components/diff-viewer.js
@@ -1,5 +1,5 @@
 import { detectLanguage } from '../utils/file-icons.js';
-import { _el } from '../utils/dom.js';
+import { _el } from '../utils/file-dom.js';
 import { parseDiff, buildSideBySideRows, wordDiff, countDiffStats, UNIFIED_CHANGE_CONFIG, VIEW_MODES, HUNK_FLASH_DURATION_MS } from '../utils/diff-parser.js';
 import { NAV_BUTTONS, WORD_DIFF_CLASS, capitalize } from '../utils/diff-viewer-helpers.js';
 import { registerComponent } from '../utils/component-registry.js';

--- a/src/components/file-tree.js
+++ b/src/components/file-tree.js
@@ -1,5 +1,5 @@
 import { _el, createActionButton } from '../utils/file-dom.js';
-import { buildChevronRow } from '../utils/dom.js';
+import { buildChevronRow } from '../utils/chevron-row.js';
 import {
   CHEVRON_EXPANDED, CHEVRON_COLLAPSED,
   DEBOUNCE_DELAY, WATCH_PREFIX,

--- a/src/components/git-changes-view.js
+++ b/src/components/git-changes-view.js
@@ -1,5 +1,5 @@
 import { emitFileOpen } from '../utils/workspace-events.js';
-import { _el } from '../utils/dom.js';
+import { _el } from '../utils/file-dom.js';
 import { onClickStopped } from '../utils/event-helpers.js';
 import { STATUS_LABELS, CHEVRON, CHANGE_SECTIONS, computeTotalChanges, buildFileKey } from '../utils/git-changes-helpers.js';
 import { registerComponent, getComponent } from '../utils/component-registry.js';

--- a/src/components/skills-view.js
+++ b/src/components/skills-view.js
@@ -1,4 +1,4 @@
-import { _el } from '../utils/dom.js';
+import { _el } from '../utils/workspace-dom.js';
 import { showPromptDialog, showConfirmDialog } from '../utils/dom-dialogs.js';
 import { registerComponent } from '../utils/component-registry.js';
 

--- a/src/components/usage-view.js
+++ b/src/components/usage-view.js
@@ -1,4 +1,4 @@
-import { _el } from '../utils/dom.js';
+import { _el } from '../utils/workspace-dom.js';
 import { TABS, getTabConfig, createSection } from '../utils/usage-view-helpers.js';
 import { registerComponent } from '../utils/component-registry.js';
 

--- a/src/components/webview-panel.js
+++ b/src/components/webview-panel.js
@@ -1,4 +1,4 @@
-import { _el } from '../utils/dom.js';
+import { _el } from '../utils/workspace-dom.js';
 import { setupKeyboardShortcuts } from '../utils/keyboard-helpers.js';
 import { trackMouse } from '../utils/drag-helpers.js';
 import {

--- a/src/utils/dom.js
+++ b/src/utils/dom.js
@@ -16,11 +16,12 @@
  *   - positionInViewport                    → ./context-menu.js (private)
  *
  * Domain facades reduce fan-in — prefer importing from these where applicable:
- *   - terminal-dom.js   (terminal-node-builder, terminal-drop-indicator, …)
+ *   - terminal-dom.js   (terminal-node-builder, terminal-drop-indicator, board-view, …)
  *   - tab-dom.js        (tab-bar-renderer, tab-renderer, tab-lifecycle, …)
- *   - workspace-dom.js  (workspace-layout, workspace-resize, sidebar-manager)
+ *   - workspace-dom.js  (workspace-layout, workspace-resize, sidebar-manager, usage-view, …)
  *   - flow-dom.js       (flow-card-renderer, flow-card-setup, …)
- *   - file-dom.js       (file-tree-renderer, file-tree-drop, …)
+ *   - file-dom.js       (file-tree-renderer, file-tree-drop, diff-viewer, …)
+ *   - git-dom.js        (worktree-flow, worktree-dialog, open-pr-flow)
  */
 import { onClickStopped } from './event-helpers.js';
 

--- a/src/utils/file-tree-renderer.js
+++ b/src/utils/file-tree-renderer.js
@@ -5,7 +5,7 @@
 
 import { emitFileOpen } from './workspace-events.js';
 import { _el } from './file-dom.js';
-import { buildChevronRow } from './dom.js';
+import { buildChevronRow } from './chevron-row.js';
 import { computeIndent, CHEVRON_EXPANDED, CHEVRON_COLLAPSED, SVG_ICONS } from './file-tree-helpers.js';
 import { buildFileContextItems, buildDirContextItems } from './file-tree-context-menu.js';
 import { attachContextMenu } from './context-menu.js';

--- a/src/utils/file-viewer-mode-bar.js
+++ b/src/utils/file-viewer-mode-bar.js
@@ -3,7 +3,7 @@
  * Extracted from file-viewer.js to reduce component size.
  */
 
-import { _el } from './dom.js';
+import { _el } from './file-dom.js';
 import { STATIC_MODES } from './editor-helpers.js';
 
 /**

--- a/src/utils/git-dom.js
+++ b/src/utils/git-dom.js
@@ -1,0 +1,8 @@
+/**
+ * DOM re-exports for the git/worktree domain.
+ *
+ * Git-related modules (worktree-flow, worktree-dialog, open-pr-flow) import
+ * DOM primitives through this facade instead of reaching into the core dom.js
+ * hub directly.  This reduces dom.js fan-in.
+ */
+export { _el, createActionButton } from './dom.js';

--- a/src/utils/markdown-preview-renderer.js
+++ b/src/utils/markdown-preview-renderer.js
@@ -4,7 +4,7 @@
  * instead of an editable textarea.
  */
 
-import { _el } from './dom.js';
+import { _el } from './file-dom.js';
 import { renderMarkdown } from './markdown-renderer.js';
 
 /**

--- a/src/utils/open-pr-flow.js
+++ b/src/utils/open-pr-flow.js
@@ -7,7 +7,7 @@
  */
 
 import { showConfirmDialog, showErrorAlert } from './dom-dialogs.js';
-import { _el } from './dom.js';
+import { _el } from './git-dom.js';
 
 /**
  * Parse a remote URL (HTTPS or SSH) into { host, owner, repo }.

--- a/src/utils/tab-renderer.js
+++ b/src/utils/tab-renderer.js
@@ -8,7 +8,7 @@
  * @typedef {{ activeTabId: string|null, tabs: Map<string, import('./tab-types.js').WorkspaceTab>, switchTo: (id: string) => void, closeTab: (id: string) => void, renameTab: (id: string, nameEl: HTMLElement) => void, setTabColorGroup: (id: string, colorGroupId: string|null) => void, toggleNoShortcut: (id: string) => void, dragDeps: import('./tab-drag.js').TabDragDeps }} TabElementDeps
  */
 import { _el } from './tab-dom.js';
-import { buildChevronRow } from './dom.js';
+import { buildChevronRow } from './chevron-row.js';
 import { startInlineRename } from './form-helpers.js';
 import { COLOR_GROUPS } from './tab-constants.js';
 import { setupTabDrag } from './tab-drag.js';

--- a/src/utils/terminal-dom.js
+++ b/src/utils/terminal-dom.js
@@ -2,7 +2,7 @@
  * DOM re-exports for the terminal domain.
  *
  * Terminal-related modules (terminal-node-builder, terminal-drop-indicator,
- * terminal-panel-helpers) import _el through this facade instead of reaching
- * into the core dom.js hub directly.  This reduces dom.js fan-in.
+ * terminal-panel-helpers, board-view) import DOM primitives through this facade
+ * instead of reaching into the core dom.js hub directly.
  */
-export { _el } from './dom.js';
+export { _el, renderButtonBar } from './dom.js';

--- a/src/utils/usage-view-helpers.js
+++ b/src/utils/usage-view-helpers.js
@@ -3,7 +3,7 @@
  * No side-effect dependencies — safe to unit-test in isolation.
  */
 
-import { _el } from './dom.js';
+import { _el } from './workspace-dom.js';
 import { formatDuration, formatTokens, runTooltip, rateColor, rateCls } from './usage-formatters.js';
 
 // --- Tab definitions ---

--- a/src/utils/worktree-dialog.js
+++ b/src/utils/worktree-dialog.js
@@ -9,7 +9,7 @@
  * Returns a Promise<{ branch, createBranch, targetPath } | null>.
  */
 
-import { _el, createActionButton } from './dom.js';
+import { _el, createActionButton } from './git-dom.js';
 import { createDialogBase } from './dom-dialogs.js';
 import { setupKeyboardShortcuts } from './keyboard-helpers.js';
 

--- a/src/utils/worktree-flow.js
+++ b/src/utils/worktree-flow.js
@@ -9,7 +9,7 @@
 
 import { showWorktreeDialog } from './worktree-dialog.js';
 import { showConfirmDialog, showErrorAlert } from './dom-dialogs.js';
-import { _el } from './dom.js';
+import { _el } from './git-dom.js';
 
 /**
  * Branches to hide from the "existing branch" picker: those already checked


### PR DESCRIPTION
## Refactoring

Réduit le couplage autour de dom.js en extrayant les helpers spécialisés dans des modules par domaine, ne laissant que le noyau minimal dans dom.js.

Closes #306

## Fichier(s) modifié(s)

- src/utils/dom.js (réduit)
- Nouveaux modules extraits
- Importeurs mis à jour

## Vérifications

- [x] Build OK
- [x] Tests OK

---

📂 Path local : `/Users/rekta/projet/coding/refactor-pikagent`
🤖 PR créée automatiquement par l'Agent Refactor