### PR TITLE
refactor: remove unused CACHE_TTL export

### DIFF
--- a/main/usage-helpers.js
+++ b/main/usage-helpers.js
@@ -25,7 +25,6 @@ const PERDAY_KEYS = TOKEN_FIELD_MAP.filter(f => f.perDay).map(f => f.key);
 
 const MAX_RUN_DURATION_MS = 24 * 60 * 60 * 1000;
 const TOP_PROJECTS_LIMIT = 10;
-const CACHE_TTL = 30000;
 const TOP_FILES_LIMIT = 15;
 const GIT_TIMEOUT_MS = 5000;
 
@@ -267,7 +266,6 @@ function collectUniqueCwds(flowRuns, sessions) {
 }
 
 module.exports = {
-  CACHE_TTL,
   TOP_FILES_LIMIT,
   GIT_TIMEOUT_MS,
   newTokenTotals,


### PR DESCRIPTION
## Refactoring

Suppression de la constante `CACHE_TTL` exportée dans `main/usage-helpers.js` qui n'était importée par aucun module. `usage-manager.js` définit sa propre constante locale.

Closes #318

## Fichier(s) modifié(s)

- `main/usage-helpers.js`

## Vérifications

- [x] Build OK
- [x] Tests OK (384 passed)

---

📂 Path local : `/Users/rekta/projet/coding/refactor-pikagent`
🤖 PR créée automatiquement par l'Agent Refactor