### PR TITLE
refactor: extract renderList helper to replace duplicated replaceChildren pattern

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -776,7 +776,6 @@
       "dev": true,
       "license": "BSD-2-Clause",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "cross-dirname": "^0.1.0",
         "debug": "^4.3.4",
@@ -798,7 +797,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -815,7 +813,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "universalify": "^2.0.0"
       },
@@ -830,34 +827,8 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -867,7 +838,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -2255,6 +2225,7 @@
       "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -3156,8 +3127,7 @@
       "integrity": "sha512-+R08/oI0nl3vfPcqftZRpytksBXDzOUveBq/NBVx0sUp1axwzPQrKinNx5yd5sxPu8j1wIy8AfnVQ+5eFdha6Q==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -3327,6 +3297,7 @@
       "integrity": "sha512-glMJgnTreo8CFINujtAhCgN96QAqApDMZ8Vl1r8f0QT8QprvC1UCltV4CcWj20YoIyLZx6IUskaJZ0NV8fokcg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "app-builder-lib": "26.8.1",
         "builder-util": "26.8.1",
@@ -3628,7 +3599,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@electron/asar": "^3.2.1",
         "debug": "^4.1.1",
@@ -3649,7 +3619,6 @@
       "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.1.2",
         "jsonfile": "^4.0.0",
@@ -3788,6 +3757,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -4265,6 +4235,7 @@
       "integrity": "sha512-GZZ9mKe8r646NUAf/zemnGbjYh4Bt8/MqASJY+pSm5ZDtc3YQox+4gsLI7yi1hba6o+eCsGxpHn5+iEVn31/FQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/node": ">=20.0.0",
         "@types/whatwg-mimetype": "^3.0.2",
@@ -5430,6 +5401,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5488,7 +5460,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "commander": "^9.4.0"
       },
@@ -5506,7 +5477,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": "^12.20.0 || >=14"
       }
@@ -6104,7 +6074,6 @@
       "integrity": "sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "mkdirp": "^0.5.1",
         "rimraf": "~2.6.2"
@@ -6168,7 +6137,6 @@
       "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "minimist": "^1.2.6"
       },
@@ -6183,7 +6151,6 @@
       "deprecated": "Rimraf versions prior to v4 are no longer supported",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -6376,6 +6343,7 @@
       "integrity": "sha512-B9ifbFudT1TFhfltfaIPgjo9Z3mDynBTJSUYxTjOQruf/zHH+ezCQKcoqO+h7a9Pw9Nm/OtlXAiGT1axBgwqrQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",

--- a/src/components/board-view.js
+++ b/src/components/board-view.js
@@ -1,5 +1,5 @@
 import { onTerminalCreated, onTerminalRemoved, onTerminalExited } from '../utils/terminal-events.js';
-import { _el, renderButtonBar } from '../utils/terminal-dom.js';
+import { _el, renderButtonBar, renderList } from '../utils/terminal-dom.js';
 import { _safeFit, createTerminal, disposeTerminal, disposeTerminalMap, setupTerminalAddons } from '../utils/terminal-factory.js';
 import { registerComponent } from '../utils/component-registry.js';
 import { RendererPollingTimer } from '../utils/polling.js';
@@ -188,14 +188,10 @@ export class BoardView extends ComponentBase {
 
   _updateHiddenBar() {
     if (!this.hiddenBarEl) return;
-    this.hiddenBarEl.replaceChildren();
-    if (this._hiddenTerms.size === 0) return;
-
-    for (const termId of this._hiddenTerms) {
+    renderList(this.hiddenBarEl, [...this._hiddenTerms], (termId) => {
       const card = this.cards.get(termId);
-      if (!card) continue;
-
-      this.hiddenBarEl.appendChild(_el('button', {
+      if (!card) return null;
+      return _el('button', {
         className: 'board-hidden-chip',
         textContent: formatCardLabel(card.info.agent, card.info.tabName),
         title: 'Show',
@@ -205,8 +201,8 @@ export class BoardView extends ComponentBase {
           this._updateHiddenBar();
           setTimeout(() => _safeFit(card.fitAddon), FIT_UNHIDE_DELAY_MS);
         },
-      }));
-    }
+      });
+    });
   }
 
   _setupListeners() {

--- a/src/components/skills-view.js
+++ b/src/components/skills-view.js
@@ -1,4 +1,4 @@
-import { _el } from '../utils/workspace-dom.js';
+import { _el, renderList } from '../utils/workspace-dom.js';
 import { showPromptDialog, showConfirmDialog } from '../utils/dom-dialogs.js';
 import { registerComponent } from '../utils/component-registry.js';
 import { ComponentBase } from '../utils/component-base.js';
@@ -153,33 +153,27 @@ export class SkillsView extends ComponentBase {
     if (!this.listEl) return;
     if (this._rootBadgeEl) this._rootBadgeEl.textContent = this.rootPath;
 
-    this.listEl.replaceChildren();
+    renderList(this.listEl, this.skills, (skill) => _el('div', {
+      className: `skills-item ${this.selectedId === skill.id ? 'skills-item-active' : ''}`,
+      onClick: () => this._selectSkill(skill.id),
+    },
+      _el('div', 'skills-item-main',
+        _el('div', 'skills-item-name', skill.name),
+        skill.description && _el('div', 'skills-item-desc', skill.description),
+      ),
+      _el('div', 'skills-item-meta',
+        _el('div', 'skills-item-source', skill.source),
+      ),
+      _el('button', {
+        className: 'skills-item-delete',
+        title: 'Supprimer',
+        textContent: '✕',
+        onClick: (e) => { e.stopPropagation(); this._deleteSkill(skill.id); },
+      }),
+    ));
 
     if (this.skills.length === 0) {
       this.listEl.appendChild(_el('div', 'skills-empty', 'Aucun skill. Créez-en un pour commencer.'));
-      return;
-    }
-
-    for (const skill of this.skills) {
-      const item = _el('div', {
-        className: `skills-item ${this.selectedId === skill.id ? 'skills-item-active' : ''}`,
-        onClick: () => this._selectSkill(skill.id),
-      },
-        _el('div', 'skills-item-main',
-          _el('div', 'skills-item-name', skill.name),
-          skill.description && _el('div', 'skills-item-desc', skill.description),
-        ),
-        _el('div', 'skills-item-meta',
-          _el('div', 'skills-item-source', skill.source),
-        ),
-        _el('button', {
-          className: 'skills-item-delete',
-          title: 'Supprimer',
-          textContent: '✕',
-          onClick: (e) => { e.stopPropagation(); this._deleteSkill(skill.id); },
-        }),
-      );
-      this.listEl.appendChild(item);
     }
   }
 

--- a/src/utils/dom.js
+++ b/src/utils/dom.js
@@ -2,7 +2,7 @@
  * Core DOM utilities.
  *
  * This module keeps only the essential DOM factories:
- *   _el, createActionButton, renderButtonBar
+ *   _el, createActionButton, renderButtonBar, renderList
  *
  * The following helpers have been extracted to dedicated modules — import
  * them directly from there instead of going through this file:
@@ -113,6 +113,20 @@ export function renderButtonBar({ containerClass, configs, handlers }) {
     }));
   }
   return bar;
+}
+
+/**
+ * Clear a container and populate it by calling `renderItem` for each item.
+ * @param {HTMLElement} container
+ * @param {Array} items
+ * @param {(item: *, index: number) => HTMLElement|null} renderItem
+ */
+export function renderList(container, items, renderItem) {
+  container.replaceChildren();
+  for (let i = 0; i < items.length; i++) {
+    const el = renderItem(items[i], i);
+    if (el) container.appendChild(el);
+  }
 }
 
 /**

--- a/src/utils/file-dom.js
+++ b/src/utils/file-dom.js
@@ -5,4 +5,4 @@
  * file-editor-renderer, file-viewer-tabs) import _el through this facade
  * instead of reaching into the core dom.js hub directly.
  */
-export { _el, createActionButton } from './dom.js';
+export { _el, createActionButton, renderList } from './dom.js';

--- a/src/utils/file-viewer-tabs.js
+++ b/src/utils/file-viewer-tabs.js
@@ -3,7 +3,7 @@
  * Extracted from file-viewer.js to reduce component size.
  */
 
-import { _el } from './file-dom.js';
+import { _el, renderList } from './file-dom.js';
 import { attachContextMenu } from './context-menu.js';
 import { createTabElement } from './tab-renderer.js';
 
@@ -69,8 +69,7 @@ function createTabEl(filePath, file, activeFile, isPinned, isModified, callbacks
  * @param {{ onClose: (filePath: string) => void, onActivate: (filePath: string) => void, onTogglePin: (filePath: string) => void }} callbacks
  */
 export function renderTabs(tabsBar, openFiles, activeFile, isPinned, isModified, callbacks) {
-  tabsBar.replaceChildren();
-  for (const [filePath, file] of openFiles) {
-    tabsBar.appendChild(createTabEl(filePath, file, activeFile, isPinned, isModified, callbacks));
-  }
+  renderList(tabsBar, [...openFiles], ([filePath, file]) =>
+    createTabEl(filePath, file, activeFile, isPinned, isModified, callbacks),
+  );
 }

--- a/src/utils/settings-dom.js
+++ b/src/utils/settings-dom.js
@@ -5,4 +5,4 @@
  * settings-keybindings, settings-update, settings-section-builder) import DOM
  * primitives through this facade instead of reaching into the core dom.js hub.
  */
-export { _el, createActionButton, renderButtonBar } from './dom.js';
+export { _el, createActionButton, renderButtonBar, renderList } from './dom.js';

--- a/src/utils/settings-section-builder.js
+++ b/src/utils/settings-section-builder.js
@@ -3,7 +3,7 @@
  * Abstracts the heading + content + action buttons pattern
  * shared across settings-appearance, settings-configs, and settings-keybindings.
  */
-import { _el, renderButtonBar } from './settings-dom.js';
+import { _el, renderButtonBar, renderList } from './settings-dom.js';
 import { createAsyncHandler } from './event-helpers.js';
 
 /**
@@ -48,9 +48,7 @@ export function createSettingsSection(contentEl, { heading, actions = [], conten
  */
 export function buildSettingsSection(contentEl, { heading, items, renderItem, listClass, actions, before = [], after = [] }) {
   const list = _el('div', listClass || null);
-  for (const item of items) {
-    list.appendChild(renderItem(item));
-  }
+  renderList(list, items, renderItem);
 
   return createSettingsSection(contentEl, {
     heading,

--- a/src/utils/terminal-dom.js
+++ b/src/utils/terminal-dom.js
@@ -5,4 +5,4 @@
  * terminal-panel-helpers, board-view) import DOM primitives through this facade
  * instead of reaching into the core dom.js hub directly.
  */
-export { _el, renderButtonBar } from './dom.js';
+export { _el, renderButtonBar, renderList } from './dom.js';

--- a/src/utils/workspace-dom.js
+++ b/src/utils/workspace-dom.js
@@ -5,4 +5,4 @@
  * import _el through this facade instead of reaching into the core dom.js
  * hub directly.  This reduces dom.js fan-in.
  */
-export { _el } from './dom.js';
+export { _el, renderList } from './dom.js';


### PR DESCRIPTION
## Refactoring

Ajout d'un helper `renderList(container, items, renderItem)` dans `src/utils/dom.js` et remplacement du pattern dupliqué `replaceChildren + for loop + appendChild` dans 4 fichiers consumers.

Le helper est aussi ré-exporté via les 4 facades DOM existantes (`file-dom`, `terminal-dom`, `workspace-dom`, `settings-dom`).

Closes #321

## Fichier(s) modifié(s)

- `src/utils/dom.js` — ajout de `renderList`
- `src/utils/file-dom.js` — ré-export
- `src/utils/terminal-dom.js` — ré-export
- `src/utils/workspace-dom.js` — ré-export
- `src/utils/settings-dom.js` — ré-export
- `src/utils/file-viewer-tabs.js` — utilise `renderList`
- `src/components/board-view.js` — utilise `renderList`
- `src/components/skills-view.js` — utilise `renderList`
- `src/utils/settings-section-builder.js` — utilise `renderList`

## Vérifications

- [x] Build OK
- [x] Tests OK (384/384)

---

📂 Path local : `/Users/rekta/projet/coding/refactor-pikagent`
🤖 PR créée automatiquement par l'Agent Refactor