### PR TITLE
refactor: remove unused variables win and log

### DIFF
--- a/main.js
+++ b/main.js
@@ -8,7 +8,7 @@ app.setName('Pickagent');
 let managerCleanup = null;
 
 app.whenReady().then(() => {
-  const win = window.create();
+  window.create();
   const getWindow = () => window.get();
 
   const { targets, cleanup, ptyManager, sessionManager } = initManagers(getWindow);

--- a/main/usage-manager.js
+++ b/main/usage-manager.js
@@ -1,5 +1,4 @@
 const { Cache, cachedAsync } = require('./cache');
-const { createLogger } = require('./logger');
 const {
   getAllFlows,
   getTokenMetrics,
@@ -9,8 +8,6 @@ const {
   collectUniqueCwds,
 } = require('./token-collector');
 const { getMostModifiedFiles } = require('./git-metrics-collector');
-
-const log = createLogger('usage-manager');
 
 let _sessionManager = null;
 const CACHE_TTL = 30_000;


### PR DESCRIPTION
## Refactoring

Suppression de 2 variables définies mais jamais utilisées :

- **`main.js`** : `const win = window.create()` → `window.create()` (l'appel side-effect est conservé)
- **`main/usage-manager.js`** : suppression de `const log = createLogger('usage-manager')` et de l'import `createLogger`

Closes #328

## Fichier(s) modifié(s)

- `main.js`
- `main/usage-manager.js`

## Vérifications

- [x] Build OK
- [x] Tests OK (386/386)

---

📂 Path local : `/Users/rekta/projet/coding/refactor-pikagent`
🤖 PR créée automatiquement par l'Agent Refactor