### PR TITLE
refactor: replace loose JSDoc types with precise signatures

### DIFF
--- a/main/ipc-helpers.js
+++ b/main/ipc-helpers.js
@@ -67,8 +67,8 @@ function getRegisteredChannels(skip = new Set()) {
  *
  * @param {Electron.IpcMain} ipc
  * @param {Record<string, (...args: unknown[]) => unknown>} target
- * @param {Array} entries
- * @param {(target: object, entry: Array) => (event: any, arg: any) => any} buildCallback
+ * @param {Array<[string, string, string[]?]>} entries
+ * @param {(target: Record<string, (...args: unknown[]) => unknown>, entry: [string, string, string[]?]) => (event: Electron.IpcMainInvokeEvent, arg: unknown) => unknown} buildCallback
  */
 function registerHandlers(ipc, target, entries, buildCallback) {
   for (const entry of entries) {

--- a/src/utils/component-base.js
+++ b/src/utils/component-base.js
@@ -17,8 +17,8 @@ export class ComponentBase {
 
   /**
    * Register an unsubscribe function (or any teardown callback) to be called on dispose.
-   * @param {Function} unsub
-   * @returns {Function} the same unsub, for chaining
+   * @param {() => void} unsub
+   * @returns {() => void} the same unsub, for chaining
    */
   _track(unsub) {
     this._disposables.push(unsub);
@@ -27,7 +27,7 @@ export class ComponentBase {
 
   /**
    * Execute `fn` only if the component has not been disposed.
-   * @param {Function} fn
+   * @param {() => void} fn
    */
   _guardDisposed(fn) {
     if (!this.disposed) fn();

--- a/src/utils/dom.js
+++ b/src/utils/dom.js
@@ -118,8 +118,8 @@ export function renderButtonBar({ containerClass, configs, handlers }) {
 /**
  * Clear a container and populate it by calling `renderItem` for each item.
  * @param {HTMLElement} container
- * @param {Array} items
- * @param {(item: *, index: number) => HTMLElement|null} renderItem
+ * @param {Array<unknown>} items
+ * @param {(item: unknown, index: number) => HTMLElement|null} renderItem
  */
 export function renderList(container, items, renderItem) {
   container.replaceChildren();


### PR DESCRIPTION
## Refactoring

Remplacement des types JSDoc lâches (`any`, `Function`, `Array` sans generics) par des types précis dans 3 fichiers :

- **`main/ipc-helpers.js`** : `any` → `unknown`, `Array` → `Array<[string, string, string[]?]>`, types Electron explicites
- **`src/utils/dom.js`** : `Array` → `Array<unknown>`, wildcard `*` → `unknown`
- **`src/utils/component-base.js`** : `Function` → `() => void`

⚠️ Régression de #248

Closes #327

## Fichier(s) modifié(s)

- `main/ipc-helpers.js`
- `src/utils/dom.js`
- `src/utils/component-base.js`

## Vérifications

- [x] Build OK
- [x] Tests OK (386/386)

---

📂 Path local : `/Users/rekta/projet/coding/refactor-pikagent`
🤖 PR créée automatiquement par l'Agent Refactor