### PR TITLE
refactor: apply renderList pattern and simplify mode-bar rendering

### DIFF
--- a/src/utils/file-viewer-mode-bar.js
+++ b/src/utils/file-viewer-mode-bar.js
@@ -15,14 +15,14 @@ import { STATIC_MODES } from './editor-helpers.js';
  * @param {{ webviewTabs: Array<{ id: string, label: string, url: string }>, buildWebviewModeBtn: (wt: { id: string, label: string, url: string }, currentMode: string) => HTMLElement, buildAddWebviewBtn: (modeBar: HTMLElement) => HTMLElement }} webviewMgr
  */
 export function renderModeBar(modeBar, currentMode, { switchMode }, webviewMgr) {
-  modeBar.replaceChildren();
-  for (const { key, label } of STATIC_MODES) {
-    const btn = _el('button', `mode-btn${currentMode === key ? ' active' : ''}`, label);
-    btn.addEventListener('click', () => switchMode(key));
-    modeBar.appendChild(btn);
-  }
-  for (const wt of webviewMgr.webviewTabs) {
-    modeBar.appendChild(webviewMgr.buildWebviewModeBtn(wt, currentMode));
-  }
-  modeBar.appendChild(webviewMgr.buildAddWebviewBtn(modeBar));
+  const allItems = [
+    ...STATIC_MODES.map(({ key, label }) => {
+      const btn = _el('button', `mode-btn${currentMode === key ? ' active' : ''}`, label);
+      btn.addEventListener('click', () => switchMode(key));
+      return btn;
+    }),
+    ...webviewMgr.webviewTabs.map(wt => webviewMgr.buildWebviewModeBtn(wt, currentMode)),
+    webviewMgr.buildAddWebviewBtn(modeBar),
+  ];
+  modeBar.replaceChildren(...allItems);
 }

--- a/src/utils/sidebar-manager.js
+++ b/src/utils/sidebar-manager.js
@@ -17,7 +17,7 @@
  */
 
 import { getComponent } from './component-registry.js';
-import { _el } from './workspace-dom.js';
+import { _el, renderList } from './workspace-dom.js';
 import { ACTIVITY_BUTTONS, SETTINGS_ICON, SIDE_VIEWS } from './tab-constants.js';
 import { createAsyncHandler } from './event-helpers.js';
 
@@ -85,14 +85,13 @@ export function renderActivityBar({ sidebarMode, setSidebarMode, onOpenSettings 
   activityBar.replaceChildren();
 
   const topSection = _el('div', 'activity-bar-top');
-
-  for (const { label, mode, icon } of ACTIVITY_BUTTONS) {
+  renderList(topSection, ACTIVITY_BUTTONS, ({ label, mode, icon }) => {
     const btn = buildActivityButton(label, icon);
     btn.dataset.mode = mode;
     if (sidebarMode === mode) btn.classList.add('active');
     btn.addEventListener('click', () => setSidebarMode(mode));
-    topSection.appendChild(btn);
-  }
+    return btn;
+  });
 
   activityBar.appendChild(topSection);
 


### PR DESCRIPTION
## Refactoring

Application du helper `renderList` existant et simplification des patterns de rendu de listes :

- **`sidebar-manager.js`** : boucle manuelle sur `ACTIVITY_BUTTONS` remplacée par `renderList(topSection, ACTIVITY_BUTTONS, ...)`
- **`file-viewer-mode-bar.js`** : 2 boucles manuelles + appendChild consolidées en un seul `replaceChildren(...allItems)` avec spread

Note : `renderList` existait déjà dans `dom.js` et était utilisé par 4 fichiers. Les autres fichiers mentionnés dans l'issue utilisent déjà `renderList` ou ont des patterns trop complexes (tab-bar-renderer avec side-effect Map).

Closes #321

## Fichier(s) modifié(s)

- `src/utils/sidebar-manager.js`
- `src/utils/file-viewer-mode-bar.js`

## Vérifications

- [x] Build OK
- [x] Tests OK (386/386)

---

📂 Path local : `/Users/rekta/projet/coding/refactor-pikagent`
🤖 PR créée automatiquement par l'Agent Refactor