### PR TITLE
refactor: introduce createTypedEvent factory to reduce event boilerplate

### DIFF
--- a/src/utils/event-bus.js
+++ b/src/utils/event-bus.js
@@ -36,3 +36,15 @@ class EventBus {
 }
 
 export const bus = new EventBus();
+
+/**
+ * Create a pair of typed on/emit helpers for a given event name.
+ * @param {string} name - the event name
+ * @returns {{ on: (cb: Function) => () => void, emit: (data?: unknown) => void }}
+ */
+export function createTypedEvent(name) {
+  return {
+    on: (cb) => bus.on(name, cb),
+    emit: (data) => bus.emit(name, data),
+  };
+}

--- a/src/utils/terminal-events.js
+++ b/src/utils/terminal-events.js
@@ -8,7 +8,7 @@
  * @see event-bus.js (singleton bus instance)
  */
 
-import { bus } from './event-bus.js';
+import { createTypedEvent } from './event-bus.js';
 
 // ── Event constants ─────────────────────────────────────────────────
 
@@ -17,7 +17,7 @@ import { bus } from './event-bus.js';
  * @readonly
  * @enum {string}
  */
-export const TERMINAL_EVENTS = {
+const TERMINAL_EVENTS = {
   /** Terminal working directory changed (user ran `cd`). */
   CWD_CHANGED: 'terminal:cwdChanged',
   /** New terminal spawned in a tab. */
@@ -28,31 +28,29 @@ export const TERMINAL_EVENTS = {
   EXITED: 'terminal:exited',
 };
 
-// ── Typed subscription helpers ──────────────────────────────────────
-// Each returns an unsubscribe function.
+// ── Typed helpers (generated via factory) ───────────────────────────
+
+const cwdChanged = createTypedEvent(TERMINAL_EVENTS.CWD_CHANGED);
+const created = createTypedEvent(TERMINAL_EVENTS.CREATED);
+const removed = createTypedEvent(TERMINAL_EVENTS.REMOVED);
+const exited = createTypedEvent(TERMINAL_EVENTS.EXITED);
 
 /** @param {(data: { id: string, cwd: string }) => void} cb */
-export const onTerminalCwdChanged = (cb) => bus.on(TERMINAL_EVENTS.CWD_CHANGED, cb);
+export const onTerminalCwdChanged = cwdChanged.on;
+/** @param {{ id: string, cwd: string }} data */
+export const emitTerminalCwdChanged = cwdChanged.emit;
 
 /** @param {(data: { id: string, cwd: string }) => void} cb */
-export const onTerminalCreated = (cb) => bus.on(TERMINAL_EVENTS.CREATED, cb);
+export const onTerminalCreated = created.on;
+/** @param {{ id: string, cwd: string }} data */
+export const emitTerminalCreated = created.emit;
 
 /** @param {(data: { id: string }) => void} cb */
-export const onTerminalRemoved = (cb) => bus.on(TERMINAL_EVENTS.REMOVED, cb);
+export const onTerminalRemoved = removed.on;
+/** @param {{ id: string }} data */
+export const emitTerminalRemoved = removed.emit;
 
 /** @param {(data: { id: string }) => void} cb */
-export const onTerminalExited = (cb) => bus.on(TERMINAL_EVENTS.EXITED, cb);
-
-// ── Typed emission helpers ──────────────────────────────────────────
-
-/** @param {{ id: string, cwd: string }} data */
-export const emitTerminalCwdChanged = (data) => bus.emit(TERMINAL_EVENTS.CWD_CHANGED, data);
-
-/** @param {{ id: string, cwd: string }} data */
-export const emitTerminalCreated = (data) => bus.emit(TERMINAL_EVENTS.CREATED, data);
-
+export const onTerminalExited = exited.on;
 /** @param {{ id: string }} data */
-export const emitTerminalRemoved = (data) => bus.emit(TERMINAL_EVENTS.REMOVED, data);
-
-/** @param {{ id: string }} data */
-export const emitTerminalExited = (data) => bus.emit(TERMINAL_EVENTS.EXITED, data);
+export const emitTerminalExited = exited.emit;

--- a/src/utils/workspace-events.js
+++ b/src/utils/workspace-events.js
@@ -9,7 +9,7 @@
  * @see event-bus.js (singleton bus instance)
  */
 
-import { bus } from './event-bus.js';
+import { createTypedEvent } from './event-bus.js';
 
 // ── Event constants ─────────────────────────────────────────────────
 
@@ -18,7 +18,7 @@ import { bus } from './event-bus.js';
  * @readonly
  * @enum {string}
  */
-export const WORKSPACE_EVENTS = {
+const WORKSPACE_EVENTS = {
   /** Workspace layout changed (panel resize, split, webview). */
   LAYOUT_CHANGED: 'layout:changed',
   /** Workspace tab activated or re-shown. */
@@ -33,43 +33,41 @@ export const WORKSPACE_EVENTS = {
   FILE_OPEN: 'file:open',
 };
 
-// ── Typed subscription helpers ──────────────────────────────────────
-// Each returns an unsubscribe function.
+// ── Typed helpers (generated via factory) ───────────────────────────
+
+const layoutChanged = createTypedEvent(WORKSPACE_EVENTS.LAYOUT_CHANGED);
+const activated = createTypedEvent(WORKSPACE_EVENTS.ACTIVATED);
+const openFromFolder = createTypedEvent(WORKSPACE_EVENTS.OPEN_FROM_FOLDER);
+const createWorktree = createTypedEvent(WORKSPACE_EVENTS.CREATE_WORKTREE);
+const openPr = createTypedEvent(WORKSPACE_EVENTS.OPEN_PR);
+const fileOpen = createTypedEvent(WORKSPACE_EVENTS.FILE_OPEN);
 
 /** @param {(data: undefined) => void} cb */
-export const onLayoutChanged = (cb) => bus.on(WORKSPACE_EVENTS.LAYOUT_CHANGED, cb);
+export const onLayoutChanged = layoutChanged.on;
+/** Emit layout:changed (no payload). */
+export const emitLayoutChanged = layoutChanged.emit;
 
 /** @param {(data: undefined) => void} cb */
-export const onWorkspaceActivated = (cb) => bus.on(WORKSPACE_EVENTS.ACTIVATED, cb);
+export const onWorkspaceActivated = activated.on;
+/** Emit workspace:activated (no payload). */
+export const emitWorkspaceActivated = activated.emit;
 
 /** @param {(data: { cwd: string }) => void} cb */
-export const onWorkspaceOpenFromFolder = (cb) => bus.on(WORKSPACE_EVENTS.OPEN_FROM_FOLDER, cb);
+export const onWorkspaceOpenFromFolder = openFromFolder.on;
+/** @param {{ cwd: string }} data */
+export const emitWorkspaceOpenFromFolder = openFromFolder.emit;
 
 /** @param {(data: { repoCwd: string }) => void} cb */
-export const onWorkspaceCreateWorktree = (cb) => bus.on(WORKSPACE_EVENTS.CREATE_WORKTREE, cb);
+export const onWorkspaceCreateWorktree = createWorktree.on;
+/** @param {{ repoCwd: string }} data */
+export const emitWorkspaceCreateWorktree = createWorktree.emit;
 
 /** @param {(data: { repoCwd: string }) => void} cb */
-export const onWorkspaceOpenPr = (cb) => bus.on(WORKSPACE_EVENTS.OPEN_PR, cb);
+export const onWorkspaceOpenPr = openPr.on;
+/** @param {{ repoCwd: string }} data */
+export const emitWorkspaceOpenPr = openPr.emit;
 
 /** @param {(data: { path: string, name: string }) => void} cb */
-export const onFileOpen = (cb) => bus.on(WORKSPACE_EVENTS.FILE_OPEN, cb);
-
-// ── Typed emission helpers ──────────────────────────────────────────
-
-/** Emit layout:changed (no payload). */
-export const emitLayoutChanged = () => bus.emit(WORKSPACE_EVENTS.LAYOUT_CHANGED);
-
-/** Emit workspace:activated (no payload). */
-export const emitWorkspaceActivated = () => bus.emit(WORKSPACE_EVENTS.ACTIVATED);
-
-/** @param {{ cwd: string }} data */
-export const emitWorkspaceOpenFromFolder = (data) => bus.emit(WORKSPACE_EVENTS.OPEN_FROM_FOLDER, data);
-
-/** @param {{ repoCwd: string }} data */
-export const emitWorkspaceCreateWorktree = (data) => bus.emit(WORKSPACE_EVENTS.CREATE_WORKTREE, data);
-
-/** @param {{ repoCwd: string }} data */
-export const emitWorkspaceOpenPr = (data) => bus.emit(WORKSPACE_EVENTS.OPEN_PR, data);
-
+export const onFileOpen = fileOpen.on;
 /** @param {{ path: string, name: string }} data */
-export const emitFileOpen = (data) => bus.emit(WORKSPACE_EVENTS.FILE_OPEN, data);
+export const emitFileOpen = fileOpen.emit;

--- a/tests/utils/di-injection-workspace.test.js
+++ b/tests/utils/di-injection-workspace.test.js
@@ -16,7 +16,10 @@ describe('DI: tab-lifecycle onTerminalCwdChanged', () => {
       _el: () => ({}),
       showConfirmDialog: vi.fn().mockResolvedValue(true),
     }));
-    vi.doMock('../../src/utils/event-bus.js', () => ({ bus: { emit: vi.fn(), on: vi.fn() } }));
+    vi.doMock('../../src/utils/event-bus.js', () => {
+      const bus = { emit: vi.fn(), on: vi.fn() };
+      return { bus, createTypedEvent: (name) => ({ on: (cb) => bus.on(name, cb), emit: (data) => bus.emit(name, data) }) };
+    });
     vi.doMock('../../src/utils/id.js', () => ({ generateId: (prefix) => prefix + '-1' }));
     vi.doMock('../../src/utils/tab-types.js', () => ({
       WorkspaceTab: class { constructor(id, name, cwd) { this.id = id; this.name = name; this.cwd = cwd; } },

--- a/tests/utils/di-injection.test.js
+++ b/tests/utils/di-injection.test.js
@@ -33,7 +33,10 @@ describe('DI: file-tree-context-menu', () => {
   let buildCommonContextItems, buildFileContextItems, buildDirContextItems;
 
   beforeAll(async () => {
-    vi.doMock('../../src/utils/event-bus.js', () => ({ bus: { emit: vi.fn(), on: vi.fn() } }));
+    vi.doMock('../../src/utils/event-bus.js', () => {
+      const bus = { emit: vi.fn(), on: vi.fn() };
+      return { bus, createTypedEvent: (name) => ({ on: (cb) => bus.on(name, cb), emit: (data) => bus.emit(name, data) }) };
+    });
     vi.doMock('../../src/utils/file-tree-helpers.js', () => ({
       getRelativePath: (p, root) => p.replace(root + '/', ''),
       getBaseName: (p) => p.split('/').filter(Boolean).pop() || '/',
@@ -121,7 +124,10 @@ describe('DI: file-tree-drop handleFileDrop', () => {
       _el: () => ({}),
       setupInlineInput: vi.fn(),
     }));
-    vi.doMock('../../src/utils/event-bus.js', () => ({ bus: { emit: vi.fn(), on: vi.fn() } }));
+    vi.doMock('../../src/utils/event-bus.js', () => {
+      const bus = { emit: vi.fn(), on: vi.fn() };
+      return { bus, createTypedEvent: (name) => ({ on: (cb) => bus.on(name, cb), emit: (data) => bus.emit(name, data) }) };
+    });
     vi.doMock('../../src/utils/file-tree-helpers.js', () => ({
       getBaseName: (p) => p.split('/').filter(Boolean).pop() || '/',
       extractFolderName: (p) => p.split('/').filter(Boolean).pop() || '/',


### PR DESCRIPTION
## Refactoring

Création d'une factory `createTypedEvent(name)` dans `event-bus.js` qui génère automatiquement les paires on/emit, éliminant le boilerplate répétitif dans les fichiers d'événements :

- **`event-bus.js`** : ajout de `createTypedEvent(name)` → retourne `{ on, emit }`
- **`terminal-events.js`** : 4 événements convertis (de 25 lignes manuelles à 8 lignes factory)
- **`workspace-events.js`** : 6 événements convertis (de 38 lignes manuelles à 12 lignes factory)
- Constantes `TERMINAL_EVENTS`/`WORKSPACE_EVENTS` rendues privées (jamais importées ailleurs)
- Mocks de tests mis à jour pour inclure `createTypedEvent`

Les signatures publiques (on*/emit*) restent identiques — aucun changement d'API.

Closes #330

## Fichier(s) modifié(s)

- `src/utils/event-bus.js`
- `src/utils/terminal-events.js`
- `src/utils/workspace-events.js`
- `tests/utils/di-injection-workspace.test.js`
- `tests/utils/di-injection.test.js`

## Vérifications

- [x] Build OK
- [x] Tests OK (386/386)

---

📂 Path local : `/Users/rekta/projet/coding/refactor-pikagent`
🤖 PR créée automatiquement par l'Agent Refactor