### PR TITLE
refactor: inject component constructors instead of getComponent() in utils

### DIFF
--- a/src/components/file-viewer.js
+++ b/src/components/file-viewer.js
@@ -9,13 +9,19 @@ import {
   renderModeBar,
   setupFileViewerListeners,
 } from '../utils/file-viewer-subsystem.js';
-import { registerComponent, getComponent } from '../utils/component-registry.js';
+import { registerComponent } from '../utils/component-registry.js';
 import { ComponentBase } from '../utils/component-base.js';
 
 export class FileViewer extends ComponentBase {
-  constructor(container, isActive) {
+  /**
+   * @param {HTMLElement} container
+   * @param {() => boolean} [isActive]
+   * @param {{ WebviewManager?: Function, GitChangesView?: Function }} [components]
+   */
+  constructor(container, isActive, components = {}) {
     super(container);
     this.isActive = isActive || (() => true);
+    this._components = components;
     this.openFiles = new Map(); // path -> { name, content, savedContent, lang }
     this.activeFile = null;
     this.editorEl = null;
@@ -24,7 +30,7 @@ export class FileViewer extends ComponentBase {
     this.mode = 'files'; // 'files' | 'git' | webview id
     this.gitChanges = null;
     this.render();
-    const WebviewManager = getComponent('WebviewManager');
+    const { WebviewManager } = this._components;
     this._webviewMgr = new WebviewManager(
       this.container, this.statusBar,
       (mode) => this.switchMode(mode),
@@ -64,7 +70,7 @@ export class FileViewer extends ComponentBase {
     this.gitViewEl = _el('div', 'git-changes-view');
     this.gitViewEl.style.display = 'none';
     this.container.appendChild(this.gitViewEl);
-    const GitChangesView = getComponent('GitChangesView');
+    const { GitChangesView } = this._components;
     this.gitChanges = new GitChangesView(this.gitViewEl);
 
     this.statusBar = _el('div', 'editor-status-bar');

--- a/src/components/tab-manager.js
+++ b/src/components/tab-manager.js
@@ -124,7 +124,13 @@ export class TabManager {
       getActiveTabId: () => this.activeTabId,
       getActiveTab: () => this._activeTab(),
       scheduleAutoSave: () => this.configManager.scheduleAutoSave(),
-    }, tab, this._api);
+    }, tab, this._api, {
+      FileTree: getComponent('FileTree'),
+      FileViewer: getComponent('FileViewer'),
+      TerminalPanel: getComponent('TerminalPanel'),
+      WebviewManager: getComponent('WebviewManager'),
+      GitChangesView: getComponent('GitChangesView'),
+    });
   }
 
   serialize() {

--- a/src/utils/workspace-layout.js
+++ b/src/utils/workspace-layout.js
@@ -10,7 +10,6 @@
  * Tab disposal logic lives in workspace-cleanup.js.
  */
 
-import { getComponent } from './component-registry.js';
 import { emitWorkspaceActivated } from './workspace-events.js';
 import { _el } from './workspace-dom.js';
 import { WORKSPACE_PANELS } from './tab-constants.js';
@@ -32,15 +31,18 @@ import {
  * @param {{ left: { content: HTMLElement, panel: HTMLElement }, right: { content: HTMLElement, panel: HTMLElement } }} sides
  * @param {HTMLElement} termContainer
  * @param {() => string|null} getActiveTabId
+ * @param {{ FileTree: new (el: HTMLElement) => unknown, FileViewer: new (el: HTMLElement, isActive: () => boolean) => unknown, TerminalPanel: new (el: HTMLElement, cwd: string) => unknown }} components
  */
-function _initTabComponents(tab, layout, sides, termContainer, getActiveTabId) {
-  const FileTree = getComponent('FileTree');
-  const FileViewer = getComponent('FileViewer');
-  const TerminalPanel = getComponent('TerminalPanel');
+function _initTabComponents(tab, layout, sides, termContainer, getActiveTabId, components) {
+  const { FileTree, FileViewer, TerminalPanel } = components;
 
   tab.layoutElement = layout;
   tab.fileTree = new FileTree(sides.left.content);
-  tab.fileViewer = new FileViewer(sides.right.content, () => tab.id === getActiveTabId());
+  tab.fileViewer = new FileViewer(
+    sides.right.content,
+    () => tab.id === getActiveTabId(),
+    { WebviewManager: components.WebviewManager, GitChangesView: components.GitChangesView },
+  );
 
   if (tab._restoreData?.splitTree) {
     tab.terminalPanel = new TerminalPanel(termContainer, tab.cwd);
@@ -63,8 +65,9 @@ function _initTabComponents(tab, layout, sides, termContainer, getActiveTabId) {
  * @param {RenderWorkspaceDeps} deps
  * @param {import('./tab-types.js').WorkspaceTab} tab
  * @param {{ gitBranch: (cwd: string) => Promise<string> }} api - injected API methods
+ * @param {{ FileTree: Function, FileViewer: Function, TerminalPanel: Function }} components - injected component constructors
  */
-export async function renderWorkspace({ workspaceContainer, getActiveTabId, getActiveTab, scheduleAutoSave }, tab, { gitBranch }) {
+export async function renderWorkspace({ workspaceContainer, getActiveTabId, getActiveTab, scheduleAutoSave }, tab, { gitBranch }, components) {
   workspaceContainer.replaceChildren();
 
   const panelDeps = { getActiveTab, scheduleAutoSave };
@@ -85,7 +88,7 @@ export async function renderWorkspace({ workspaceContainer, getActiveTabId, getA
   );
   workspaceContainer.appendChild(layout);
 
-  _initTabComponents(tab, layout, sides, termContainer, getActiveTabId);
+  _initTabComponents(tab, layout, sides, termContainer, getActiveTabId, components);
 
   const branch = await gitBranch(tab.cwd);
   if (branch) tab.branchBadgeEl.textContent = ` ${branch}`;


### PR DESCRIPTION
## Refactoring

Élimine le couplage inverse entre couches en injectant les constructeurs de composants plutôt qu'en les résolvant via `getComponent()` :

### `workspace-layout.js` (couche utils)
- Avant : appelait `getComponent('FileTree')`, `getComponent('FileViewer')`, `getComponent('TerminalPanel')` directement
- Après : reçoit les constructeurs via le paramètre `components` injecté par l'appelant

### `file-viewer.js` (couche components)
- Avant : appelait `getComponent('WebviewManager')` et `getComponent('GitChangesView')` dans le constructeur
- Après : reçoit les constructeurs via un paramètre `components` du constructeur

### `tab-manager.js` (orchestrateur)
- Résout les 5 composants via `getComponent()` et les injecte dans `renderWorkspace()` et `FileViewer`
- Le registre reste utilisé uniquement par l'orchestrateur, pas par les utils ni les constructeurs

Les dépendances sont maintenant **explicites et visibles** dans les signatures de fonctions.

Closes #329

## Fichier(s) modifié(s)

- `src/utils/workspace-layout.js`
- `src/components/file-viewer.js`
- `src/components/tab-manager.js`

## Vérifications

- [x] Build OK
- [x] Tests OK (386/386)

---

📂 Path local : `/Users/rekta/projet/coding/refactor-pikagent`
🤖 PR créée automatiquement par l'Agent Refactor