### PR TITLE
refactor: break circular dependency between flow-card-setup and flow-category-renderer

### DIFF
--- a/src/utils/flow-card-setup.js
+++ b/src/utils/flow-card-setup.js
@@ -10,7 +10,7 @@
 
 import { _el } from './flow-dom.js';
 import { getLastRun, toggleInSet } from './flow-view-helpers.js';
-import { cleanupAllDragState } from './flow-category-renderer.js';
+import { cleanupAllDragState } from './flow-drag-cleanup.js';
 import { createCardHeader } from './flow-card-renderer.js';
 import { onDragEvents } from './event-helpers.js';
 import { setupSimpleDragState } from './drag-helpers.js';

--- a/src/utils/flow-category-renderer.js
+++ b/src/utils/flow-category-renderer.js
@@ -8,6 +8,7 @@ import { buildChevronRow } from './chevron-row.js';
 import { setupDropZone } from './drop-zone-helpers.js';
 import { CATEGORY_ACTIONS, UNCATEGORIZED } from './flow-view-helpers.js';
 import { computeInsertionIndex } from './drag-helpers.js';
+import { clearIndicators } from './flow-drag-cleanup.js';
 
 /**
  * Create a category group DOM element with header and flow items.
@@ -122,27 +123,7 @@ function _updateDropIndicator(container, clientY) {
   }
 }
 
-/**
- * Remove all elements matching `selector` from `container`.
- * Shared by _updateDropIndicator / _setupCategoryDropZone / cleanupAllDragState.
- */
-function clearIndicators(container, selector) {
-  for (const el of container.querySelectorAll(selector)) {
-    el.remove();
-  }
-}
-
 function _getDropIndex(container, clientY) {
   const cards = [...container.querySelectorAll(':scope > .flow-card')];
   return computeInsertionIndex(cards, clientY, 'y');
-}
-
-/**
- * Remove all drag state indicators from the document.
- */
-export function cleanupAllDragState() {
-  clearIndicators(document, '.flow-drop-indicator');
-  for (const el of document.querySelectorAll('.flow-drop-zone-active')) {
-    el.classList.remove('flow-drop-zone-active');
-  }
 }

--- a/src/utils/flow-drag-cleanup.js
+++ b/src/utils/flow-drag-cleanup.js
@@ -1,0 +1,29 @@
+/**
+ * Drag cleanup helpers — extracted from flow-category-renderer.js
+ * to break the circular dependency with flow-card-setup.js.
+ *
+ * @see https://github.com/agentdouble/pikagent/issues/337
+ */
+
+/**
+ * Remove all elements matching `selector` from `container`.
+ * Shared by _updateDropIndicator / _setupCategoryDropZone / cleanupAllDragState.
+ *
+ * @param {Document|HTMLElement} container
+ * @param {string} selector
+ */
+export function clearIndicators(container, selector) {
+  for (const el of container.querySelectorAll(selector)) {
+    el.remove();
+  }
+}
+
+/**
+ * Remove all drag state indicators from the document.
+ */
+export function cleanupAllDragState() {
+  clearIndicators(document, '.flow-drop-indicator');
+  for (const el of document.querySelectorAll('.flow-drop-zone-active')) {
+    el.classList.remove('flow-drop-zone-active');
+  }
+}


### PR DESCRIPTION
## Summary

- Extracted `cleanupAllDragState()` and its helper `clearIndicators()` from `flow-category-renderer.js` into a new module `src/utils/flow-drag-cleanup.js`
- Updated `flow-card-setup.js` to import `cleanupAllDragState` from `flow-drag-cleanup.js` instead of `flow-category-renderer.js`
- Updated `flow-category-renderer.js` to import `clearIndicators` from `flow-drag-cleanup.js` instead of defining it locally

This breaks the circular dependency cycle:
`flow-card-setup.js` -> `flow-category-renderer.js` -> `flow-card-setup.js` (via createCard callback + JSDoc refs)

Closes #337

## Files modified

| File | Change |
|------|--------|
| `src/utils/flow-drag-cleanup.js` | **New** — contains `clearIndicators()` and `cleanupAllDragState()` |
| `src/utils/flow-card-setup.js` | Import source changed from `flow-category-renderer.js` to `flow-drag-cleanup.js` |
| `src/utils/flow-category-renderer.js` | Removed `clearIndicators` and `cleanupAllDragState` definitions; added import from `flow-drag-cleanup.js` |

## Checks

- [x] `npm run build` passes
- [x] `npm test` passes (25 test files, 387 tests)
- [x] No circular dependency between `flow-card-setup.js` and `flow-category-renderer.js`

Path local : `/Users/rekta/projet/coding/refactor-pikagent`