### PR TITLE
refactor: replace getComponent() with dependency injection

### DIFF
--- a/src/components/tab-manager.js
+++ b/src/components/tab-manager.js
@@ -110,6 +110,7 @@ export class TabManager {
       reattachLayout,
       renderWorkspace: (tab) => this.renderWorkspace(tab),
       tabManager: this,
+      resolveComponent: getComponent,
     }, this.sidebarMode, mode);
     this.sidebarMode = mode;
 

--- a/src/utils/sidebar-manager.js
+++ b/src/utils/sidebar-manager.js
@@ -16,7 +16,6 @@
  * @typedef {{ getActiveTab: () => import('./tab-types.js').WorkspaceTab|null, capturePanelWidths: (tab: import('./tab-types.js').WorkspaceTab) => void, viewStore: SideViewStore }} DetachDeps
  */
 
-import { getComponent } from './component-registry.js';
 import { _el, renderList } from './workspace-dom.js';
 import { ACTIVITY_BUTTONS, SETTINGS_ICON, SIDE_VIEWS } from './tab-constants.js';
 import { createAsyncHandler } from './event-helpers.js';
@@ -31,7 +30,7 @@ function buildActivityButton(label, iconSvg, extraClass = '') {
 
 /**
  * Declarative map for sidebar view rendering — single source of truth for
- * component name (resolved via registry), constructor args, and post-reattach behavior.
+ * component name (resolved via injected resolver), constructor args, and post-reattach behavior.
  */
 const SIDE_VIEW_RENDERERS = {
   board: {
@@ -136,7 +135,7 @@ export function renderSideView({ workspaceContainer, viewStore }, viewKey, conta
 
 /**
  * Activate a side view by mode using SIDE_VIEW_RENDERERS config.
- * @param {SideViewDeps} deps
+ * @param {SideViewDeps & { resolveComponent: (name: string) => Function }} deps
  * @param {string} mode         - Side view mode (board, flow, usage)
  * @param {{ boardCtorArgs?: unknown[], flowCtorArgs?: unknown[] }} extraArgs - Additional constructor args per mode
  */
@@ -144,7 +143,7 @@ export function activateSideView(deps, mode, extraArgs = {}) {
   const sideView = SIDE_VIEWS[mode];
   const renderer = SIDE_VIEW_RENDERERS[mode];
   if (!sideView || !renderer) return;
-  const ViewClass = getComponent(renderer.componentName);
+  const ViewClass = deps.resolveComponent(renderer.componentName);
   const reattached = renderSideView(
     deps, sideView.viewKey, sideView.containerKey,
     ViewClass, ...renderer.ctorArgs(extraArgs),
@@ -157,7 +156,7 @@ export function activateSideView(deps, mode, extraArgs = {}) {
 /**
  * Switch sidebar mode: detach current view, activate new view (or re-attach work layout).
  *
- * @typedef {{ getActiveTab: () => import('./tab-types.js').WorkspaceTab|null, capturePanelWidths: (tab: import('./tab-types.js').WorkspaceTab) => void, viewStore: SideViewStore, workspaceContainer: HTMLElement, reattachLayout: (deps: { workspaceContainer: HTMLElement }, tab: import('./tab-types.js').WorkspaceTab) => void, renderWorkspace: (tab: import('./tab-types.js').WorkspaceTab) => void, tabManager: unknown }} ChangeSidebarModeDeps
+ * @typedef {{ getActiveTab: () => import('./tab-types.js').WorkspaceTab|null, capturePanelWidths: (tab: import('./tab-types.js').WorkspaceTab) => void, viewStore: SideViewStore, workspaceContainer: HTMLElement, reattachLayout: (deps: { workspaceContainer: HTMLElement }, tab: import('./tab-types.js').WorkspaceTab) => void, renderWorkspace: (tab: import('./tab-types.js').WorkspaceTab) => void, tabManager: unknown, resolveComponent: (name: string) => Function }} ChangeSidebarModeDeps
  */
 
 /**
@@ -176,6 +175,7 @@ export function changeSidebarMode(deps, currentMode, newMode) {
     activateSideView({
       workspaceContainer: deps.workspaceContainer,
       viewStore: deps.viewStore,
+      resolveComponent: deps.resolveComponent,
     }, newMode, {
       boardCtorArgs: [deps.tabManager],
       flowCtorArgs: [deps.tabManager],


### PR DESCRIPTION
## Summary

- Remove `getComponent()` import from `src/utils/sidebar-manager.js` — a utils module should not resolve UI components via the global registry
- Inject a `resolveComponent` callback through the deps object from the orchestrator (`tab-manager.js`), following the same dependency injection pattern already applied to `workspace-layout.js` and `file-viewer.js`
- Update JSDoc typedefs to document the new `resolveComponent` dependency

Closes #329

## Files modified

- `src/utils/sidebar-manager.js` — removed `getComponent` import; `activateSideView()` and `changeSidebarMode()` now receive `resolveComponent` via deps
- `src/components/tab-manager.js` — passes `resolveComponent: getComponent` when calling `changeSidebarMode()`

## Verifications

- [x] `npm run build` passes
- [x] `npm test` passes (386/386 tests)
- [x] No remaining `getComponent()` calls in `src/utils/` (only the definition in `component-registry.js` and re-export in `tab-manager-init.js`)

📂 Path local : `/Users/rekta/projet/coding/refactor-pikagent`