### PR TITLE
refactor: remove residual code duplications

### DIFF
--- a/main/date-utils.js
+++ b/main/date-utils.js
@@ -7,9 +7,7 @@
  * Domain-specific helpers (extractDateString, generateDateRange) stay here.
  */
 
-const { formatDateTime } = require('../shared/date-utils');
-
-const DATE_LOCALE = 'fr-FR';
+const { formatDateTime, DATE_LOCALE } = require('../shared/date-utils');
 const DAY_LABEL_FORMAT = { day: '2-digit', month: '2-digit' };
 
 /**

--- a/shared/date-utils.js
+++ b/shared/date-utils.js
@@ -24,4 +24,4 @@ function formatDateTime(date, timestamp) {
   return `${date}${time ? ' ' + time : ''}`;
 }
 
-module.exports = { formatDateTime };
+module.exports = { DATE_LOCALE, formatDateTime };

--- a/src/components/flow-card-terminal.js
+++ b/src/components/flow-card-terminal.js
@@ -36,6 +36,23 @@ export class FlowCardTerminalManager {
     map.delete(flowId);
   }
 
+  /**
+   * Create a readonly terminal, register it in the given map, and run an
+   * optional setup callback.  Returns the terminal record.
+   * @param {Map} map - target map (_liveTerminals or _logTerminals)
+   * @param {string} flowId
+   * @param {HTMLElement} containerEl
+   * @param {object} opts - extra terminal options (scrollback, cursorStyle, …)
+   * @param {(record: object) => void} [setupFn] - called with the record before it is stored
+   * @returns {object} the terminal record stored in the map
+   */
+  _createAndRegister(map, flowId, containerEl, opts, setupFn) {
+    const record = this._createReadonlyTerminal(containerEl, opts);
+    if (setupFn) setupFn(record);
+    map.set(flowId, { ...record, containerEl });
+    return record;
+  }
+
   // === Live Terminal (for running flows) ===
 
   createLiveTerminal(flowId, ptyId) {
@@ -47,16 +64,15 @@ export class FlowCardTerminalManager {
 
     const containerEl = _el('div', 'flow-card-terminal');
 
-    const { term, fitAddon, resizeObs } = this._createReadonlyTerminal(containerEl, {
-      scrollback: LIVE_SCROLLBACK,
-      cursorStyle: 'bar',
-    });
-
-    const unsubData = window.api.pty.onData(ptyId, (data) => {
-      term.write(data);
-    });
-
-    this._liveTerminals.set(flowId, { term, fitAddon, unsubData, resizeObs, containerEl, ptyId });
+    this._createAndRegister(
+      this._liveTerminals, flowId, containerEl,
+      { scrollback: LIVE_SCROLLBACK, cursorStyle: 'bar' },
+      (rec) => {
+        const unsubData = window.api.pty.onData(ptyId, (data) => { rec.term.write(data); });
+        rec.unsubData = unsubData;
+        rec.ptyId = ptyId;
+      },
+    );
 
     return containerEl;
   }
@@ -72,12 +88,12 @@ export class FlowCardTerminalManager {
       ? await window.api.flow.getRunLog(flowId, run.logTimestamp)
       : null;
 
-    const { term, fitAddon, resizeObs } = this._createReadonlyTerminal(containerEl, {
-      scrollback: LOG_SCROLLBACK,
-    });
+    const { term } = this._createAndRegister(
+      this._logTerminals, flowId, containerEl,
+      { scrollback: LOG_SCROLLBACK },
+    );
 
     term.write(log || NO_LOG_MESSAGE);
-    this._logTerminals.set(flowId, { term, fitAddon, resizeObs });
   }
 
   disposeLogTerminal(flowId) {

--- a/src/utils/flow-card-renderer.js
+++ b/src/utils/flow-card-renderer.js
@@ -2,7 +2,7 @@
  * Pure rendering helpers for flow cards.
  * Extracted from flow-view.js to reduce component size.
  */
-import { _el, createActionButton, renderButtonBar } from './flow-dom.js';
+import { _el, createActionButton, buildDomainButtonBar } from './flow-dom.js';
 import { formatSchedule } from './flow-schedule-helpers.js';
 import { MAX_VISIBLE_RUNS, buildDotTooltip, buildCardActionEntries } from './flow-view-helpers.js';
 
@@ -32,14 +32,7 @@ function createRunDots(flow, onShowLog) {
  * @param {{ run: () => void, toggle: () => void, edit: () => void, delete: () => void }} handlers
  */
 function createCardActions(flow, isRunning, handlers) {
-  const configs = buildCardActionEntries(flow, isRunning).map(({ text, title, action, cls }) => ({
-    text,
-    title,
-    cls: cls ? `flow-card-btn ${cls}` : 'flow-card-btn',
-    action,
-    stopPropagation: true,
-  }));
-  return renderButtonBar({ containerClass: 'flow-card-actions', configs, handlers });
+  return buildDomainButtonBar('flow-card-btn', 'flow-card-actions', buildCardActionEntries(flow, isRunning), handlers);
 }
 
 /**

--- a/src/utils/flow-category-renderer.js
+++ b/src/utils/flow-category-renderer.js
@@ -3,7 +3,7 @@
  * Handles category headers, collapse state, and drag-drop zone setup.
  * Extracted from flow-view.js to reduce component size.
  */
-import { _el, renderButtonBar } from './flow-dom.js';
+import { _el, buildDomainButtonBar } from './flow-dom.js';
 import { buildChevronRow } from './chevron-row.js';
 import { setupDropZone } from './drop-zone-helpers.js';
 import { CATEGORY_ACTIONS, UNCATEGORIZED } from './flow-view-helpers.js';
@@ -62,14 +62,7 @@ function _buildCategoryHeader(cat, flows, isUncategorized, collapsedCategories, 
       rename: () => onRenameCategory(cat.id, name),
       delete: () => onDeleteCategory(cat.id),
     };
-    const configs = CATEGORY_ACTIONS.map(({ text, title, cls, action }) => ({
-      text,
-      title,
-      cls: cls ? `flow-category-btn ${cls}` : 'flow-category-btn',
-      action,
-      stopPropagation: true,
-    }));
-    header.appendChild(renderButtonBar({ containerClass: 'flow-category-actions', configs, handlers: catHandlers }));
+    header.appendChild(buildDomainButtonBar('flow-category-btn', 'flow-category-actions', CATEGORY_ACTIONS, catHandlers));
   }
 
   header.addEventListener('click', () => onToggleCollapse(cat.id));

--- a/src/utils/flow-dom.js
+++ b/src/utils/flow-dom.js
@@ -6,3 +6,27 @@
  * of reaching into the core dom.js hub directly.
  */
 export { _el, createActionButton, renderButtonBar } from './dom.js';
+
+import { renderButtonBar as _renderButtonBar } from './dom.js';
+
+/**
+ * Build a domain-specific button bar from a list of action definitions.
+ * Each action's `cls` is prefixed with `baseClass` and `stopPropagation` is set
+ * to true — the two repetitive steps previously duplicated across renderers.
+ *
+ * @param {string} baseClass   - CSS class prefix for each button (e.g. "flow-card-btn")
+ * @param {string} containerClass - CSS class for the bar container
+ * @param {Array<{text: string, title: string, action: string, cls?: string}>} actions
+ * @param {Record<string, () => void>} handlers
+ * @returns {HTMLElement}
+ */
+export function buildDomainButtonBar(baseClass, containerClass, actions, handlers) {
+  const configs = actions.map(({ text, title, action, cls }) => ({
+    text,
+    title,
+    cls: cls ? `${baseClass} ${cls}` : baseClass,
+    action,
+    stopPropagation: true,
+  }));
+  return _renderButtonBar({ containerClass, configs, handlers });
+}

--- a/src/utils/tab-navigation.js
+++ b/src/utils/tab-navigation.js
@@ -57,6 +57,23 @@ export function focusDirection(direction, sidebarMode, boardView, getActiveTab) 
 }
 
 /**
+ * Retrieve a tab, apply a mutation, re-render the tab bar, and schedule a save.
+ * Shared plumbing for setTabColorGroup / toggleNoShortcut (and future mutators).
+ * @param {Map<string, import('./tab-types.js').WorkspaceTab>} tabs
+ * @param {string} id
+ * @param {(tab: import('./tab-types.js').WorkspaceTab) => void} mutationFn
+ * @param {() => void} renderTabBar
+ * @param {{ scheduleAutoSave: () => void }} configManager
+ */
+function _mutateTab(tabs, id, mutationFn, renderTabBar, configManager) {
+  const tab = tabs.get(id);
+  if (!tab) return;
+  mutationFn(tab);
+  renderTabBar();
+  configManager.scheduleAutoSave();
+}
+
+/**
  * Set or clear a tab's color group.
  * @param {Map<string, import('./tab-types.js').WorkspaceTab>} tabs
  * @param {string} id
@@ -65,11 +82,7 @@ export function focusDirection(direction, sidebarMode, boardView, getActiveTab) 
  * @param {{ scheduleAutoSave: () => void }} configManager
  */
 export function setTabColorGroup(tabs, id, colorGroupId, renderTabBar, configManager) {
-  const tab = tabs.get(id);
-  if (!tab) return;
-  tab.colorGroup = colorGroupId;
-  renderTabBar();
-  configManager.scheduleAutoSave();
+  _mutateTab(tabs, id, (tab) => { tab.colorGroup = colorGroupId; }, renderTabBar, configManager);
 }
 
 /**
@@ -80,9 +93,5 @@ export function setTabColorGroup(tabs, id, colorGroupId, renderTabBar, configMan
  * @param {{ scheduleAutoSave: () => void }} configManager
  */
 export function toggleNoShortcut(tabs, id, renderTabBar, configManager) {
-  const tab = tabs.get(id);
-  if (!tab) return;
-  tab.noShortcut = !tab.noShortcut;
-  renderTabBar();
-  configManager.scheduleAutoSave();
+  _mutateTab(tabs, id, (tab) => { tab.noShortcut = !tab.noShortcut; }, renderTabBar, configManager);
 }


### PR DESCRIPTION
## Summary

Closes #338 — Supprime 4 duplications de code résiduelles identifiées dans l'issue.

### Changements

1. **`flow-card-terminal.js`** — Extraction de `_createAndRegister(map, flowId, containerEl, opts, setupFn)` pour unifier le pattern *create terminal -> store in Map -> write data* partagé par `createLiveTerminal` et `loadLogIntoContainer`.

2. **`flow-dom.js` + `flow-card-renderer.js` + `flow-category-renderer.js`** — Création de `buildDomainButtonBar(baseClass, containerClass, actions, handlers)` dans `flow-dom.js` pour centraliser la construction de button bars avec préfixe CSS class + stopPropagation, utilisée par les deux renderers.

3. **`tab-navigation.js`** — Extraction de `_mutateTab(tabs, id, mutationFn, renderTabBar, configManager)` pour dédupliquer la séquence *get tab -> mutate -> renderTabBar -> scheduleAutoSave* commune à `setTabColorGroup` et `toggleNoShortcut`.

4. **`shared/date-utils.js` + `main/date-utils.js`** — Export de `DATE_LOCALE` depuis `shared/date-utils.js` et import dans `main/date-utils.js` au lieu de définir `'fr-FR'` dans les deux fichiers.

## Fichiers modifiés

- `src/components/flow-card-terminal.js`
- `src/utils/flow-dom.js`
- `src/utils/flow-card-renderer.js`
- `src/utils/flow-category-renderer.js`
- `src/utils/tab-navigation.js`
- `shared/date-utils.js`
- `main/date-utils.js`

## Vérifications

- [x] `npm run build` — OK
- [x] `npm test` — 25 fichiers, 386 tests passent

📂 Path local : `/Users/rekta/projet/coding/refactor-pikagent`