### PR TITLE
refactor: apply renderList helper to remaining files (closes #321)

### DIFF
--- a/src/utils/context-menu.js
+++ b/src/utils/context-menu.js
@@ -2,7 +2,7 @@
  * @typedef {{ label?: string, action?: () => void, separator?: boolean, shortcut?: string, colorDot?: string, children?: Array<ContextMenuItem> }} ContextMenuItem
  */
 
-import { _el } from './dom.js';
+import { _el, renderList } from './dom.js';
 import { onClickStopped, onKeyAction } from './event-helpers.js';
 
 /**
@@ -69,7 +69,7 @@ class ContextMenu {
   }
 
   show(x, y, items) {
-    this.el.replaceChildren(...items.map((item) => this._buildItem(item)));
+    renderList(this.el, items, (item) => this._buildItem(item));
 
     this.el.style.display = 'block';
     const { width, height } = this.el.getBoundingClientRect();

--- a/src/utils/file-viewer-mode-bar.js
+++ b/src/utils/file-viewer-mode-bar.js
@@ -3,7 +3,7 @@
  * Extracted from file-viewer.js to reduce component size.
  */
 
-import { _el } from './file-dom.js';
+import { _el, renderList } from './file-dom.js';
 import { STATIC_MODES } from './editor-helpers.js';
 
 /**
@@ -24,5 +24,5 @@ export function renderModeBar(modeBar, currentMode, { switchMode }, webviewMgr) 
     ...webviewMgr.webviewTabs.map(wt => webviewMgr.buildWebviewModeBtn(wt, currentMode)),
     webviewMgr.buildAddWebviewBtn(modeBar),
   ];
-  modeBar.replaceChildren(...allItems);
+  renderList(modeBar, allItems, (item) => item);
 }


### PR DESCRIPTION
## Summary

- Replace `replaceChildren(...items.map(...))` with `renderList()` in `context-menu.js`
- Replace `replaceChildren(...allItems)` with `renderList()` in `file-viewer-mode-bar.js`
- Added `renderList` to existing imports from `dom.js` and `file-dom.js` respectively

The `renderList` helper already exists in `src/utils/dom.js` (added in #324) and is re-exported through facade modules. Of the 9 files listed in #321, 3 were already refactored in prior PRs (#324, #333), and 4 use single-element `replaceChildren()` calls or complex mixed-content patterns that do not match the clear+loop pattern. This PR completes the remaining 2 files.

Closes #321

## Files modified

- `src/utils/context-menu.js` — use `renderList` in `ContextMenu.show()`
- `src/utils/file-viewer-mode-bar.js` — use `renderList` in `renderModeBar()`

## Verification

- [x] `npm run build` passes
- [x] `npm test` passes (386/386 tests)
- [x] No new dependencies added

📂 Path local : `/Users/rekta/projet/coding/refactor-pikagent`