### PR TITLE
refactor: extract renderList helper for list-rendering pattern

### DIFF
--- a/src/utils/settings-section-builder.js
+++ b/src/utils/settings-section-builder.js
@@ -18,10 +18,14 @@ export function createSettingsSection(contentEl, { heading, actions = [], conten
 
   const headingEl = _el('div', 'settings-section-header');
   headingEl.appendChild(_el('h3', null, heading));
-  renderList(headingEl, actions, (el) => el);
+  for (const action of actions) {
+    if (action) headingEl.appendChild(action);
+  }
   contentEl.appendChild(headingEl);
 
-  renderList(contentEl, content, (el) => el);
+  for (const node of content) {
+    if (node) contentEl.appendChild(node);
+  }
 
   return headingEl;
 }

--- a/src/utils/settings-section-builder.js
+++ b/src/utils/settings-section-builder.js
@@ -18,10 +18,10 @@ export function createSettingsSection(contentEl, { heading, actions = [], conten
 
   const headingEl = _el('div', 'settings-section-header');
   headingEl.appendChild(_el('h3', null, heading));
-  for (const el of actions) headingEl.appendChild(el);
+  renderList(headingEl, actions, (el) => el);
   contentEl.appendChild(headingEl);
 
-  for (const el of content) contentEl.appendChild(el);
+  renderList(contentEl, content, (el) => el);
 
   return headingEl;
 }


### PR DESCRIPTION
## Refactoring

Ajouté `renderList(container, items, renderItem)` dans `src/utils/dom.js` et remplacé les occurrences du pattern `replaceChildren() + loop + appendChild` dans 9+ fichiers.

Closes #321

## Fichier(s) modifié(s)

- `src/utils/dom.js`
- `src/utils/file-editor-renderer.js`
- `src/utils/file-viewer-tabs.js`
- `src/utils/workspace-layout.js`
- `src/utils/tab-bar-renderer.js`
- `src/utils/context-menu.js`
- `src/utils/settings-section-builder.js`
- `src/utils/sidebar-manager.js`
- `src/utils/markdown-preview-renderer.js`
- `src/utils/file-viewer-mode-bar.js`

## Vérifications

- [x] Build OK
- [x] Tests OK

---

📂 Path local : `/Users/rekta/projet/coding/refactor-pikagent`
🤖 PR créée automatiquement par l'Agent Refactor