### PR TITLE
refactor: remove dead flowPath function

### DIFF
--- a/main/flow-helpers.js
+++ b/main/flow-helpers.js
@@ -1,5 +1,5 @@
 const path = require('path');
-const { FLOWS_DIR, LOGS_DIR } = require('./paths');
+const { LOGS_DIR } = require('./paths');
 const { createStreamParser } = require('./flow-stream-parser');
 const { getLastRun } = require('../shared/flow-utils');
 const { AGENT_IDS } = require('../shared/agent-registry');
@@ -10,10 +10,6 @@ const SHELL_INIT_DELAY_MS = 500;
 const MAX_RUN_HISTORY = 7;
 const DEFAULT_PTY_COLS = 120;
 const DEFAULT_PTY_ROWS = 30;
-
-function flowPath(id) {
-  return path.join(FLOWS_DIR, `${id}.json`);
-}
 
 function logPath(flowId, timestamp) {
   return path.join(LOGS_DIR, `${flowId}_${timestamp}.log`);


### PR DESCRIPTION
## Refactoring

Suppression de la fonction privée `flowPath` dans `main/flow-helpers.js` qui n'est jamais appelée. La logique de persistence a été migrée vers `JsonStore`.

Vérification que l'import `path` peut aussi être retiré s'il n'est plus référencé.

Closes #358

## Fichier(s) modifié(s)

- `main/flow-helpers.js`

## Vérifications

- [x] Build OK
- [x] Tests OK

---

📂 Path local : `/Users/rekta/projet/coding/refactor-pikagent`
🤖 PR créée automatiquement par l'Agent Refactor