### PR TITLE
refactor: extract renderList helper to factorize list-rendering pattern

### DIFF
--- a/src/utils/settings-section-builder.js
+++ b/src/utils/settings-section-builder.js
@@ -14,18 +14,10 @@ import { createAsyncHandler } from './event-helpers.js';
  * @returns {HTMLElement} the heading element that was created
  */
 export function createSettingsSection(contentEl, { heading, actions = [], content = [] }) {
-  contentEl.replaceChildren();
-
   const headingEl = _el('div', 'settings-section-header');
-  headingEl.appendChild(_el('h3', null, heading));
-  for (const action of actions) {
-    if (action) headingEl.appendChild(action);
-  }
-  contentEl.appendChild(headingEl);
+  renderList(headingEl, [_el('h3', null, heading), ...actions], (item) => item);
 
-  for (const node of content) {
-    if (node) contentEl.appendChild(node);
-  }
+  renderList(contentEl, [headingEl, ...content], (item) => item);
 
   return headingEl;
 }

--- a/src/utils/tab-bar-renderer.js
+++ b/src/utils/tab-bar-renderer.js
@@ -6,7 +6,7 @@
  * @typedef {{ tabBar: HTMLElement, tabs: Map<string, import('./tab-types.js').WorkspaceTab>, activeTabId: string|null, activeColorFilter: string|null, excludedColors: Set<string>, switchTo: (id: string) => void, closeTab: (id: string) => void, renameTab: (id: string, nameEl: HTMLElement) => void, setTabColorGroup: (id: string, colorGroupId: string|null) => void, toggleNoShortcut: (id: string) => void, setColorFilter: (colorGroupId: string) => void, toggleExcludeColor: (colorGroupId: string) => void, createTab: () => void, reorderTab: (fromId: string, toId: string, before: boolean) => void, isTabVisible: (tab: import('./tab-types.js').WorkspaceTab) => boolean, renderTabBar: () => void, clearColorFilters: () => void }} RenderTabBarDeps
  */
 
-import { _el } from './tab-dom.js';
+import { _el, renderList } from './tab-dom.js';
 import { buildColorFilters } from './tab-color-filter.js';
 import { buildTabElement } from './tab-renderer.js';
 
@@ -18,14 +18,11 @@ import { buildTabElement } from './tab-renderer.js';
  * @returns {Map<string, HTMLElement>}
  */
 export function renderTabBar(deps) {
-  deps.tabBar.replaceChildren();
-
   const filters = buildColorFilters(deps.tabs, deps.activeColorFilter, deps.excludedColors, {
     onClearFilter: () => { deps.clearColorFilters(); deps.renderTabBar(); },
     onSetFilter: (id) => deps.setColorFilter(id),
     onToggleExclude: (id) => deps.toggleExcludeColor(id),
   });
-  if (filters) deps.tabBar.appendChild(filters);
 
   const tabElements = new Map();
 
@@ -44,16 +41,21 @@ export function renderTabBar(deps) {
     },
   };
 
-  for (const [id, tab] of deps.tabs) {
-    if (!deps.isTabVisible(tab)) continue;
-    const tabEl = buildTabElement(tabElementDeps, id, tab);
-    deps.tabBar.appendChild(tabEl);
-    tabElements.set(id, tabEl);
-  }
+  const visibleTabs = [...deps.tabs].filter(([, tab]) => deps.isTabVisible(tab));
 
   const addBtn = _el('div', 'tab tab-add', '+');
   addBtn.addEventListener('click', () => deps.createTab());
-  deps.tabBar.appendChild(addBtn);
+
+  const allItems = [
+    filters,
+    ...visibleTabs.map(([id, tab]) => {
+      const tabEl = buildTabElement(tabElementDeps, id, tab);
+      tabElements.set(id, tabEl);
+      return tabEl;
+    }),
+    addBtn,
+  ];
+  renderList(deps.tabBar, allItems, (item) => item);
 
   return tabElements;
 }

--- a/src/utils/tab-dom.js
+++ b/src/utils/tab-dom.js
@@ -5,4 +5,4 @@
  * tab-lifecycle) import _el through this facade instead of reaching into
  * the core dom.js hub directly.  This reduces dom.js fan-in.
  */
-export { _el } from './dom.js';
+export { _el, renderList } from './dom.js';


### PR DESCRIPTION
## Summary

- Apply `renderList` to `tab-bar-renderer.js`: replace `replaceChildren()` + manual for-loop with `renderList` over pre-filtered visible tabs, color filters, and add button
- Apply `renderList` to `settings-section-builder.js`: replace `replaceChildren()` + two manual for-loops in `createSettingsSection` with two `renderList` calls
- Re-export `renderList` from `tab-dom.js` facade so tab-domain modules can import it without reaching into `dom.js` directly

The remaining 6 files listed in the issue were already using `renderList` (context-menu, file-viewer-tabs, file-viewer-mode-bar, sidebar-manager, settings-section-builder's `buildSettingsSection`) or did not have the replaceChildren + loop pattern (file-editor-renderer, markdown-preview-renderer, workspace-layout use `replaceChildren(...)` with direct arguments, not the clear-then-iterate pattern).

Closes #321

## Test plan

- [x] `npm run build` passes
- [x] `npm test` passes (384/384 tests)
- [ ] Manual verification of tab bar rendering (color filters, visible tabs, add button)
- [ ] Manual verification of settings sections (heading, actions, content)

🤖 Generated with [Claude Code](https://claude.com/claude-code)