### PR TITLE
refactor: reduce long files and functions via targeted extractions

### DIFF
--- a/src/components/file-tree.js
+++ b/src/components/file-tree.js
@@ -2,7 +2,6 @@ import { _el, createActionButton } from '../utils/file-dom.js';
 import { buildChevronRow } from '../utils/chevron-row.js';
 import {
   CHEVRON_EXPANDED, CHEVRON_COLLAPSED,
-  DEBOUNCE_DELAY, WATCH_PREFIX,
   HEADER_ACTIONS,
   extractFolderName, resolveWatchCwd,
 } from '../utils/file-tree-helpers.js';
@@ -16,6 +15,7 @@ import {
   promptRename as doPromptRename,
   promptNewEntry as doPromptNewEntry,
 } from '../utils/file-tree-drop.js';
+import { listenForChanges, startWatch, stopWatch } from '../utils/file-tree-watcher.js';
 import { ComponentBase } from '../utils/component-base.js';
 
 export class FileTree extends ComponentBase {
@@ -56,18 +56,7 @@ export class FileTree extends ComponentBase {
   }
 
   listenForChanges() {
-    this._track(window.api.fs.onChanged(({ id }) => {
-      if (this.debounceTimers.has(id)) {
-        clearTimeout(this.debounceTimers.get(id));
-      }
-      this.debounceTimers.set(
-        id,
-        setTimeout(() => {
-          this.debounceTimers.delete(id);
-          this.refreshSection(id).catch(() => {});
-        }, DEBOUNCE_DELAY)
-      );
-    }));
+    this._track(listenForChanges(this.debounceTimers, (id) => this.refreshSection(id), { onChanged: window.api.fs.onChanged }));
   }
 
   async setTerminalRoot(termId, dirPath) {
@@ -88,12 +77,10 @@ export class FileTree extends ComponentBase {
 
     const sectionEl = _el('div', { className: 'file-tree-section' });
     const expandedDirs = new Set([dirPath]);
-    const watchId = `${WATCH_PREFIX}${dirPath}`;
+    const watchId = startWatch(dirPath, { watch: window.api.fs.watch });
     this.sections.set(dirPath, { termIds: new Set([termId]), sectionEl, expandedDirs, watchId });
     this.treeEl.appendChild(sectionEl);
     await this.refreshSection(dirPath);
-
-    window.api.fs.watch(watchId, dirPath);
   }
 
   removeTerminal(termId) {
@@ -110,7 +97,7 @@ export class FileTree extends ComponentBase {
     section.termIds.delete(termId);
 
     if (section.termIds.size === 0) {
-      window.api.fs.unwatch(section.watchId);
+      stopWatch(section.watchId, { unwatch: window.api.fs.unwatch });
       section.sectionEl.remove();
       this.sections.delete(cwd);
     }
@@ -290,8 +277,9 @@ export class FileTree extends ComponentBase {
 
   dispose() {
     super.dispose();
+    const fsApi = { unwatch: window.api.fs.unwatch };
     for (const [, section] of this.sections) {
-      window.api.fs.unwatch(section.watchId);
+      stopWatch(section.watchId, fsApi);
     }
     this.sections.clear();
     this.termCwds.clear();

--- a/src/components/file-viewer.js
+++ b/src/components/file-viewer.js
@@ -1,4 +1,3 @@
-import { detectLanguage } from '../utils/file-icons.js';
 import { emitLayoutChanged } from '../utils/workspace-events.js';
 import { _el } from '../utils/file-dom.js';
 import { EMPTY_MESSAGE, MODE_CONFIG, ALL_STATIC_ELEMENTS, MODE_ACTIVATE, pinnedFiles } from '../utils/editor-helpers.js';
@@ -9,6 +8,10 @@ import {
   renderModeBar,
   setupFileViewerListeners,
 } from '../utils/file-viewer-subsystem.js';
+import {
+  openFileEntry, isModified as isFileModified, isPinned as isFilePinned,
+  togglePin as toggleFilePin, isMarkdown as isFileMarkdown, closeFileEntry,
+} from '../utils/file-viewer-files.js';
 import { registerComponent } from '../utils/component-registry.js';
 import { ComponentBase } from '../utils/component-base.js';
 
@@ -87,18 +90,10 @@ export class FileViewer extends ComponentBase {
     }
   }
 
-  isPinned(filePath) {
-    return pinnedFiles.has(filePath);
-  }
+  isPinned(filePath) { return isFilePinned(filePath); }
 
   togglePin(filePath) {
-    const file = this.openFiles.get(filePath);
-    if (!file) return;
-    if (pinnedFiles.has(filePath)) {
-      pinnedFiles.delete(filePath);
-    } else {
-      pinnedFiles.set(filePath, { name: file.name });
-    }
+    toggleFilePin(this.openFiles, filePath);
     this.renderTabs();
   }
 
@@ -120,27 +115,11 @@ export class FileViewer extends ComponentBase {
   // ===== Files Mode =====
 
   async openFile(filePath, fileName) {
-    if (this.openFiles.has(filePath)) {
-      this.setActiveTab(filePath);
-      return;
-    }
-
-    const result = await window.api.fs.readfile(filePath);
-    if (result.error) {
-      this.openFiles.set(filePath, { name: fileName, content: '', savedContent: '', lang: 'plaintext', error: result.error, viewMode: 'edit' });
-    } else {
-      const lang = detectLanguage(fileName);
-      const viewMode = lang === 'markdown' ? 'preview' : 'edit';
-      this.openFiles.set(filePath, { name: fileName, content: result.content, savedContent: result.content, lang, error: null, viewMode });
-    }
-
+    await openFileEntry(this.openFiles, filePath, fileName, { readfile: window.api.fs.readfile });
     this.setActiveTab(filePath);
   }
 
-  isMarkdown(filePath) {
-    const file = this.openFiles.get(filePath);
-    return !!file && file.lang === 'markdown';
-  }
+  isMarkdown(filePath) { return isFileMarkdown(this.openFiles, filePath); }
 
   toggleViewMode(filePath) {
     const file = this.openFiles.get(filePath);
@@ -156,11 +135,7 @@ export class FileViewer extends ComponentBase {
     this.renderEditor();
   }
 
-  isModified(filePath) {
-    const file = this.openFiles.get(filePath);
-    if (!file) return false;
-    return file.content !== file.savedContent;
-  }
+  isModified(filePath) { return isFileModified(this.openFiles, filePath); }
 
   renderTabs() {
     renderTabsHelper(this.tabsBar, this.openFiles, this.activeFile,
@@ -243,22 +218,11 @@ export class FileViewer extends ComponentBase {
   }
 
   closeFile(filePath) {
-    if (this.isModified(filePath)) {
-      const file = this.openFiles.get(filePath);
-      if (!confirm(`"${file.name}" has unsaved changes. Close anyway?`)) return;
-    }
-
-    this.openFiles.delete(filePath);
-
-    if (this.activeFile === filePath) {
-      if (this.openFiles.size > 0) {
-        this.setActiveTab([...this.openFiles.keys()].pop());
-      } else {
-        this._resetEditor();
-      }
-    } else {
-      this.renderTabs();
-    }
+    const result = closeFileEntry(this.openFiles, filePath, this.activeFile);
+    if (result === false) return;
+    if (result.switchTo === null) this._resetEditor();
+    else if (result.switchTo !== undefined) this.setActiveTab(result.switchTo);
+    else this.renderTabs();
   }
 
   _resetEditor() {

--- a/src/components/settings-update.js
+++ b/src/components/settings-update.js
@@ -45,13 +45,10 @@ function _showAvailable(area, result, onInstall) {
 }
 
 /**
- * Render the Update section into the given content element.
- * @param {HTMLElement} contentEl
+ * Build the version bar and update area, appending them to contentEl.
+ * @returns {{ area: HTMLElement }}
  */
-export async function renderUpdate(contentEl) {
-  createSettingsSection(contentEl, { heading: 'Update' });
-
-  const version = await window.api.update.version();
+function _buildUpdateUI(contentEl, version) {
   const bar = _el('div', 'update-version-bar');
   bar.appendChild(_el('span', 'update-version-label', 'Version'));
   bar.appendChild(_el('span', 'update-version-value', `v${version}`));
@@ -59,6 +56,60 @@ export async function renderUpdate(contentEl) {
 
   const area = _el('div', 'update-area');
   contentEl.appendChild(area);
+  return { area };
+}
+
+/**
+ * Build progress DOM elements and bind the onProgress event.
+ * @returns {{ unsub: Function|undefined }}
+ */
+function _bindProgressUpdates(area) {
+  const progress = _el('div', 'update-progress');
+  const barTrack = _el('div', 'update-progress-track');
+  const barFill = _el('div', 'update-progress-fill');
+  barTrack.appendChild(barFill);
+  const label = _el('div', 'update-progress-label', 'Starting...');
+  progress.appendChild(barTrack);
+  progress.appendChild(label);
+  area.appendChild(progress);
+
+  const unsub = window.api.update.onProgress((p) => {
+    barFill.style.width = `${(p.step / p.total) * 100}%`;
+    label.textContent = p.label;
+  });
+  return { unsub };
+}
+
+/**
+ * Run the download/install flow: show progress, then success or error.
+ */
+async function _handleDownload(area, runCheck) {
+  area.replaceChildren();
+  const { unsub } = _bindProgressUpdates(area);
+
+  try {
+    await window.api.update.run();
+    unsub?.();
+    area.replaceChildren();
+    area.appendChild(_el('div', 'update-message update-ok', '\u2713 Update installed successfully!'));
+    const btn = _el('button', 'update-btn update-btn-primary', 'Restart now');
+    btn.addEventListener('click', () => window.api.update.relaunch());
+    area.appendChild(btn);
+  } catch (err) {
+    unsub?.();
+    _showMessage(area, 'error', err.message, runCheck);
+  }
+}
+
+/**
+ * Render the Update section into the given content element.
+ * @param {HTMLElement} contentEl
+ */
+export async function renderUpdate(contentEl) {
+  createSettingsSection(contentEl, { heading: 'Update' });
+
+  const version = await window.api.update.version();
+  const { area } = _buildUpdateUI(contentEl, version);
 
   async function runCheck(btn) {
     btn.textContent = 'Checking...';
@@ -68,39 +119,8 @@ export async function renderUpdate(contentEl) {
       const result = await window.api.update.check();
       if (result.error) _showMessage(area, 'error', result.error, runCheck);
       else if (!result.available) _showMessage(area, 'ok', 'Your application is up to date', runCheck);
-      else _showAvailable(area, result, runInstall);
+      else _showAvailable(area, result, () => _handleDownload(area, runCheck));
     } catch (err) {
-      _showMessage(area, 'error', err.message, runCheck);
-    }
-  }
-
-  async function runInstall() {
-    area.replaceChildren();
-
-    const progress = _el('div', 'update-progress');
-    const barTrack = _el('div', 'update-progress-track');
-    const barFill = _el('div', 'update-progress-fill');
-    barTrack.appendChild(barFill);
-    const label = _el('div', 'update-progress-label', 'Starting...');
-    progress.appendChild(barTrack);
-    progress.appendChild(label);
-    area.appendChild(progress);
-
-    const unsub = window.api.update.onProgress((p) => {
-      barFill.style.width = `${(p.step / p.total) * 100}%`;
-      label.textContent = p.label;
-    });
-
-    try {
-      await window.api.update.run();
-      unsub?.();
-      area.replaceChildren();
-      area.appendChild(_el('div', 'update-message update-ok', '\u2713 Update installed successfully!'));
-      const btn = _el('button', 'update-btn update-btn-primary', 'Restart now');
-      btn.addEventListener('click', () => window.api.update.relaunch());
-      area.appendChild(btn);
-    } catch (err) {
-      unsub?.();
       _showMessage(area, 'error', err.message, runCheck);
     }
   }

--- a/src/utils/file-tree-watcher.js
+++ b/src/utils/file-tree-watcher.js
@@ -1,0 +1,48 @@
+/**
+ * Filesystem watch + debounce logic extracted from FileTree.
+ * Manages watchers per section and coalesces rapid change events.
+ */
+import { DEBOUNCE_DELAY, WATCH_PREFIX } from './file-tree-helpers.js';
+
+/**
+ * Set up a debounced fs.onChanged listener.
+ * @param {Map} debounceTimers - shared timer map
+ * @param {(watchIdOrCwd: string) => Promise<void>} refreshSection - callback to refresh
+ * @param {{ onChanged: Function }} fsApi - injected fs API
+ * @returns {Function} unsubscribe function
+ */
+export function listenForChanges(debounceTimers, refreshSection, fsApi) {
+  return fsApi.onChanged(({ id }) => {
+    if (debounceTimers.has(id)) {
+      clearTimeout(debounceTimers.get(id));
+    }
+    debounceTimers.set(
+      id,
+      setTimeout(() => {
+        debounceTimers.delete(id);
+        refreshSection(id).catch(() => {});
+      }, DEBOUNCE_DELAY),
+    );
+  });
+}
+
+/**
+ * Start watching a directory for changes.
+ * @param {string} cwd
+ * @param {{ watch: Function }} fsApi - injected fs API
+ * @returns {string} watchId
+ */
+export function startWatch(cwd, fsApi) {
+  const watchId = `${WATCH_PREFIX}${cwd}`;
+  fsApi.watch(watchId, cwd);
+  return watchId;
+}
+
+/**
+ * Stop watching a directory.
+ * @param {string} watchId
+ * @param {{ unwatch: Function }} fsApi - injected fs API
+ */
+export function stopWatch(watchId, fsApi) {
+  fsApi.unwatch(watchId);
+}

--- a/src/utils/file-viewer-files.js
+++ b/src/utils/file-viewer-files.js
@@ -1,0 +1,80 @@
+/**
+ * File management helpers extracted from FileViewer.
+ * Handles open-file state, pinning, modification tracking, and close logic.
+ */
+import { detectLanguage } from './file-icons.js';
+import { pinnedFiles } from './editor-helpers.js';
+
+/**
+ * Open a file and add it to the open-files map.
+ * If already open, returns false (caller should just activate the tab).
+ *
+ * @param {Map} openFiles
+ * @param {string} filePath
+ * @param {string} fileName
+ * @param {{ readfile: Function }} fsApi - injected fs API
+ * @returns {Promise<boolean>} true if the file was newly opened
+ */
+export async function openFileEntry(openFiles, filePath, fileName, fsApi) {
+  if (openFiles.has(filePath)) return false;
+
+  const result = await fsApi.readfile(filePath);
+  if (result.error) {
+    openFiles.set(filePath, { name: fileName, content: '', savedContent: '', lang: 'plaintext', error: result.error, viewMode: 'edit' });
+  } else {
+    const lang = detectLanguage(fileName);
+    const viewMode = lang === 'markdown' ? 'preview' : 'edit';
+    openFiles.set(filePath, { name: fileName, content: result.content, savedContent: result.content, lang, error: null, viewMode });
+  }
+  return true;
+}
+
+/** Check whether a file has unsaved changes. */
+export function isModified(openFiles, filePath) {
+  const file = openFiles.get(filePath);
+  if (!file) return false;
+  return file.content !== file.savedContent;
+}
+
+/** Check whether a file is pinned. */
+export function isPinned(filePath) {
+  return pinnedFiles.has(filePath);
+}
+
+/** Toggle the pinned state of a file. */
+export function togglePin(openFiles, filePath) {
+  const file = openFiles.get(filePath);
+  if (!file) return;
+  if (pinnedFiles.has(filePath)) {
+    pinnedFiles.delete(filePath);
+  } else {
+    pinnedFiles.set(filePath, { name: file.name });
+  }
+}
+
+/** Check if a file is markdown. */
+export function isMarkdown(openFiles, filePath) {
+  const file = openFiles.get(filePath);
+  return !!file && file.lang === 'markdown';
+}
+
+/**
+ * Close a file, handling unsaved-changes confirmation.
+ * Returns the next file to activate (or null if none remain), or false if close was cancelled.
+ */
+export function closeFileEntry(openFiles, filePath, activeFile) {
+  if (isModified(openFiles, filePath)) {
+    const file = openFiles.get(filePath);
+    if (!confirm(`"${file.name}" has unsaved changes. Close anyway?`)) return false;
+  }
+
+  openFiles.delete(filePath);
+
+  if (activeFile === filePath) {
+    if (openFiles.size > 0) {
+      return { switchTo: [...openFiles.keys()].pop() };
+    }
+    return { switchTo: null };
+  }
+  return { switchTo: undefined }; // no switch needed, just re-render tabs
+}

--- a/src/utils/worktree-dialog.js
+++ b/src/utils/worktree-dialog.js
@@ -105,6 +105,29 @@ function populateModal(modal, { btnNew, btnExisting, els, pathEl, cancel, confir
 }
 
 /**
+ * Build all form elements needed by the worktree dialog.
+ * @returns {{ els: object, pathEl: HTMLElement, btnNew: HTMLElement, btnExisting: HTMLElement }}
+ */
+function _buildWorktreeForm({ allBranches, existingBranches, currentBranch }) {
+  const els = {
+    newInput: buildBranchInput(),
+    baseSelect: buildBaseSelect(allBranches, currentBranch),
+    baseLabel: _el('label', 'worktree-dialog-sub-label', 'Base branch'),
+    existingSelect: buildExistingSelect(existingBranches),
+  };
+  const pathEl = _el('div', 'worktree-dialog-path');
+  const { btnNew, btnExisting } = buildModeButtons(() => {}, () => {});
+  return { els, pathEl, btnNew, btnExisting };
+}
+
+/**
+ * Validate the worktree input: return the trimmed branch name or empty string.
+ */
+function _validateWorktreeInput(mode, els) {
+  return readBranchValue(mode, els.newInput, els.existingSelect);
+}
+
+/**
  * Show the worktree creation dialog.
  *
  * `allBranches` is the full list of local branches (used to build the
@@ -122,23 +145,12 @@ export function showWorktreeDialog({ repoCwd, allBranches, existingBranches, cur
     modalClass: 'prompt-dialog-box worktree-dialog-box',
     builder({ modal, cleanup, cancel }) {
       let mode = 'new';
-      const els = {
-        newInput: buildBranchInput(),
-        baseSelect: buildBaseSelect(allBranches, currentBranch),
-        baseLabel: _el('label', 'worktree-dialog-sub-label', 'Base branch'),
-        existingSelect: buildExistingSelect(existingBranches),
-      };
-      const pathEl = _el('div', 'worktree-dialog-path');
+      const { els, pathEl, btnNew, btnExisting } = _buildWorktreeForm({ allBranches, existingBranches, currentBranch });
 
       const updatePath = () => {
-        const branch = readBranchValue(mode, els.newInput, els.existingSelect);
+        const branch = _validateWorktreeInput(mode, els);
         pathEl.textContent = branch ? defaultWorktreePath(repoCwd, branch) : '';
       };
-
-      const { btnNew, btnExisting } = buildModeButtons(
-        () => setMode('new'),
-        () => setMode('existing'),
-      );
 
       function setMode(next) {
         mode = next;
@@ -149,11 +161,14 @@ export function showWorktreeDialog({ repoCwd, allBranches, existingBranches, cur
         (isNew ? els.newInput : els.existingSelect).focus();
       }
 
+      btnNew.addEventListener('click', () => setMode('new'));
+      btnExisting.addEventListener('click', () => setMode('existing'));
+
       els.newInput.addEventListener('input', updatePath);
       els.existingSelect.addEventListener('change', updatePath);
 
       const confirm = () => {
-        const branch = readBranchValue(mode, els.newInput, els.existingSelect);
+        const branch = _validateWorktreeInput(mode, els);
         if (!branch) return;
         cleanup({
           branch,


### PR DESCRIPTION
## Summary

- **settings-update.js**: Extract `_buildUpdateUI`, `_bindProgressUpdates`, `_handleDownload` from `renderUpdate` (59 -> 22 lines)
- **worktree-dialog.js**: Extract `_buildWorktreeForm`, `_validateWorktreeInput` from `showWorktreeDialog` (54 -> 46 lines)
- **file-viewer.js**: Extract file management helpers (open, close, pin, modified, markdown) into `file-viewer-files.js` (308 -> 273 lines)
- **file-tree.js**: Extract filesystem watch/debounce logic into `file-tree-watcher.js` (301 -> 289 lines)

All new utility modules follow the project's DI convention (no direct `window.api` references).

Closes #357

## Test plan

- [x] `npm run build` passes
- [x] All 386 tests pass (`npm test`)
- [ ] Manual verification: settings update flow works (check, download, install)
- [ ] Manual verification: worktree dialog opens and creates worktrees correctly
- [ ] Manual verification: file viewer opens/closes/pins files as before
- [ ] Manual verification: file tree watches filesystem and refreshes on changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)