### PR TITLE
refactor: centralize aggregation patterns

### DIFF
--- a/main/aggregation-utils.js
+++ b/main/aggregation-utils.js
@@ -6,7 +6,7 @@
  * for cross-process reuse (main + renderer).
  */
 
-const { aggregateByKey, groupAndAggregate } = require('../shared/aggregation-utils');
+const { aggregateByKey, groupAndAggregate, initializeCounters } = require('../shared/aggregation-utils');
 
 /**
  * Compute a category rate from items using a category set map.
@@ -20,7 +20,7 @@ const { aggregateByKey, groupAndAggregate } = require('../shared/aggregation-uti
  */
 function computeRate(items, categories, field = 'status', rateKey = 'success') {
   const keys = Object.keys(categories);
-  const counts = Object.fromEntries(keys.map((k) => [k, 0]));
+  const counts = initializeCounters(keys);
 
   for (const item of items) {
     const val = item[field];

--- a/main/usage-helpers.js
+++ b/main/usage-helpers.js
@@ -3,7 +3,7 @@ const path = require('path');
 const { computeRate, computeDuration, perDay, DEFAULT_DAYS } = require('./stats-helpers');
 const { extractDateString } = require('./date-utils');
 const { aggregateByKey, groupAndAggregate } = require('./aggregation-utils');
-const { countBy, initializeCounters } = require('../shared/aggregation-utils');
+const { accumulateBy, countBy, initializeCounters } = require('../shared/aggregation-utils');
 
 // ===== Declarative configs =====
 
@@ -40,12 +40,13 @@ function newPerDayTotals() {
 
 /**
  * Add numeric token fields from `source` into `target` (in-place).
+ * Delegates to the generic accumulateBy helper.
  * @param {Record<string, number>} target
  * @param {Record<string, number>} source
  * @param {string[]} [keys=TOKEN_KEYS] - field names to accumulate
  */
 function addTokens(target, source, keys = TOKEN_KEYS) {
-  for (const k of keys) target[k] += source[k] || 0;
+  accumulateBy(target, source, keys);
 }
 
 /** @internal */

--- a/shared/aggregation-utils.js
+++ b/shared/aggregation-utils.js
@@ -58,6 +58,18 @@ function initializeCounters(keys, defaultValue = 0) {
 }
 
 /**
+ * Accumulate numeric values from `source` into `target` (in-place).
+ * For each key in `keys`, adds `source[k]` (defaulting to 0) to `target[k]`.
+ *
+ * @param {Record<string, number>} target - object to mutate
+ * @param {Record<string, number>} source - object to read values from
+ * @param {string[]} keys - field names to accumulate
+ */
+function accumulateBy(target, source, keys) {
+  for (const k of keys) target[k] += source[k] || 0;
+}
+
+/**
  * Counts occurrences of each key produced by keyFn.
  * @param {Array<unknown>} items
  * @param {(item: unknown) => string} keyFn - Returns the key for each item
@@ -93,4 +105,4 @@ function resolveFromMap(map, keys) {
   return keys.map(k => map.get(k)).filter(Boolean);
 }
 
-module.exports = { aggregateByKey, groupAndAggregate, countBy, createLookupMap, resolveFromMap, initializeCounters };
+module.exports = { aggregateByKey, groupAndAggregate, accumulateBy, countBy, createLookupMap, resolveFromMap, initializeCounters };


### PR DESCRIPTION
## Summary

- Added generic `accumulateBy(target, source, keys)` helper to `shared/aggregation-utils.js` to centralize the numeric accumulation pattern (`target[k] += source[k] || 0`) that was duplicated in `usage-helpers.js`
- Replaced inline `Object.fromEntries(keys.map(k => [k, 0]))` in `main/aggregation-utils.js` with the existing `initializeCounters(keys)` from shared utils
- `addTokens` in `usage-helpers.js` now delegates to the shared `accumulateBy` — same behavior, single source of truth

Closes #347

## Test plan

- [x] All 384 existing tests pass (25 test files)
- [x] Build completes successfully
- [ ] Manually verify the usage view renders correctly (medium risk — token accumulation logic unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)