### PR TITLE
refactor: replace generic Function types with precise JSDoc signatures

### DIFF
--- a/src/components/settings-update.js
+++ b/src/components/settings-update.js
@@ -61,7 +61,7 @@ function _buildUpdateUI(contentEl, version) {
 
 /**
  * Build progress DOM elements and bind the onProgress event.
- * @returns {{ unsub: Function|undefined }}
+ * @returns {{ unsub: (() => void)|undefined }}
  */
 function _bindProgressUpdates(area) {
   const progress = _el('div', 'update-progress');

--- a/src/utils/event-bus.js
+++ b/src/utils/event-bus.js
@@ -40,7 +40,7 @@ const bus = new EventBus();
 /**
  * Create a pair of typed on/emit helpers for a given event name.
  * @param {string} name - the event name
- * @returns {{ on: (cb: Function) => () => void, emit: (data?: unknown) => void }}
+ * @returns {{ on: (cb: (data?: unknown) => void) => () => void, emit: (data?: unknown) => void }}
  */
 export function createTypedEvent(name) {
   return {

--- a/src/utils/file-tree-watcher.js
+++ b/src/utils/file-tree-watcher.js
@@ -8,8 +8,8 @@ import { DEBOUNCE_DELAY, WATCH_PREFIX } from './file-tree-helpers.js';
  * Set up a debounced fs.onChanged listener.
  * @param {Map} debounceTimers - shared timer map
  * @param {(watchIdOrCwd: string) => Promise<void>} refreshSection - callback to refresh
- * @param {{ onChanged: Function }} fsApi - injected fs API
- * @returns {Function} unsubscribe function
+ * @param {{ onChanged: (cb: (event: { id: string }) => void) => (() => void) }} fsApi - injected fs API
+ * @returns {() => void} unsubscribe function
  */
 export function listenForChanges(debounceTimers, refreshSection, fsApi) {
   return fsApi.onChanged(({ id }) => {
@@ -29,7 +29,7 @@ export function listenForChanges(debounceTimers, refreshSection, fsApi) {
 /**
  * Start watching a directory for changes.
  * @param {string} cwd
- * @param {{ watch: Function }} fsApi - injected fs API
+ * @param {{ watch: (id: string, cwd: string) => void }} fsApi - injected fs API
  * @returns {string} watchId
  */
 export function startWatch(cwd, fsApi) {
@@ -41,7 +41,7 @@ export function startWatch(cwd, fsApi) {
 /**
  * Stop watching a directory.
  * @param {string} watchId
- * @param {{ unwatch: Function }} fsApi - injected fs API
+ * @param {{ unwatch: (id: string) => void }} fsApi - injected fs API
  */
 export function stopWatch(watchId, fsApi) {
   fsApi.unwatch(watchId);

--- a/src/utils/file-viewer-files.js
+++ b/src/utils/file-viewer-files.js
@@ -12,7 +12,7 @@ import { pinnedFiles } from './editor-helpers.js';
  * @param {Map} openFiles
  * @param {string} filePath
  * @param {string} fileName
- * @param {{ readfile: Function }} fsApi - injected fs API
+ * @param {{ readfile: (path: string) => Promise<{ content?: string, error?: string }> }} fsApi - injected fs API
  * @returns {Promise<boolean>} true if the file was newly opened
  */
 export async function openFileEntry(openFiles, filePath, fileName, fsApi) {

--- a/src/utils/settings-section-builder.js
+++ b/src/utils/settings-section-builder.js
@@ -70,7 +70,7 @@ export function buildSettingsSection(contentEl, { heading, items, renderItem, li
  * @param {{
  *   containerClass: string,
  *   actions: Array<{ action: string, label?: string, title?: string, cls?: string, hideWhen?: string }>,
- *   handlerDefs: Record<string, Function | { apiCall: Function, guard?: () => boolean }>,
+ *   handlerDefs: Record<string, ((...args: unknown[]) => void) | { apiCall: () => Promise<unknown>, guard?: () => boolean }>,
  *   onSuccess?: () => void,
  *   filter?: (desc: object) => boolean,
  * }} opts

--- a/src/utils/workspace-layout.js
+++ b/src/utils/workspace-layout.js
@@ -65,7 +65,7 @@ function _initTabComponents(tab, layout, sides, termContainer, getActiveTabId, c
  * @param {RenderWorkspaceDeps} deps
  * @param {import('./tab-types.js').WorkspaceTab} tab
  * @param {{ gitBranch: (cwd: string) => Promise<string> }} api - injected API methods
- * @param {{ FileTree: Function, FileViewer: Function, TerminalPanel: Function }} components - injected component constructors
+ * @param {{ FileTree: new (el: HTMLElement) => unknown, FileViewer: new (el: HTMLElement, isActive: () => boolean) => unknown, TerminalPanel: new (el: HTMLElement, cwd: string) => unknown }} components - injected component constructors
  */
 export async function renderWorkspace({ workspaceContainer, getActiveTabId, getActiveTab, scheduleAutoSave }, tab, { gitBranch }, components) {
   workspaceContainer.replaceChildren();


### PR DESCRIPTION
## Refactoring

Remplacement de 9 occurrences du type générique `Function` dans les JSDoc par des signatures typées précises. Cela améliore la documentation du code et aide les IDE à fournir une meilleure assistance.

Closes #367

## Fichier(s) modifié(s)

- `src/utils/event-bus.js`
- `src/utils/file-tree-watcher.js`
- `src/utils/file-viewer-files.js`
- `src/utils/workspace-layout.js`
- `src/components/settings-update.js`
- `src/utils/settings-section-builder.js`

## Vérifications

- [x] Build OK
- [x] Tests OK

---

📂 Path local : `/Users/rekta/projet/coding/refactor-pikagent`
🤖 PR créée automatiquement par l'Agent Refactor