### PR TITLE
refactor: reduce flow-manager coupling

### DIFF
--- a/main/flow-executor.js
+++ b/main/flow-executor.js
@@ -8,6 +8,7 @@
 
 const fsp = require('fs/promises');
 const os = require('os');
+const path = require('path');
 const {
   SHELL_INIT_DELAY_MS,
   DEFAULT_PTY_COLS, DEFAULT_PTY_ROWS,
@@ -144,6 +145,7 @@ function setupPtyListeners(deps, runningFlows, proc, flow, ptyId, runTimestamp) 
  *   stopAll: () => void,
  *   getRunning: () => Record<string, string>,
  *   getRunLog: (flowId: string, timestamp: string) => Promise<string | null>,
+ *   cleanLogs: (flowId: string) => Promise<void>,
  * }}
  */
 function createFlowExecutor(deps) {
@@ -192,6 +194,21 @@ function createFlowExecutor(deps) {
     }
   }
 
+  // --- Log cleanup ---
+
+  async function cleanLogs(flowId) {
+    await trySafe(
+      async () => {
+        const files = (await fsp.readdir(LOGS_DIR)).filter((f) => f.startsWith(flowId + '_'));
+        await Promise.all(files.map((f) => fsp.unlink(path.join(LOGS_DIR, f))));
+      },
+      undefined,
+      { log, label: 'cleanLogs' },
+    );
+  }
+
+  // --- Public API ---
+
   function stopAll() {
     const ptyManager = getPtyManager();
     for (const [, { ptyId, timeout }] of runningFlows) {
@@ -213,6 +230,7 @@ function createFlowExecutor(deps) {
     stopAll,
     getRunning,
     getRunLog: (flowId, timestamp) => getRunLog(deps, flowId, timestamp),
+    cleanLogs,
   };
 }
 

--- a/main/flow-manager.js
+++ b/main/flow-manager.js
@@ -6,10 +6,7 @@
  * IPC communication, and wiring the sub-modules together.
  */
 
-const fsp = require('fs/promises');
-const path = require('path');
-const { FLOWS_DIR, LOGS_DIR, FLOW_CATEGORIES_FILE } = require('./paths');
-const { readJson, writeJson, ensureDirOnce } = require('./fs-utils');
+const { FLOWS_DIR, FLOW_CATEGORIES_FILE } = require('./paths');
 const { safeSend } = require('./ipc-helpers');
 const { buildTimestampedRecord } = require('./record-helpers');
 const { trySafe } = require('./logger');
@@ -18,7 +15,6 @@ const { createFlowScheduler } = require('./flow-scheduler');
 const { createFlowExecutor } = require('./flow-executor');
 
 const store = new JsonStore(FLOWS_DIR, 'flow-manager');
-const ensureLogsDir = ensureDirOnce(LOGS_DIR);
 
 class FlowManager {
   constructor() {
@@ -64,7 +60,6 @@ class FlowManager {
   // --- CRUD ---
 
   async save(flow) {
-    await ensureLogsDir();
     const existing = await this.get(flow.id);
     const data = buildTimestampedRecord(flow, existing);
     if (!data.runs) data.runs = [];
@@ -112,25 +107,17 @@ class FlowManager {
 
   async getCategories() {
     await store.ensureDir();
-    const data = await readJson(FLOW_CATEGORIES_FILE);
+    const data = await store.readFile(FLOW_CATEGORIES_FILE);
     return data || { categories: [], order: {} };
   }
 
   async saveCategories(data) {
-    await store.ensureDir();
-    await writeJson(FLOW_CATEGORIES_FILE, data);
+    await store.writeFile(FLOW_CATEGORIES_FILE, data);
     return data;
   }
 
   async _cleanLogs(flowId) {
-    await trySafe(
-      async () => {
-        const files = (await fsp.readdir(LOGS_DIR)).filter((f) => f.startsWith(flowId + '_'));
-        await Promise.all(files.map((f) => fsp.unlink(path.join(LOGS_DIR, f))));
-      },
-      undefined,
-      { log: store.log, label: 'cleanLogs' },
-    );
+    await this._executor.cleanLogs(flowId);
   }
 
   // --- On-demand execution ---

--- a/main/json-store.js
+++ b/main/json-store.js
@@ -73,6 +73,23 @@ class JsonStore {
     return this._ensureDir();
   }
 
+  /**
+   * Read a JSON file at an arbitrary absolute path (returns null when missing).
+   * Useful for satellite files (e.g. categories) that live alongside the store.
+   */
+  async readFile(filePath) {
+    return readJson(filePath);
+  }
+
+  /**
+   * Write a JSON file at an arbitrary absolute path.
+   * Ensures the store directory exists first.
+   */
+  async writeFile(filePath, data) {
+    await this._ensureDir();
+    return writeJson(filePath, data);
+  }
+
   /** Expose the logger so the owning manager can reuse it. */
   get log() {
     return this._log;


### PR DESCRIPTION
## Refactoring

Réduction du couplage de `flow-manager.js` en déléguant davantage aux modules existants `flow-executor.js` et `flow-scheduler.js`. Le nombre d'imports passe de 10 à 7 modules distincts.

### Changements

- **`main/flow-manager.js`** : suppression des imports `fs/promises`, `path` et `./fs-utils` ; délégation du nettoyage des logs à l'executor et de la lecture/écriture des catégories au `JsonStore`
- **`main/flow-executor.js`** : ajout de la méthode `cleanLogs(flowId)` (déplacée depuis flow-manager)
- **`main/json-store.js`** : ajout des méthodes `readFile()` et `writeFile()` pour les fichiers satellites (ex: catégories)

Closes #359

## Vérifications

- [x] Build OK
- [x] Tests OK (386 tests, 25 fichiers)

---

📂 Path local : `/Users/rekta/projet/coding/refactor-pikagent`
🤖 PR créée automatiquement par l'Agent Refactor