### PR TITLE
refactor: factorize aggregation patterns

### DIFF
--- a/main/aggregation-utils.js
+++ b/main/aggregation-utils.js
@@ -2,56 +2,17 @@
  * Generic aggregation utilities shared across helper modules.
  * Pure functions — no domain-specific logic.
  *
- * aggregateByKey and groupAndAggregate are re-exported from shared/aggregation-utils.js
+ * Thin re-export layer: all logic lives in shared/aggregation-utils.js
  * for cross-process reuse (main + renderer).
  */
 
-const { aggregateByKey, groupAndAggregate, initializeCounters } = require('../shared/aggregation-utils');
+const {
+  aggregateByKey,
+  groupAndAggregate,
+  initializeCounters,
+  computeRate,
+  computeNumericStats,
+  buildMetrics,
+} = require('../shared/aggregation-utils');
 
-/**
- * Compute a category rate from items using a category set map.
- * Generic version that accepts category definitions.
- *
- * @param {Array<Record<string, unknown>>} items
- * @param {Record<string, Set<unknown>>} categories - map of categoryName -> Set of matching values
- * @param {string} [field='status'] - field to read from each item
- * @param {string} [rateKey='success'] - category key used to compute the rate
- * @returns {{ total: number, rate: number } & Record<string, number>}
- */
-function computeRate(items, categories, field = 'status', rateKey = 'success') {
-  const keys = Object.keys(categories);
-  const counts = initializeCounters(keys);
-
-  for (const item of items) {
-    const val = item[field];
-    for (const key of keys) {
-      if (categories[key].has(val)) { counts[key]++; break; }
-    }
-  }
-
-  const total = items.length;
-  const rate = total > 0 ? Math.round(((counts[rateKey] || 0) / total) * 100) : 0;
-
-  return { total, ...counts, rate };
-}
-
-/**
- * Compute basic numeric statistics (avg, min, max, count) from an array of values.
- * Filters out null/undefined/zero/negative values before computing.
- *
- * @param {Array<number|null>} values
- * @returns {{ avg: number, min: number, max: number, count: number }}
- */
-function computeNumericStats(values) {
-  const valid = values.filter((v) => v != null && v > 0);
-  if (valid.length === 0) return { avg: 0, min: 0, max: 0, count: 0 };
-  const avg = valid.reduce((a, b) => a + b, 0) / valid.length;
-  return {
-    avg: Math.round(avg),
-    min: Math.round(Math.min(...valid)),
-    max: Math.round(Math.max(...valid)),
-    count: valid.length,
-  };
-}
-
-module.exports = { aggregateByKey, groupAndAggregate, computeRate, computeNumericStats };
+module.exports = { aggregateByKey, groupAndAggregate, computeRate, computeNumericStats, initializeCounters, buildMetrics };

--- a/main/stats-helpers.js
+++ b/main/stats-helpers.js
@@ -1,4 +1,4 @@
-const { computeRate: genericComputeRate, groupAndAggregate, computeNumericStats } = require('./aggregation-utils');
+const { computeRate: genericComputeRate, groupAndAggregate, computeNumericStats } = require('../shared/aggregation-utils');
 const { generateDateRange } = require('./date-utils');
 
 const DEFAULT_DAYS = 30;

--- a/main/usage-helpers.js
+++ b/main/usage-helpers.js
@@ -2,8 +2,14 @@ const os = require('os');
 const path = require('path');
 const { computeRate, computeDuration, perDay, DEFAULT_DAYS } = require('./stats-helpers');
 const { extractDateString } = require('./date-utils');
-const { aggregateByKey, groupAndAggregate } = require('./aggregation-utils');
-const { accumulateBy, countBy, initializeCounters } = require('../shared/aggregation-utils');
+const {
+  aggregateByKey,
+  groupAndAggregate,
+  accumulateBy,
+  countBy,
+  initializeCounters,
+  buildMetrics: genericBuildMetrics,
+} = require('../shared/aggregation-utils');
 
 // ===== Declarative configs =====
 
@@ -169,8 +175,8 @@ function getFlowRunDuration(run) {
 }
 
 /**
- * Shared metrics builder — computes rate, duration, and perDay from a list of
- * items and merges any extra fields supplied by the caller.
+ * Domain-specific metrics builder — delegates to the generic shared buildMetrics
+ * factory, injecting domain-specific rate and perDay functions.
  *
  * @param {Array<{ status?: string, [key: string]: unknown }>} items - The items to compute base metrics for
  * @param {{ durationMapper: (item: { status?: string, [key: string]: unknown }) => number|null,
@@ -179,12 +185,14 @@ function getFlowRunDuration(run) {
  * @returns {Record<string, unknown>}
  */
 function buildMetrics(items, { durationMapper, dateExtractor, extra = {} }) {
-  return {
-    rate: computeRate(items),
-    duration: computeDuration(items.map(durationMapper)),
-    perDay: perDay(items, dateExtractor, DEFAULT_DAYS),
-    ...extra,
-  };
+  return genericBuildMetrics(items, {
+    rateFn: computeRate,
+    durationMapper,
+    dateExtractor,
+    perDayFn: perDay,
+    days: DEFAULT_DAYS,
+    extra,
+  });
 }
 
 function buildFlowMetrics(flows, flowRuns) {

--- a/shared/aggregation-utils.js
+++ b/shared/aggregation-utils.js
@@ -105,4 +105,83 @@ function resolveFromMap(map, keys) {
   return keys.map(k => map.get(k)).filter(Boolean);
 }
 
-module.exports = { aggregateByKey, groupAndAggregate, accumulateBy, countBy, createLookupMap, resolveFromMap, initializeCounters };
+/**
+ * Compute a category rate from items using a category set map.
+ * Generic version that accepts category definitions.
+ *
+ * @param {Array<Record<string, unknown>>} items
+ * @param {Record<string, Set<unknown>>} categories - map of categoryName -> Set of matching values
+ * @param {string} [field='status'] - field to read from each item
+ * @param {string} [rateKey='success'] - category key used to compute the rate
+ * @returns {{ total: number, rate: number } & Record<string, number>}
+ */
+function computeRate(items, categories, field = 'status', rateKey = 'success') {
+  const keys = Object.keys(categories);
+  const counts = initializeCounters(keys);
+
+  for (const item of items) {
+    const val = item[field];
+    for (const key of keys) {
+      if (categories[key].has(val)) { counts[key]++; break; }
+    }
+  }
+
+  const total = items.length;
+  const rate = total > 0 ? Math.round(((counts[rateKey] || 0) / total) * 100) : 0;
+
+  return { total, ...counts, rate };
+}
+
+/**
+ * Compute basic numeric statistics (avg, min, max, count) from an array of values.
+ * Filters out null/undefined/zero/negative values before computing.
+ *
+ * @param {Array<number|null>} values
+ * @returns {{ avg: number, min: number, max: number, count: number }}
+ */
+function computeNumericStats(values) {
+  const valid = values.filter((v) => v != null && v > 0);
+  if (valid.length === 0) return { avg: 0, min: 0, max: 0, count: 0 };
+  const avg = valid.reduce((a, b) => a + b, 0) / valid.length;
+  return {
+    avg: Math.round(avg),
+    min: Math.round(Math.min(...valid)),
+    max: Math.round(Math.max(...valid)),
+    count: valid.length,
+  };
+}
+
+/**
+ * Declarative metrics builder. Computes rate, duration, and perDay from a list
+ * of items and merges any extra fields supplied by the caller.
+ *
+ * @param {Array<{ status?: string, [key: string]: unknown }>} items
+ * @param {{ rateFn: (items: Array) => Record<string, unknown>,
+ *           durationMapper: (item: unknown) => number|null,
+ *           dateExtractor: (item: unknown) => string,
+ *           perDayFn: (items: Array, dateExtractor: Function, days: number) => Array,
+ *           days?: number,
+ *           extra?: Record<string, unknown> }} config
+ * @returns {Record<string, unknown>}
+ */
+function buildMetrics(items, { rateFn, durationMapper, dateExtractor, perDayFn, days = 30, extra = {} }) {
+  return {
+    rate: rateFn(items),
+    duration: computeNumericStats(items.map(durationMapper)),
+    perDay: perDayFn(items, dateExtractor, days),
+    ...extra,
+  };
+}
+
+module.exports = {
+  aggregateByKey,
+  groupAndAggregate,
+  accumulateBy,
+  countBy,
+  createLookupMap,
+  resolveFromMap,
+  initializeCounters,
+  computeRate,
+  computeNumericStats,
+  buildMetrics,
+};


### PR DESCRIPTION
## Refactoring

Factorisation des patterns d'agregation dupliques :
- `initializeCounters(keys, defaultValue)` remplace les `Object.fromEntries` repetitifs
- `accumulateBy(target, source, keys)` generalise `addTokens`
- `buildMetrics(config)` factory declarative pour les metriques agents/flows/perDay
- `computeRate` et `computeNumericStats` centralises dans `shared/aggregation-utils.js`

Closes #347

## Fichier(s) modifie(s)

- `shared/aggregation-utils.js` — ajout de `computeRate`, `computeNumericStats`, `buildMetrics`
- `main/aggregation-utils.js` — reduit a un thin re-export layer
- `main/usage-helpers.js` — imports consolides, `buildMetrics` delegue au shared
- `main/stats-helpers.js` — import direct depuis `shared/aggregation-utils`

## Verifications

- [x] Build OK
- [x] Tests OK (25 fichiers, 386 tests)