### PR TITLE
refactor: reduce long files and functions

### DIFF
--- a/src/components/file-tree.js
+++ b/src/components/file-tree.js
@@ -1,15 +1,14 @@
-import { _el, createActionButton } from '../utils/file-dom.js';
+import { _el } from '../utils/file-dom.js';
 import { buildChevronRow } from '../utils/chevron-row.js';
 import {
   CHEVRON_EXPANDED, CHEVRON_COLLAPSED,
-  HEADER_ACTIONS,
   extractFolderName, resolveWatchCwd,
 } from '../utils/file-tree-helpers.js';
 import { registerComponent } from '../utils/component-registry.js';
 import { buildDirContextItems } from '../utils/file-tree-context-menu.js';
 import { attachContextMenu } from '../utils/context-menu.js';
 import { emitWorkspaceCreateWorktree, emitWorkspaceOpenPr } from '../utils/workspace-events.js';
-import { renderDirEntry, renderFileEntry, PARSED_ICONS } from '../utils/file-tree-renderer.js';
+import { renderDirEntry, renderFileEntry, buildSectionActions } from '../utils/file-tree-renderer.js';
 import {
   setupDropZone, handleFileDrop,
   promptRename as doPromptRename,
@@ -146,17 +145,7 @@ export class FileTree extends ComponentBase {
       openPr:      () => emitWorkspaceOpenPr({ repoCwd: cwd }),
       refresh:     () => this.refreshSection(cwd),
     };
-    const actionBtns = HEADER_ACTIONS.map(({ key, title, action }) =>
-      createActionButton({
-        title,
-        cls: 'file-tree-action-btn',
-        childNode: PARSED_ICONS[key].cloneNode(true),
-        stopPropagation: true,
-        onClick: actionDispatcher[action],
-      }),
-    );
-
-    const actionsContainer = _el('div', { className: 'file-tree-section-actions' }, ...actionBtns);
+    const actionsContainer = buildSectionActions(actionDispatcher);
 
     const { chevron, name: labelEl, row: header } = buildChevronRow({
       chevronClass: 'file-tree-section-chevron',

--- a/src/components/file-viewer.js
+++ b/src/components/file-viewer.js
@@ -2,7 +2,8 @@ import { emitLayoutChanged } from '../utils/workspace-events.js';
 import { _el } from '../utils/file-dom.js';
 import { EMPTY_MESSAGE, MODE_CONFIG, ALL_STATIC_ELEMENTS, MODE_ACTIVATE, pinnedFiles } from '../utils/editor-helpers.js';
 import {
-  createEditorDOM, bindEditorEvents, updateLineNumbers, updateHighlight, updateStatusBar, saveFile,
+  updateLineNumbers, updateHighlight, updateStatusBar, saveFile,
+  initCodeEditor,
   createMarkdownPreviewDOM, updatePreviewStatusBar,
   renderTabs as renderTabsHelper,
   renderModeBar,
@@ -175,17 +176,13 @@ export class FileViewer extends ComponentBase {
       return;
     }
 
-    const { lineNumbers, highlightLayer, editorEl } = createEditorDOM(this.editorWrapper, file);
-    this.lineNumbers = lineNumbers;
-    this.highlightLayer = highlightLayer;
-    this.editorEl = editorEl;
-
-    bindEditorEvents(this.editorEl, this.lineNumbers, this.highlightLayer, file, {
+    const { lineNumbers, highlightLayer, editorEl } = initCodeEditor(this.editorWrapper, file, {
       onUpdate: () => { this.updateLineNumbers(); this.updateHighlight(); this.renderTabs(); this.updateStatusBar(); },
       onSave: () => this.saveActive(),
     });
-    this.updateLineNumbers();
-    this.updateHighlight();
+    this.lineNumbers = lineNumbers;
+    this.highlightLayer = highlightLayer;
+    this.editorEl = editorEl;
     this.updateStatusBar();
     this.editorEl.focus();
   }

--- a/src/components/settings-update.js
+++ b/src/components/settings-update.js
@@ -48,7 +48,7 @@ function _showAvailable(area, result, onInstall) {
  * Build the version bar and update area, appending them to contentEl.
  * @returns {{ area: HTMLElement }}
  */
-function _buildUpdateUI(contentEl, version) {
+function renderUpdateUI(contentEl, version) {
   const bar = _el('div', 'update-version-bar');
   bar.appendChild(_el('span', 'update-version-label', 'Version'));
   bar.appendChild(_el('span', 'update-version-value', `v${version}`));
@@ -63,7 +63,7 @@ function _buildUpdateUI(contentEl, version) {
  * Build progress DOM elements and bind the onProgress event.
  * @returns {{ unsub: Function|undefined }}
  */
-function _bindProgressUpdates(area) {
+function handleProgress(area) {
   const progress = _el('div', 'update-progress');
   const barTrack = _el('div', 'update-progress-track');
   const barFill = _el('div', 'update-progress-fill');
@@ -83,9 +83,9 @@ function _bindProgressUpdates(area) {
 /**
  * Run the download/install flow: show progress, then success or error.
  */
-async function _handleDownload(area, runCheck) {
+async function handleDownload(area, runCheck) {
   area.replaceChildren();
-  const { unsub } = _bindProgressUpdates(area);
+  const { unsub } = handleProgress(area);
 
   try {
     await window.api.update.run();
@@ -109,7 +109,7 @@ export async function renderUpdate(contentEl) {
   createSettingsSection(contentEl, { heading: 'Update' });
 
   const version = await window.api.update.version();
-  const { area } = _buildUpdateUI(contentEl, version);
+  const { area } = renderUpdateUI(contentEl, version);
 
   async function runCheck(btn) {
     btn.textContent = 'Checking...';
@@ -119,7 +119,7 @@ export async function renderUpdate(contentEl) {
       const result = await window.api.update.check();
       if (result.error) _showMessage(area, 'error', result.error, runCheck);
       else if (!result.available) _showMessage(area, 'ok', 'Your application is up to date', runCheck);
-      else _showAvailable(area, result, () => _handleDownload(area, runCheck));
+      else _showAvailable(area, result, () => handleDownload(area, runCheck));
     } catch (err) {
       _showMessage(area, 'error', err.message, runCheck);
     }

--- a/src/utils/file-editor-renderer.js
+++ b/src/utils/file-editor-renderer.js
@@ -127,16 +127,6 @@ export function updateStatusBar(statusBar, editorEl, file) {
 }
 
 /**
- * Persist the active file to disk and flash the status bar.
- * Mutates file.savedContent on success.
- *
- * @param {string} filePath
- * @param {{ content: string, savedContent: string, error?: string }} file
- * @param {HTMLElement} statusBar
- * @param {{ onSuccess: () => void }} callbacks
- * @param {{ writefile: (path: string, content: string) => Promise<{ error?: string }> }} api - injected API methods
- */
-/**
  * Create the code editor DOM, bind events, and run initial updates.
  * Returns { lineNumbers, highlightLayer, editorEl }.
  *
@@ -158,6 +148,16 @@ export function initCodeEditor(editorWrapper, file, { onUpdate, onSave }) {
   return { lineNumbers, highlightLayer, editorEl };
 }
 
+/**
+ * Persist the active file to disk and flash the status bar.
+ * Mutates file.savedContent on success.
+ *
+ * @param {string} filePath
+ * @param {{ content: string, savedContent: string, error?: string }} file
+ * @param {HTMLElement} statusBar
+ * @param {{ onSuccess: () => void }} callbacks
+ * @param {{ writefile: (path: string, content: string) => Promise<{ error?: string }> }} api - injected API methods
+ */
 export async function saveFile(filePath, file, statusBar, { onSuccess }, { writefile }) {
   if (!file || file.error) return;
   const result = await writefile(filePath, file.content);

--- a/src/utils/file-editor-renderer.js
+++ b/src/utils/file-editor-renderer.js
@@ -136,6 +136,28 @@ export function updateStatusBar(statusBar, editorEl, file) {
  * @param {{ onSuccess: () => void }} callbacks
  * @param {{ writefile: (path: string, content: string) => Promise<{ error?: string }> }} api - injected API methods
  */
+/**
+ * Create the code editor DOM, bind events, and run initial updates.
+ * Returns { lineNumbers, highlightLayer, editorEl }.
+ *
+ * @param {HTMLElement} editorWrapper
+ * @param {{ content: string, lang: string }} file
+ * @param {{ onUpdate: () => void, onSave: () => void }} callbacks
+ * @returns {{ lineNumbers: HTMLElement, highlightLayer: HTMLElement, editorEl: HTMLTextAreaElement }}
+ */
+export function initCodeEditor(editorWrapper, file, { onUpdate, onSave }) {
+  const { lineNumbers, highlightLayer, editorEl } = createEditorDOM(editorWrapper, file);
+
+  bindEditorEvents(editorEl, lineNumbers, highlightLayer, file, {
+    onUpdate,
+    onSave,
+  });
+  updateLineNumbers(lineNumbers, editorEl);
+  updateHighlight(highlightLayer, editorEl, file.lang);
+
+  return { lineNumbers, highlightLayer, editorEl };
+}
+
 export async function saveFile(filePath, file, statusBar, { onSuccess }, { writefile }) {
   if (!file || file.error) return;
   const result = await writefile(filePath, file.content);

--- a/src/utils/file-tree-renderer.js
+++ b/src/utils/file-tree-renderer.js
@@ -4,9 +4,9 @@
  */
 
 import { emitFileOpen } from './workspace-events.js';
-import { _el } from './file-dom.js';
+import { _el, createActionButton } from './file-dom.js';
 import { buildChevronRow } from './chevron-row.js';
-import { computeIndent, CHEVRON_EXPANDED, CHEVRON_COLLAPSED, SVG_ICONS } from './file-tree-helpers.js';
+import { computeIndent, CHEVRON_EXPANDED, CHEVRON_COLLAPSED, SVG_ICONS, HEADER_ACTIONS } from './file-tree-helpers.js';
 import { buildFileContextItems, buildDirContextItems } from './file-tree-context-menu.js';
 import { attachContextMenu } from './context-menu.js';
 
@@ -115,4 +115,23 @@ export function renderFileEntry(entry, parentEl, depth, callbacks) {
     (path, nameEl) => promptRename(path, nameEl),
     contextMenuApi,
   ));
+}
+
+/**
+ * Build the action buttons container for a section header.
+ *
+ * @param {Record<string, () => void>} actionDispatcher - action name -> handler
+ * @returns {HTMLElement} container with action buttons
+ */
+export function buildSectionActions(actionDispatcher) {
+  const actionBtns = HEADER_ACTIONS.map(({ key, title, action }) =>
+    createActionButton({
+      title,
+      cls: 'file-tree-action-btn',
+      childNode: PARSED_ICONS[key].cloneNode(true),
+      stopPropagation: true,
+      onClick: actionDispatcher[action],
+    }),
+  );
+  return _el('div', { className: 'file-tree-section-actions' }, ...actionBtns);
 }

--- a/src/utils/file-viewer-subsystem.js
+++ b/src/utils/file-viewer-subsystem.js
@@ -13,6 +13,7 @@ export {
   updateHighlight,
   updateStatusBar,
   saveFile,
+  initCodeEditor,
 } from './file-editor-renderer.js';
 
 export {

--- a/src/utils/worktree-dialog.js
+++ b/src/utils/worktree-dialog.js
@@ -128,13 +128,51 @@ function _validateWorktreeInput(mode, els) {
 }
 
 /**
+ * Wire up mode switching, path updates, and confirm/cancel inside the dialog.
+ * Returns an initializer function to call after the modal is mounted.
+ */
+function _wireWorktreeDialog({ modal, cleanup, cancel, repoCwd, allBranches, existingBranches, currentBranch }) {
+  let mode = 'new';
+  const { els, pathEl, btnNew, btnExisting } = _buildWorktreeForm({ allBranches, existingBranches, currentBranch });
+
+  const updatePath = () => {
+    const branch = _validateWorktreeInput(mode, els);
+    pathEl.textContent = branch ? defaultWorktreePath(repoCwd, branch) : '';
+  };
+
+  function setMode(next) {
+    mode = next;
+    btnNew.classList.toggle('active', mode === 'new');
+    btnExisting.classList.toggle('active', mode === 'existing');
+    const isNew = applyModeVisibility(mode, els);
+    updatePath();
+    (isNew ? els.newInput : els.existingSelect).focus();
+  }
+
+  btnNew.addEventListener('click', () => setMode('new'));
+  btnExisting.addEventListener('click', () => setMode('existing'));
+  els.newInput.addEventListener('input', updatePath);
+  els.existingSelect.addEventListener('change', updatePath);
+
+  const confirm = () => {
+    const branch = _validateWorktreeInput(mode, els);
+    if (!branch) return;
+    cleanup({
+      branch,
+      createBranch: mode === 'new',
+      targetPath: defaultWorktreePath(repoCwd, branch),
+      baseBranch: mode === 'new' ? (els.baseSelect.value || null) : null,
+    });
+  };
+
+  wireKeyboardShortcuts([els.newInput, els.existingSelect, els.baseSelect], { onEnter: confirm, onEscape: cancel });
+  populateModal(modal, { btnNew, btnExisting, els, pathEl, cancel, confirm });
+
+  return () => { updatePath(); els.newInput.focus(); };
+}
+
+/**
  * Show the worktree creation dialog.
- *
- * `allBranches` is the full list of local branches (used to build the
- * base-branch dropdown in "new branch" mode — a base branch can be one
- * that's already checked out elsewhere).
- * `existingBranches` is the list of branches available for the "existing
- * branch" mode (i.e. not already checked out in another worktree).
  *
  * @param {{ repoCwd: string, allBranches: string[], existingBranches: string[], currentBranch: string|null }} opts
  * @returns {Promise<{ branch: string, createBranch: boolean, targetPath: string, baseBranch: string|null } | null>}
@@ -144,44 +182,7 @@ export function showWorktreeDialog({ repoCwd, allBranches, existingBranches, cur
     overlayClass: 'prompt-dialog-overlay',
     modalClass: 'prompt-dialog-box worktree-dialog-box',
     builder({ modal, cleanup, cancel }) {
-      let mode = 'new';
-      const { els, pathEl, btnNew, btnExisting } = _buildWorktreeForm({ allBranches, existingBranches, currentBranch });
-
-      const updatePath = () => {
-        const branch = _validateWorktreeInput(mode, els);
-        pathEl.textContent = branch ? defaultWorktreePath(repoCwd, branch) : '';
-      };
-
-      function setMode(next) {
-        mode = next;
-        btnNew.classList.toggle('active', mode === 'new');
-        btnExisting.classList.toggle('active', mode === 'existing');
-        const isNew = applyModeVisibility(mode, els);
-        updatePath();
-        (isNew ? els.newInput : els.existingSelect).focus();
-      }
-
-      btnNew.addEventListener('click', () => setMode('new'));
-      btnExisting.addEventListener('click', () => setMode('existing'));
-
-      els.newInput.addEventListener('input', updatePath);
-      els.existingSelect.addEventListener('change', updatePath);
-
-      const confirm = () => {
-        const branch = _validateWorktreeInput(mode, els);
-        if (!branch) return;
-        cleanup({
-          branch,
-          createBranch: mode === 'new',
-          targetPath: defaultWorktreePath(repoCwd, branch),
-          baseBranch: mode === 'new' ? (els.baseSelect.value || null) : null,
-        });
-      };
-
-      wireKeyboardShortcuts([els.newInput, els.existingSelect, els.baseSelect], { onEnter: confirm, onEscape: cancel });
-      populateModal(modal, { btnNew, btnExisting, els, pathEl, cancel, confirm });
-
-      return () => { updatePath(); els.newInput.focus(); };
+      return _wireWorktreeDialog({ modal, cleanup, cancel, repoCwd, allBranches, existingBranches, currentBranch });
     },
   });
 }


### PR DESCRIPTION
## Refactoring

- Extraction de `initCodeEditor` depuis `file-viewer.js` vers `file-editor-renderer.js` (re-export via `file-viewer-subsystem.js`)
- Extraction de `buildSectionActions` depuis `file-tree.js` vers `file-tree-renderer.js`
- Renommage des fonctions internes de `settings-update.js` : `renderUpdateUI`, `handleDownload`, `handleProgress`
- Extraction de `_wireWorktreeDialog` depuis `showWorktreeDialog` dans `worktree-dialog.js`

Closes #357

## Fichier(s) modifie(s)

- `src/components/file-viewer.js` (272 -> 269 lignes)
- `src/components/file-tree.js` (289 -> 278 lignes)
- `src/components/settings-update.js` (131 lignes, fonctions renommees)
- `src/utils/worktree-dialog.js` (187 -> 188 lignes, showWorktreeDialog 46 -> 8 lignes)
- `src/utils/file-editor-renderer.js` (+initCodeEditor)
- `src/utils/file-tree-renderer.js` (+buildSectionActions)
- `src/utils/file-viewer-subsystem.js` (+re-export initCodeEditor)

## Verifications

- [x] Build OK
- [x] Tests OK (386 tests, 25 suites)

---

PR creee automatiquement par l'Agent Refactor