### PR TITLE
refactor: create file-tree-subsystem facade to reduce coupling

### DIFF
--- a/src/components/file-tree.js
+++ b/src/components/file-tree.js
@@ -1,21 +1,19 @@
 import { _el } from '../utils/file-dom.js';
 import { buildChevronRow } from '../utils/chevron-row.js';
+import { registerComponent } from '../utils/component-registry.js';
+import { attachContextMenu } from '../utils/context-menu.js';
+import { emitWorkspaceCreateWorktree, emitWorkspaceOpenPr } from '../utils/workspace-events.js';
+import { ComponentBase } from '../utils/component-base.js';
 import {
   CHEVRON_EXPANDED, CHEVRON_COLLAPSED,
   extractFolderName, resolveWatchCwd,
-} from '../utils/file-tree-helpers.js';
-import { registerComponent } from '../utils/component-registry.js';
-import { buildDirContextItems } from '../utils/file-tree-context-menu.js';
-import { attachContextMenu } from '../utils/context-menu.js';
-import { emitWorkspaceCreateWorktree, emitWorkspaceOpenPr } from '../utils/workspace-events.js';
-import { renderDirEntry, renderFileEntry, buildSectionActions } from '../utils/file-tree-renderer.js';
-import {
+  buildDirContextItems,
+  renderDirEntry, renderFileEntry, buildSectionActions,
   setupDropZone, handleFileDrop,
   promptRename as doPromptRename,
   promptNewEntry as doPromptNewEntry,
-} from '../utils/file-tree-drop.js';
-import { listenForChanges, startWatch, stopWatch } from '../utils/file-tree-watcher.js';
-import { ComponentBase } from '../utils/component-base.js';
+  listenForChanges, startWatch, stopWatch,
+} from '../utils/file-tree-subsystem.js';
 
 export class FileTree extends ComponentBase {
   constructor(container) {

--- a/src/utils/file-tree-subsystem.js
+++ b/src/utils/file-tree-subsystem.js
@@ -1,0 +1,34 @@
+/**
+ * Facade module that re-exports all file-tree-specific utilities.
+ * Reduces coupling by providing a single import point for file-tree subsystem.
+ */
+
+export {
+  buildDirContextItems,
+} from './file-tree-context-menu.js';
+
+export {
+  setupDropZone,
+  handleFileDrop,
+  promptRename,
+  promptNewEntry,
+} from './file-tree-drop.js';
+
+export {
+  CHEVRON_EXPANDED,
+  CHEVRON_COLLAPSED,
+  extractFolderName,
+  resolveWatchCwd,
+} from './file-tree-helpers.js';
+
+export {
+  renderDirEntry,
+  renderFileEntry,
+  buildSectionActions,
+} from './file-tree-renderer.js';
+
+export {
+  listenForChanges,
+  startWatch,
+  stopWatch,
+} from './file-tree-watcher.js';


### PR DESCRIPTION
## Refactoring

Create `src/utils/file-tree-subsystem.js` facade that re-exports file-tree-specific utilities (context-menu, drop, helpers, renderer, watcher). Update `file-tree.js` to import from the facade, reducing direct dependencies from 11 to ~7.

Closes #374

## Fichier(s) modifié(s)

- `src/utils/file-tree-subsystem.js` (nouveau)
- `src/components/file-tree.js`

## Vérifications

- [x] Build OK
- [x] Tests OK

---

📂 Path local : `/Users/rekta/projet/coding/refactor-pikagent`
🤖 PR créée automatiquement par l'Agent Refactor