### PR TITLE
refactor: introduce service layer to abstract window.api calls

### DIFF
--- a/src/components/board-view.js
+++ b/src/components/board-view.js
@@ -11,6 +11,9 @@ import {
   resolveCardStatus, findTabForTerminal, getTabNameForTerminal, computeFocusIndex,
   formatCardLabel,
 } from '../utils/board-helpers.js';
+import * as ptyApi from '../services/terminal-api.js';
+import * as shellApi from '../services/shell-api.js';
+import * as fsApi from '../services/fs-api.js';
 
 export class BoardView extends ComponentBase {
   constructor(container, tabManager) {
@@ -40,7 +43,7 @@ export class BoardView extends ComponentBase {
     if (this.disposed) return;
 
     try {
-      const agents = await window.api.pty.checkAgents();
+      const agents = await ptyApi.checkAgents();
 
       for (const [termId] of this.cards) {
         if (!agents[termId]) this.removeCard(termId);
@@ -140,12 +143,12 @@ export class BoardView extends ComponentBase {
     const { term, fitAddon } = createTerminal(termContainer, BOARD_TERMINAL_OPTS);
 
     setupTerminalAddons(term, {
-      openExternal: (url) => window.api.shell.openExternal(url),
+      openExternal: (url) => shellApi.openExternal(url),
       getCwd: () => null,
-      homedir: window.api.fs.homedir,
-      openPath: window.api.shell.openPath,
+      homedir: fsApi.homedir,
+      openPath: shellApi.openPath,
     });
-    term.onData((data) => window.api.pty.write(termId, data));
+    term.onData((data) => ptyApi.write(termId, data));
 
     return { term, fitAddon };
   }
@@ -162,7 +165,7 @@ export class BoardView extends ComponentBase {
 
     const cardData = { element: card, term, fitAddon, unsubData: null, resizeObs: null, info, status: 'running', dataBytes: DATA_VOLUME_THRESHOLD };
 
-    cardData.unsubData = window.api.pty.onData(termId, (data) => {
+    cardData.unsubData = ptyApi.onData(termId, (data) => {
       term.write(data);
       cardData.dataBytes += data.length;
     });

--- a/src/components/config-manager.js
+++ b/src/components/config-manager.js
@@ -8,6 +8,7 @@ import {
   suggestedDuplicateName,
 } from '../utils/config-manager-helpers.js';
 import { registerComponent } from '../utils/component-registry.js';
+import * as configApi from '../services/config-api.js';
 
 export class ConfigManager {
   constructor(tabManager) {
@@ -38,8 +39,8 @@ export class ConfigManager {
     try {
       const data = this.tabManager.serialize();
       const name = this.currentConfigName || DEFAULT_CONFIG_NAME;
-      await window.api.config.save(name, data);
-      await window.api.config.setDefault(name);
+      await configApi.save(name, data);
+      await configApi.setDefault(name);
       this.currentConfigName = name;
       this.updateConfigBar();
     } catch (e) {
@@ -56,7 +57,7 @@ export class ConfigManager {
     this.tabManager._disposeSideView('board');
     this.tabManager._disposeAllTabs();
     this.tabManager.createTab();
-    await window.api.config.setDefault(name);
+    await configApi.setDefault(name);
     await this.autoSave();
     this.updateConfigBar();
   }
@@ -64,19 +65,19 @@ export class ConfigManager {
   async duplicateConfig(newName) {
     if (!newName) return;
     const data = this.tabManager.serialize();
-    await window.api.config.save(newName, data);
+    await configApi.save(newName, data);
     this.currentConfigName = newName;
-    await window.api.config.setDefault(newName);
+    await configApi.setDefault(newName);
     this.updateConfigBar();
   }
 
   async switchConfig(name) {
     if (name === this.currentConfigName) return;
     await this.autoSave();
-    const config = await window.api.config.load(name);
+    const config = await configApi.load(name);
     if (config && config.tabs && config.tabs.length > 0) {
       this.currentConfigName = name;
-      await window.api.config.setDefault(name);
+      await configApi.setDefault(name);
       await this.tabManager.restoreConfig(config);
       this.updateConfigBar();
     }
@@ -92,7 +93,7 @@ export class ConfigManager {
   }
 
   async showConfigMenu(anchorEl) {
-    const configs = await window.api.config.list();
+    const configs = await configApi.list();
     const rect = anchorEl.getBoundingClientRect();
 
     const items = configs.map((config) => ({

--- a/src/components/file-tree.js
+++ b/src/components/file-tree.js
@@ -14,6 +14,9 @@ import {
   promptNewEntry as doPromptNewEntry,
   listenForChanges, startWatch, stopWatch,
 } from '../utils/file-tree-subsystem.js';
+import * as fsApi from '../services/fs-api.js';
+import * as shellApi from '../services/shell-api.js';
+import * as clipboardApi from '../services/clipboard-api.js';
 
 export class FileTree extends ComponentBase {
   constructor(container) {
@@ -25,16 +28,16 @@ export class FileTree extends ComponentBase {
 
     // Injected API methods for file-tree-drop and file-tree-context-menu utils
     this._contextMenuApi = {
-      clipboardWrite: window.api.clipboard.write,
-      fsCopy: window.api.fs.copy,
-      showInFolder: window.api.shell.showInFolder,
-      fsTrash: window.api.fs.trash,
+      clipboardWrite: clipboardApi.write,
+      fsCopy: fsApi.copy,
+      showInFolder: shellApi.showInFolder,
+      fsTrash: fsApi.trash,
     };
     this._dropApi = {
-      copyTo: window.api.fs.copyTo,
-      rename: window.api.fs.rename,
-      mkdir: window.api.fs.mkdir,
-      writefile: window.api.fs.writefile,
+      copyTo: fsApi.copyTo,
+      rename: fsApi.rename,
+      mkdir: fsApi.mkdir,
+      writefile: fsApi.writefile,
     };
 
     this.render();
@@ -53,7 +56,7 @@ export class FileTree extends ComponentBase {
   }
 
   listenForChanges() {
-    this._track(listenForChanges(this.debounceTimers, (id) => this.refreshSection(id), { onChanged: window.api.fs.onChanged }));
+    this._track(listenForChanges(this.debounceTimers, (id) => this.refreshSection(id), { onChanged: fsApi.onChanged }));
   }
 
   async setTerminalRoot(termId, dirPath) {
@@ -74,7 +77,7 @@ export class FileTree extends ComponentBase {
 
     const sectionEl = _el('div', { className: 'file-tree-section' });
     const expandedDirs = new Set([dirPath]);
-    const watchId = startWatch(dirPath, { watch: window.api.fs.watch });
+    const watchId = startWatch(dirPath, { watch: fsApi.watch });
     this.sections.set(dirPath, { termIds: new Set([termId]), sectionEl, expandedDirs, watchId });
     this.treeEl.appendChild(sectionEl);
     await this.refreshSection(dirPath);
@@ -94,7 +97,7 @@ export class FileTree extends ComponentBase {
     section.termIds.delete(termId);
 
     if (section.termIds.size === 0) {
-      stopWatch(section.watchId, { unwatch: window.api.fs.unwatch });
+      stopWatch(section.watchId, { unwatch: fsApi.unwatch });
       section.sectionEl.remove();
       this.sections.delete(cwd);
     }
@@ -257,7 +260,7 @@ export class FileTree extends ComponentBase {
   }
 
   async renderDir(dirPath, parentEl, depth, expandedDirs) {
-    const entries = await window.api.fs.readdir(dirPath);
+    const entries = await fsApi.readdir(dirPath);
     for (const entry of entries) {
       if (entry.isDirectory) {
         await this._renderDirEntry(entry, parentEl, depth, expandedDirs);
@@ -269,9 +272,9 @@ export class FileTree extends ComponentBase {
 
   dispose() {
     super.dispose();
-    const fsApi = { unwatch: window.api.fs.unwatch };
+    const unwatchApi = { unwatch: fsApi.unwatch };
     for (const [, section] of this.sections) {
-      stopWatch(section.watchId, fsApi);
+      stopWatch(section.watchId, unwatchApi);
     }
     this.sections.clear();
     this.termCwds.clear();

--- a/src/components/file-viewer.js
+++ b/src/components/file-viewer.js
@@ -15,6 +15,7 @@ import {
 } from '../utils/file-viewer-files.js';
 import { registerComponent } from '../utils/component-registry.js';
 import { ComponentBase } from '../utils/component-base.js';
+import * as fsApi from '../services/fs-api.js';
 
 export class FileViewer extends ComponentBase {
   /**
@@ -124,7 +125,7 @@ export class FileViewer extends ComponentBase {
   // ===== Files Mode =====
 
   async openFile(filePath, fileName) {
-    await openFileEntry(this.openFiles, filePath, fileName, { readfile: window.api.fs.readfile });
+    await openFileEntry(this.openFiles, filePath, fileName, { readfile: fsApi.readfile });
     this.setActiveTab(filePath);
   }
 
@@ -227,7 +228,7 @@ export class FileViewer extends ComponentBase {
         this.renderTabs();
         this.updateStatusBar();
       },
-    }, { writefile: window.api.fs.writefile });
+    }, { writefile: fsApi.writefile });
   }
 
   closeFile(filePath) {

--- a/src/components/flow-card-terminal.js
+++ b/src/components/flow-card-terminal.js
@@ -12,6 +12,8 @@ import {
   formatRunDateTime,
 } from '../utils/flow-view-helpers.js';
 import { registerComponent } from '../utils/component-registry.js';
+import * as ptyApi from '../services/terminal-api.js';
+import * as flowApi from '../services/flow-api.js';
 
 export class FlowCardTerminalManager {
   constructor() {
@@ -68,7 +70,7 @@ export class FlowCardTerminalManager {
       this._liveTerminals, flowId, containerEl,
       { scrollback: LIVE_SCROLLBACK, cursorStyle: 'bar' },
       (rec) => {
-        const unsubData = window.api.pty.onData(ptyId, (data) => { rec.term.write(data); });
+        const unsubData = ptyApi.onData(ptyId, (data) => { rec.term.write(data); });
         rec.unsubData = unsubData;
         rec.ptyId = ptyId;
       },
@@ -85,7 +87,7 @@ export class FlowCardTerminalManager {
 
   async loadLogIntoContainer(flowId, run, containerEl) {
     const log = run.logTimestamp
-      ? await window.api.flow.getRunLog(flowId, run.logTimestamp)
+      ? await flowApi.getRunLog(flowId, run.logTimestamp)
       : null;
 
     const { term } = this._createAndRegister(
@@ -111,7 +113,7 @@ export class FlowCardTerminalManager {
   }
 
   async showRunLog(flow, run) {
-    const log = await window.api.flow.getRunLog(flow.id, run.logTimestamp);
+    const log = await flowApi.getRunLog(flow.id, run.logTimestamp);
 
     const close = () => { resizeObs.disconnect(); term.dispose(); overlay.remove(); };
     const { overlay, modal } = createModalOverlay('flow-modal-overlay', 'flow-log-modal', close);

--- a/src/components/flow-modal.js
+++ b/src/components/flow-modal.js
@@ -11,6 +11,7 @@ import {
 } from '../utils/flow-modal-helpers.js';
 import { registerComponent } from '../utils/component-registry.js';
 import { createAsyncHandler } from '../utils/event-helpers.js';
+import * as dialogApi from '../services/dialog-api.js';
 
 // --- Section builders ---
 
@@ -62,7 +63,7 @@ function _buildCwdPicker(state) {
     onClick: createAsyncHandler(
       { stopProp: false },
       async () => {
-        const folder = await window.api.dialog.openFolder();
+        const folder = await dialogApi.openFolder();
         if (folder) {
           state.selectedCwd = folder;
           cwdLabel.textContent = folder.split('/').pop();

--- a/src/components/flow-view.js
+++ b/src/components/flow-view.js
@@ -11,6 +11,7 @@ import {
 } from '../utils/flow-view-helpers.js';
 import { createCategoryGroup } from '../utils/flow-category-renderer.js';
 import { createFlowCard } from '../utils/flow-card-setup.js';
+import * as flowApi from '../services/flow-api.js';
 
 
 export class FlowView extends ComponentBase {
@@ -28,13 +29,13 @@ export class FlowView extends ComponentBase {
     // Drag state (shared mutable object for use with setupCardDrag)
     this._drag = { flowId: null, catId: null };
 
-    this._track(window.api.flow.onRunStarted(({ flowId, ptyId }) => {
+    this._track(flowApi.onRunStarted(({ flowId, ptyId }) => {
       this._runningMap[flowId] = ptyId;
       this._expandedCards.add(flowId);
       this.refresh();
     }));
 
-    this._track(window.api.flow.onRunComplete(({ flowId }) => {
+    this._track(flowApi.onRunComplete(({ flowId }) => {
       this._termManager.disposeLiveTerminal(flowId);
       delete this._runningMap[flowId];
       this.refresh();
@@ -45,7 +46,7 @@ export class FlowView extends ComponentBase {
   }
 
   async _initRunning() {
-    this._runningMap = await window.api.flow.getRunning();
+    this._runningMap = await flowApi.getRunning();
     for (const flowId of Object.keys(this._runningMap)) {
       this._expandedCards.add(flowId);
     }
@@ -54,13 +55,13 @@ export class FlowView extends ComponentBase {
 
   async refresh() {
     if (this.disposed) return;
-    this.flows = await window.api.flow.list();
-    this.catData = await window.api.flow.getCategories();
+    this.flows = await flowApi.list();
+    this.catData = await flowApi.getCategories();
     this._renderList();
   }
 
   async _persistCategories() {
-    await window.api.flow.saveCategories(this.catData);
+    await flowApi.saveCategories(this.catData);
   }
 
   // --- Category helpers ---
@@ -180,8 +181,8 @@ export class FlowView extends ComponentBase {
       termManager: this._termManager,
       onRenderList: () => this._renderList(),
       onShowLog: (f, run) => this._termManager.showRunLog(f, run),
-      onRun: (flowId) => window.api.flow.runNow(flowId),
-      onToggle: (flowId) => window.api.flow.toggle(flowId),
+      onRun: (flowId) => flowApi.runNow(flowId),
+      onToggle: (flowId) => flowApi.toggle(flowId),
       onRefresh: () => this.refresh(),
       onOpenModal: (f) => this._openModal(f),
       onDeleteFlow: (id) => this._deleteFlow(id),
@@ -193,7 +194,7 @@ export class FlowView extends ComponentBase {
     this._termManager.disposeLiveTerminal(flowId);
     removeFlowFromOrder(this.catData.order, flowId);
     await this._persistCategories();
-    await window.api.flow.delete(flowId);
+    await flowApi.deleteFlow(flowId);
     this.refresh();
   }
 
@@ -247,7 +248,7 @@ export class FlowView extends ComponentBase {
       const catId = flow._category;
       delete flow._category;
 
-      await window.api.flow.save(flow);
+      await flowApi.save(flow);
 
       if (catId) {
         this._moveFlowToCategory(flow.id, catId);

--- a/src/components/git-changes-view.js
+++ b/src/components/git-changes-view.js
@@ -4,6 +4,7 @@ import { onClickStopped } from '../utils/event-helpers.js';
 import { STATUS_LABELS, CHEVRON, CHANGE_SECTIONS, computeTotalChanges, buildFileKey } from '../utils/git-changes-helpers.js';
 import { registerComponent, getComponent } from '../utils/component-registry.js';
 import { ComponentBase } from '../utils/component-base.js';
+import * as gitApi from '../services/git-api.js';
 
 export class GitChangesView extends ComponentBase {
   constructor(container) {
@@ -42,7 +43,7 @@ export class GitChangesView extends ComponentBase {
 
     this._renderMessage(this.container, 'git-loading', 'Loading changes...');
 
-    const changes = await window.api.git.localChanges(this.gitCwd);
+    const changes = await gitApi.localChanges(this.gitCwd);
     this._renderChanges(changes);
   }
 
@@ -115,7 +116,7 @@ export class GitChangesView extends ComponentBase {
   }
 
   async _loadFileDiff(filePath, isStaged, container) {
-    const diff = await window.api.git.fileDiff(this.gitCwd, filePath, isStaged);
+    const diff = await gitApi.fileDiff(this.gitCwd, filePath, isStaged);
 
     if (!diff) {
       this._setContent(container, _el('div', { className: 'git-empty', textContent: 'No diff available', style: { height: 'auto', padding: '8px' } }));

--- a/src/components/settings-configs.js
+++ b/src/components/settings-configs.js
@@ -7,15 +7,16 @@ import { CONFIG_ACTIONS, BOTTOM_CONFIG_BUTTONS, formatConfigMeta } from '../util
 import { buildSettingsSection, createActionBar } from '../utils/settings-section-builder.js';
 import { registerComponent } from '../utils/component-registry.js';
 import { createAsyncHandler } from '../utils/event-helpers.js';
+import * as configApi from '../services/config-api.js';
 
 function _createConfigActions(config, tabManager, renderConfigsFn) {
   return createActionBar({
     containerClass: 'config-actions',
     actions: CONFIG_ACTIONS,
     handlerDefs: {
-      setDefault: { apiCall: () => window.api.config.setDefault(config.name) },
-      overwrite: { apiCall: () => window.api.config.save(config.name, tabManager.serialize()), guard: () => !!tabManager },
-      delete: { apiCall: () => window.api.config.delete(config.name) },
+      setDefault: { apiCall: () => configApi.setDefault(config.name) },
+      overwrite: { apiCall: () => configApi.save(config.name, tabManager.serialize()), guard: () => !!tabManager },
+      delete: { apiCall: () => configApi.deleteConfig(config.name) },
     },
     onSuccess: renderConfigsFn,
     filter: (desc) => !(desc.hideWhen && config[desc.hideWhen]),
@@ -93,7 +94,7 @@ export async function renderConfigs(contentEl, tabManager, renderConfigsFn) {
   currentBar.appendChild(_el('span', 'config-current-value', currentName));
 
   // Config list
-  const configs = await window.api.config.list();
+  const configs = await configApi.list();
 
   buildSettingsSection(contentEl, {
     heading: 'Workspace Configs',

--- a/src/components/settings-update.js
+++ b/src/components/settings-update.js
@@ -5,6 +5,7 @@
 import { _el } from '../utils/settings-dom.js';
 import { createSettingsSection } from '../utils/settings-section-builder.js';
 import { registerComponent } from '../utils/component-registry.js';
+import * as updateApi from '../services/update-api.js';
 
 function _showCheckButton(area, onCheck) {
   area.replaceChildren();
@@ -73,7 +74,7 @@ function handleProgress(area) {
   progress.appendChild(label);
   area.appendChild(progress);
 
-  const unsub = window.api.update.onProgress((p) => {
+  const unsub = updateApi.onProgress((p) => {
     barFill.style.width = `${(p.step / p.total) * 100}%`;
     label.textContent = p.label;
   });
@@ -88,12 +89,12 @@ async function handleDownload(area, runCheck) {
   const { unsub } = handleProgress(area);
 
   try {
-    await window.api.update.run();
+    await updateApi.run();
     unsub?.();
     area.replaceChildren();
     area.appendChild(_el('div', 'update-message update-ok', '\u2713 Update installed successfully!'));
     const btn = _el('button', 'update-btn update-btn-primary', 'Restart now');
-    btn.addEventListener('click', () => window.api.update.relaunch());
+    btn.addEventListener('click', () => updateApi.relaunch());
     area.appendChild(btn);
   } catch (err) {
     unsub?.();
@@ -111,7 +112,7 @@ async function runCheck(area, btn) {
   btn.disabled = true;
   btn.classList.add('disabled');
   try {
-    const result = await window.api.update.check();
+    const result = await updateApi.check();
     if (result.error) _showMessage(area, 'error', result.error, (b) => runCheck(area, b));
     else if (!result.available) _showMessage(area, 'ok', 'Your application is up to date', (b) => runCheck(area, b));
     else _showAvailable(area, result, () => handleDownload(area, (b) => runCheck(area, b)));
@@ -126,7 +127,7 @@ async function runCheck(area, btn) {
  */
 export async function renderUpdate(contentEl) {
   createSettingsSection(contentEl, { heading: 'Update' });
-  const version = await window.api.update.version();
+  const version = await updateApi.version();
   const { area } = renderUpdateUI(contentEl, version);
   _showCheckButton(area, (btn) => runCheck(area, btn));
 }

--- a/src/components/skills-view.js
+++ b/src/components/skills-view.js
@@ -2,6 +2,9 @@ import { _el, renderList } from '../utils/workspace-dom.js';
 import { showPromptDialog, showConfirmDialog } from '../utils/dom-dialogs.js';
 import { registerComponent } from '../utils/component-registry.js';
 import { ComponentBase } from '../utils/component-base.js';
+import * as skillsApi from '../services/skills-api.js';
+import * as shellApi from '../services/shell-api.js';
+import * as dialogApi from '../services/dialog-api.js';
 
 export class SkillsView extends ComponentBase {
   constructor(container) {
@@ -19,8 +22,8 @@ export class SkillsView extends ComponentBase {
 
   async refresh() {
     if (this.disposed) return;
-    this.skills = await window.api.skills.list();
-    if (!this.rootPath) this.rootPath = await window.api.skills.getRoot();
+    this.skills = await skillsApi.list();
+    if (!this.rootPath) this.rootPath = await skillsApi.getRoot();
     if (this.selectedId && !this.skills.find((s) => s.id === this.selectedId)) {
       this.selectedId = null;
     }
@@ -87,13 +90,13 @@ export class SkillsView extends ComponentBase {
 
   async _openRoot() {
     if (!this.rootPath) return;
-    await window.api.shell.openPath(this.rootPath);
+    await shellApi.openPath(this.rootPath);
   }
 
   async _configurePath() {
-    const picked = await window.api.dialog.openFolder();
+    const picked = await dialogApi.openFolder();
     if (!picked) return;
-    const res = await window.api.skills.setRoot(picked);
+    const res = await skillsApi.setRoot(picked);
     if (res && res.success) {
       this.rootPath = res.root;
       this.selectedId = null;
@@ -103,9 +106,9 @@ export class SkillsView extends ComponentBase {
   }
 
   async _importSkill() {
-    const picked = await window.api.dialog.openFolder();
+    const picked = await dialogApi.openFolder();
     if (!picked) return;
-    const res = await window.api.skills.import(picked);
+    const res = await skillsApi.importSkill(picked);
     if (res && res.success) {
       this.selectedId = res.id;
       await this.refresh();
@@ -131,7 +134,7 @@ export class SkillsView extends ComponentBase {
       confirmLabel: 'Créer',
       cancelLabel: 'Annuler',
     });
-    const res = await window.api.skills.create({ id, description: description || '' });
+    const res = await skillsApi.create({ id, description: description || '' });
     if (res && res.success) {
       this.selectedId = res.id;
       await this.refresh();
@@ -144,7 +147,7 @@ export class SkillsView extends ComponentBase {
       { confirmLabel: 'Supprimer', cancelLabel: 'Annuler' },
     );
     if (!ok) return;
-    await window.api.skills.delete(id);
+    await skillsApi.deleteSkill(id);
     if (this.selectedId === id) this.selectedId = null;
     await this.refresh();
   }
@@ -167,7 +170,7 @@ export class SkillsView extends ComponentBase {
       _el('button', {
         className: 'skills-item-delete',
         title: 'Supprimer',
-        textContent: '✕',
+        textContent: '\u2715',
         onClick: (e) => { e.stopPropagation(); this._deleteSkill(skill.id); },
       }),
     ));
@@ -206,7 +209,7 @@ export class SkillsView extends ComponentBase {
     const skill = this.skills.find((s) => s.id === this.selectedId);
     if (!skill) return;
 
-    const content = await window.api.skills.read(skill.path);
+    const content = await skillsApi.read(skill.path);
     this.editorValue = content ?? '';
     this.editorDirty = false;
 
@@ -263,7 +266,7 @@ export class SkillsView extends ComponentBase {
   async _save() {
     const skill = this.skills.find((s) => s.id === this.selectedId);
     if (!skill) return;
-    const res = await window.api.skills.write(skill.path, this.editorValue);
+    const res = await skillsApi.write(skill.path, this.editorValue);
     if (res && res.success) {
       this.editorDirty = false;
       this._updateDirtyBadge();

--- a/src/components/tab-manager.js
+++ b/src/components/tab-manager.js
@@ -30,6 +30,9 @@ import {
   toggleNoShortcut as doToggleNoShortcut,
   buildPrApi, buildWorktreeApi, buildViewStore,
 } from '../utils/tab-facade.js';
+import * as gitApi from '../services/git-api.js';
+import * as fsApi from '../services/fs-api.js';
+import * as configApi from '../services/config-api.js';
 
 export class TabManager {
   constructor(tabBar, workspaceContainer) {
@@ -54,13 +57,13 @@ export class TabManager {
     this.excludedColors = new Set(); // COLOR_GROUPS ids to hide
 
     // Injected API methods for workspace-layout utils
-    this._api = { gitBranch: window.api.git.branch };
+    this._api = { gitBranch: gitApi.branch };
 
     this.init();
   }
 
-  _prApi() { return buildPrApi(window.api); }
-  _worktreeApi() { return buildWorktreeApi(window.api); }
+  _prApi() { return buildPrApi(); }
+  _worktreeApi() { return buildWorktreeApi(); }
   _viewStore() { return buildViewStore(this); }
 
   async init() {
@@ -70,7 +73,7 @@ export class TabManager {
       restoreConfig: (config) => this.restoreConfig(config),
       createTab: (name) => this.createTab(name),
       setDefaultCwd: (cwd) => { this.defaultCwd = cwd; },
-      api: { homedir: window.api.fs.homedir, getDefault: window.api.config.getDefault, loadDefault: window.api.config.loadDefault },
+      api: { homedir: fsApi.homedir, getDefault: configApi.getDefault, loadDefault: configApi.loadDefault },
     });
 
     this._busListeners = setupBusListeners({
@@ -80,7 +83,7 @@ export class TabManager {
       createTab: (name, cwd) => this.createTab(name, cwd),
       renderTabBar: () => this.renderTabBar(),
       api: {
-        gitBranch: window.api.git.branch,
+        gitBranch: gitApi.branch,
         worktree: this._worktreeApi(),
         pr: this._prApi(),
       },

--- a/src/components/terminal-panel.js
+++ b/src/components/terminal-panel.js
@@ -15,6 +15,9 @@ import {
   splitTerminal,
   focusDirection as focusDirectionHelper,
 } from '../utils/terminal-subsystem.js';
+import * as shellApi from '../services/shell-api.js';
+import * as fsApi from '../services/fs-api.js';
+import * as ptyApi from '../services/terminal-api.js';
 
 export class TerminalPanel {
   constructor(container, cwd) {
@@ -26,16 +29,16 @@ export class TerminalPanel {
 
     // Injected API methods forwarded to TerminalInstance
     this._terminalApi = {
-      openExternal: window.api.shell.openExternal,
-      homedir: window.api.fs.homedir,
-      openPath: window.api.shell.openPath,
-      ptyWrite: window.api.pty.write,
-      ptyOnData: window.api.pty.onData,
-      ptyOnExit: window.api.pty.onExit,
-      ptyCreate: window.api.pty.create,
-      ptyGetCwd: window.api.pty.getCwd,
-      ptyResize: window.api.pty.resize,
-      ptyKill: window.api.pty.kill,
+      openExternal: shellApi.openExternal,
+      homedir: fsApi.homedir,
+      openPath: shellApi.openPath,
+      ptyWrite: ptyApi.write,
+      ptyOnData: ptyApi.onData,
+      ptyOnExit: ptyApi.onExit,
+      ptyCreate: ptyApi.create,
+      ptyGetCwd: ptyApi.getCwd,
+      ptyResize: ptyApi.resize,
+      ptyKill: ptyApi.kill,
     };
 
     // Drag and drop state

--- a/src/components/usage-view.js
+++ b/src/components/usage-view.js
@@ -2,6 +2,7 @@ import { _el } from '../utils/workspace-dom.js';
 import { TABS, getTabConfig, createSection } from '../utils/usage-view-helpers.js';
 import { registerComponent } from '../utils/component-registry.js';
 import { ComponentBase } from '../utils/component-base.js';
+import * as usageApi from '../services/usage-api.js';
 
 // --- Component ---
 
@@ -49,7 +50,7 @@ export class UsageView extends ComponentBase {
     this._renderEmpty('Chargement des métriques...');
 
     try {
-      this.metrics = await window.api.usage.getMetrics();
+      this.metrics = await usageApi.getMetrics();
     } catch {
       this._renderEmpty('Erreur lors du chargement');
       return;

--- a/src/components/webview-panel.js
+++ b/src/components/webview-panel.js
@@ -14,6 +14,7 @@ import {
   shortLevelLabel,
 } from '../utils/webview-helpers.js';
 import { registerComponent } from '../utils/component-registry.js';
+import * as shellApi from '../services/shell-api.js';
 
 export class WebviewInstance {
   constructor(container, url) {
@@ -57,7 +58,7 @@ export class WebviewInstance {
     this._mobileBtn.addEventListener('click', () => this.toggleMobile());
 
     const openExtBtn = _el('button', 'webview-nav-btn', { textContent: '\u2197', title: 'Open in browser' });
-    openExtBtn.addEventListener('click', () => window.api.shell.openExternal(this.url));
+    openExtBtn.addEventListener('click', () => shellApi.openExternal(this.url));
 
     this.consoleToggle = _el('button', 'webview-nav-btn', { textContent: CONSOLE_ICONS.closed, title: 'Toggle console' });
     this.consoleToggle.addEventListener('click', () => this.toggleConsole());

--- a/src/services/clipboard-api.js
+++ b/src/services/clipboard-api.js
@@ -1,0 +1,6 @@
+/**
+ * Service layer for window.api.clipboard — clipboard operations.
+ * Components should import from here instead of calling window.api.clipboard directly.
+ */
+
+export const write = (...args) => window.api.clipboard.write(...args);

--- a/src/services/config-api.js
+++ b/src/services/config-api.js
@@ -1,0 +1,12 @@
+/**
+ * Service layer for window.api.config — workspace config operations.
+ * Components should import from here instead of calling window.api.config directly.
+ */
+
+export const save        = (...args) => window.api.config.save(...args);
+export const load        = (...args) => window.api.config.load(...args);
+export const list        = (...args) => window.api.config.list(...args);
+export const deleteConfig = (...args) => window.api.config.delete(...args);
+export const setDefault  = (...args) => window.api.config.setDefault(...args);
+export const getDefault  = (...args) => window.api.config.getDefault(...args);
+export const loadDefault = (...args) => window.api.config.loadDefault(...args);

--- a/src/services/dialog-api.js
+++ b/src/services/dialog-api.js
@@ -1,0 +1,6 @@
+/**
+ * Service layer for window.api.dialog — native dialog operations.
+ * Components should import from here instead of calling window.api.dialog directly.
+ */
+
+export const openFolder = (...args) => window.api.dialog.openFolder(...args);

--- a/src/services/flow-api.js
+++ b/src/services/flow-api.js
@@ -1,0 +1,16 @@
+/**
+ * Service layer for window.api.flow — flow/automation operations.
+ * Components should import from here instead of calling window.api.flow directly.
+ */
+
+export const list           = (...args) => window.api.flow.list(...args);
+export const save           = (...args) => window.api.flow.save(...args);
+export const deleteFlow     = (...args) => window.api.flow.delete(...args);
+export const toggle         = (...args) => window.api.flow.toggle(...args);
+export const runNow         = (...args) => window.api.flow.runNow(...args);
+export const getRunning     = (...args) => window.api.flow.getRunning(...args);
+export const getCategories  = (...args) => window.api.flow.getCategories(...args);
+export const saveCategories = (...args) => window.api.flow.saveCategories(...args);
+export const getRunLog      = (...args) => window.api.flow.getRunLog(...args);
+export const onRunStarted   = (...args) => window.api.flow.onRunStarted(...args);
+export const onRunComplete  = (...args) => window.api.flow.onRunComplete(...args);

--- a/src/services/fs-api.js
+++ b/src/services/fs-api.js
@@ -1,0 +1,17 @@
+/**
+ * Service layer for window.api.fs — file-system operations.
+ * Components should import from here instead of calling window.api.fs directly.
+ */
+
+export const readdir    = (...args) => window.api.fs.readdir(...args);
+export const readfile   = (...args) => window.api.fs.readfile(...args);
+export const writefile  = (...args) => window.api.fs.writefile(...args);
+export const copy       = (...args) => window.api.fs.copy(...args);
+export const copyTo     = (...args) => window.api.fs.copyTo(...args);
+export const rename     = (...args) => window.api.fs.rename(...args);
+export const mkdir      = (...args) => window.api.fs.mkdir(...args);
+export const trash      = (...args) => window.api.fs.trash(...args);
+export const watch      = (...args) => window.api.fs.watch(...args);
+export const unwatch    = (...args) => window.api.fs.unwatch(...args);
+export const onChanged  = (...args) => window.api.fs.onChanged(...args);
+export const homedir    = (...args) => window.api.fs.homedir(...args);

--- a/src/services/git-api.js
+++ b/src/services/git-api.js
@@ -1,0 +1,17 @@
+/**
+ * Service layer for window.api.git — git operations.
+ * Components should import from here instead of calling window.api.git directly.
+ */
+
+export const branch         = (...args) => window.api.git.branch(...args);
+export const localChanges   = (...args) => window.api.git.localChanges(...args);
+export const fileDiff       = (...args) => window.api.git.fileDiff(...args);
+export const remoteUrl      = (...args) => window.api.git.remoteUrl(...args);
+export const pushBranch     = (...args) => window.api.git.pushBranch(...args);
+export const ghAvailable    = (...args) => window.api.git.ghAvailable(...args);
+export const ghPrCreate     = (...args) => window.api.git.ghPrCreate(...args);
+export const isRepo         = (...args) => window.api.git.isRepo(...args);
+export const listBranches   = (...args) => window.api.git.listBranches(...args);
+export const worktreeList   = (...args) => window.api.git.worktreeList(...args);
+export const worktreeAdd    = (...args) => window.api.git.worktreeAdd(...args);
+export const worktreeRemove = (...args) => window.api.git.worktreeRemove(...args);

--- a/src/services/shell-api.js
+++ b/src/services/shell-api.js
@@ -1,0 +1,8 @@
+/**
+ * Service layer for window.api.shell — shell/OS interaction operations.
+ * Components should import from here instead of calling window.api.shell directly.
+ */
+
+export const openExternal = (...args) => window.api.shell.openExternal(...args);
+export const openPath     = (...args) => window.api.shell.openPath(...args);
+export const showInFolder = (...args) => window.api.shell.showInFolder(...args);

--- a/src/services/skills-api.js
+++ b/src/services/skills-api.js
@@ -1,0 +1,13 @@
+/**
+ * Service layer for window.api.skills — skills management operations.
+ * Components should import from here instead of calling window.api.skills directly.
+ */
+
+export const list        = (...args) => window.api.skills.list(...args);
+export const getRoot     = (...args) => window.api.skills.getRoot(...args);
+export const setRoot     = (...args) => window.api.skills.setRoot(...args);
+export const importSkill = (...args) => window.api.skills.import(...args);
+export const create      = (...args) => window.api.skills.create(...args);
+export const deleteSkill = (...args) => window.api.skills.delete(...args);
+export const read        = (...args) => window.api.skills.read(...args);
+export const write       = (...args) => window.api.skills.write(...args);

--- a/src/services/terminal-api.js
+++ b/src/services/terminal-api.js
@@ -1,0 +1,13 @@
+/**
+ * Service layer for window.api.pty — pseudo-terminal operations.
+ * Components should import from here instead of calling window.api.pty directly.
+ */
+
+export const create      = (...args) => window.api.pty.create(...args);
+export const write       = (...args) => window.api.pty.write(...args);
+export const resize      = (...args) => window.api.pty.resize(...args);
+export const kill        = (...args) => window.api.pty.kill(...args);
+export const getCwd      = (...args) => window.api.pty.getCwd(...args);
+export const onData      = (...args) => window.api.pty.onData(...args);
+export const onExit      = (...args) => window.api.pty.onExit(...args);
+export const checkAgents = (...args) => window.api.pty.checkAgents(...args);

--- a/src/services/update-api.js
+++ b/src/services/update-api.js
@@ -1,0 +1,10 @@
+/**
+ * Service layer for window.api.update — application update operations.
+ * Components should import from here instead of calling window.api.update directly.
+ */
+
+export const check      = (...args) => window.api.update.check(...args);
+export const run        = (...args) => window.api.update.run(...args);
+export const relaunch   = (...args) => window.api.update.relaunch(...args);
+export const version    = (...args) => window.api.update.version(...args);
+export const onProgress = (...args) => window.api.update.onProgress(...args);

--- a/src/services/usage-api.js
+++ b/src/services/usage-api.js
@@ -1,0 +1,6 @@
+/**
+ * Service layer for window.api.usage — usage metrics operations.
+ * Components should import from here instead of calling window.api.usage directly.
+ */
+
+export const getMetrics = (...args) => window.api.usage.getMetrics(...args);

--- a/src/utils/tab-manager-api.js
+++ b/src/utils/tab-manager-api.js
@@ -5,9 +5,11 @@
  * helpers (worktree-flow, open-pr-flow, sidebar-manager) so that the
  * main TabManager class stays focused on orchestration.
  *
- * All functions receive their dependencies via parameters — no direct
- * window.api references.
+ * All API access is routed through the service layer in src/services/.
  */
+
+import * as gitApi from '../services/git-api.js';
+import * as shellApi from '../services/shell-api.js';
 
 /**
  * @typedef {{ branch: (cwd: string) => Promise<string|null>, remoteUrl: (cwd: string) => Promise<string|null>, pushBranch: (cwd: string, branch: string) => Promise<{ ok: boolean, error?: string }>, ghAvailable: () => Promise<boolean>, ghPrCreate: (cwd: string, baseBranch: string|null) => Promise<{ ok: boolean, url?: string, existed?: boolean, code?: string, error?: string }> }} GitApi
@@ -16,17 +18,16 @@
 
 /**
  * Adapter exposing the git + shell surface needed by the open-PR flow.
- * @param {{ git: GitApi, shell: ShellApi }} api — injected API surface
  * @returns {import('./open-pr-flow.js').OpenPrApi}
  */
-export function buildPrApi(api) {
+export function buildPrApi() {
   return {
-    branch:       (cwd) => api.git.branch(cwd),
-    remoteUrl:    (cwd) => api.git.remoteUrl(cwd),
-    pushBranch:   ({ cwd, branch }) => api.git.pushBranch(cwd, branch),
-    ghAvailable:  () => api.git.ghAvailable(),
-    ghPrCreate:   ({ cwd, baseBranch }) => api.git.ghPrCreate(cwd, baseBranch),
-    openExternal: (url) => api.shell.openExternal(url),
+    branch:       (cwd) => gitApi.branch(cwd),
+    remoteUrl:    (cwd) => gitApi.remoteUrl(cwd),
+    pushBranch:   ({ cwd, branch }) => gitApi.pushBranch(cwd, branch),
+    ghAvailable:  () => gitApi.ghAvailable(),
+    ghPrCreate:   ({ cwd, baseBranch }) => gitApi.ghPrCreate(cwd, baseBranch),
+    openExternal: (url) => shellApi.openExternal(url),
   };
 }
 
@@ -37,19 +38,18 @@ export function buildPrApi(api) {
 /**
  * Adapter exposing the git-worktree IPC surface as an object-style API,
  * matching {@link import('./worktree-flow.js').GitWorktreeApi}.
- * @param {{ git: GitWorktreeIpc }} api — injected API surface
  * @returns {import('./worktree-flow.js').GitWorktreeApi}
  */
-export function buildWorktreeApi(api) {
+export function buildWorktreeApi() {
   return {
-    isRepo:       (cwd) => api.git.isRepo(cwd),
-    branch:       (cwd) => api.git.branch(cwd),
-    listBranches: (cwd) => api.git.listBranches(cwd),
-    worktreeList: (cwd) => api.git.worktreeList(cwd),
+    isRepo:       (cwd) => gitApi.isRepo(cwd),
+    branch:       (cwd) => gitApi.branch(cwd),
+    listBranches: (cwd) => gitApi.listBranches(cwd),
+    worktreeList: (cwd) => gitApi.worktreeList(cwd),
     worktreeAdd:  ({ cwd, branch, targetPath, createBranch, baseBranch }) =>
-      api.git.worktreeAdd(cwd, branch, targetPath, createBranch, baseBranch),
+      gitApi.worktreeAdd(cwd, branch, targetPath, createBranch, baseBranch),
     worktreeRemove: ({ cwd, worktreePath, force }) =>
-      api.git.worktreeRemove(cwd, worktreePath, force),
+      gitApi.worktreeRemove(cwd, worktreePath, force),
   };
 }
 


### PR DESCRIPTION
## Refactoring

Introduce `src/services/` layer that centralizes `window.api` access by domain. Components now import from service modules instead of calling `window.api` directly, making dependencies explicit and enabling easier testing.

Closes #373

## Fichier(s) modifie(s)

### New service modules (11 files)
- `src/services/fs-api.js` — file-system operations
- `src/services/flow-api.js` — flow/automation operations
- `src/services/terminal-api.js` — pseudo-terminal operations
- `src/services/config-api.js` — workspace config operations
- `src/services/skills-api.js` — skills management
- `src/services/shell-api.js` — shell/OS interaction
- `src/services/clipboard-api.js` — clipboard operations
- `src/services/dialog-api.js` — native dialog operations
- `src/services/git-api.js` — git operations
- `src/services/update-api.js` — application update operations
- `src/services/usage-api.js` — usage metrics

### Updated components (15 files)
- `src/components/file-tree.js` (13 calls migrated)
- `src/components/skills-view.js` (11 calls migrated)
- `src/components/flow-view.js` (10 calls migrated)
- `src/components/terminal-panel.js` (10 calls migrated)
- `src/components/config-manager.js` (8 calls migrated)
- `src/components/board-view.js` (6 calls migrated)
- `src/components/settings-update.js` (5 calls migrated)
- `src/components/settings-configs.js` (4 calls migrated)
- `src/components/tab-manager.js` (3 calls migrated)
- `src/components/flow-card-terminal.js` (3 calls migrated)
- `src/components/git-changes-view.js` (2 calls migrated)
- `src/components/file-viewer.js` (2 calls migrated)
- `src/components/flow-modal.js` (1 call migrated)
- `src/components/webview-panel.js` (1 call migrated)
- `src/components/usage-view.js` (1 call migrated)

### Updated utility
- `src/utils/tab-manager-api.js` — refactored to import from services instead of receiving `window.api` as parameter

## Verifications

- [x] Build OK (`npm run build`)
- [x] Tests OK (25 test files, 386 tests passed)

---

PR creee automatiquement par l'Agent Refactor