### PR TITLE
refactor: remove per-method re-exports from service modules

### DIFF
--- a/src/components/board-view.js
+++ b/src/components/board-view.js
@@ -11,9 +11,9 @@ import {
   resolveCardStatus, findTabForTerminal, getTabNameForTerminal, computeFocusIndex,
   formatCardLabel,
 } from '../utils/board-helpers.js';
-import * as ptyApi from '../services/terminal-api.js';
-import * as shellApi from '../services/shell-api.js';
-import * as fsApi from '../services/fs-api.js';
+import ptyApi from '../services/terminal-api.js';
+import shellApi from '../services/shell-api.js';
+import fsApi from '../services/fs-api.js';
 
 export class BoardView extends ComponentBase {
   constructor(container, tabManager) {

--- a/src/components/config-manager.js
+++ b/src/components/config-manager.js
@@ -8,7 +8,7 @@ import {
   suggestedDuplicateName,
 } from '../utils/config-manager-helpers.js';
 import { registerComponent } from '../utils/component-registry.js';
-import * as configApi from '../services/config-api.js';
+import configApi from '../services/config-api.js';
 
 export class ConfigManager {
   constructor(tabManager) {

--- a/src/components/file-tree.js
+++ b/src/components/file-tree.js
@@ -14,9 +14,9 @@ import {
   promptNewEntry as doPromptNewEntry,
   listenForChanges, startWatch, stopWatch,
 } from '../utils/file-tree-subsystem.js';
-import * as fsApi from '../services/fs-api.js';
-import * as shellApi from '../services/shell-api.js';
-import * as clipboardApi from '../services/clipboard-api.js';
+import fsApi from '../services/fs-api.js';
+import shellApi from '../services/shell-api.js';
+import clipboardApi from '../services/clipboard-api.js';
 
 export class FileTree extends ComponentBase {
   constructor(container) {

--- a/src/components/file-viewer.js
+++ b/src/components/file-viewer.js
@@ -15,7 +15,7 @@ import {
 } from '../utils/file-viewer-files.js';
 import { registerComponent } from '../utils/component-registry.js';
 import { ComponentBase } from '../utils/component-base.js';
-import * as fsApi from '../services/fs-api.js';
+import fsApi from '../services/fs-api.js';
 
 export class FileViewer extends ComponentBase {
   /**

--- a/src/components/flow-card-terminal.js
+++ b/src/components/flow-card-terminal.js
@@ -12,8 +12,8 @@ import {
   formatRunDateTime,
 } from '../utils/flow-view-helpers.js';
 import { registerComponent } from '../utils/component-registry.js';
-import * as ptyApi from '../services/terminal-api.js';
-import * as flowApi from '../services/flow-api.js';
+import ptyApi from '../services/terminal-api.js';
+import flowApi from '../services/flow-api.js';
 
 export class FlowCardTerminalManager {
   constructor() {

--- a/src/components/flow-modal.js
+++ b/src/components/flow-modal.js
@@ -11,7 +11,7 @@ import {
 } from '../utils/flow-modal-helpers.js';
 import { registerComponent } from '../utils/component-registry.js';
 import { createAsyncHandler } from '../utils/event-helpers.js';
-import * as dialogApi from '../services/dialog-api.js';
+import dialogApi from '../services/dialog-api.js';
 
 // --- Section builders ---
 

--- a/src/components/flow-view.js
+++ b/src/components/flow-view.js
@@ -11,7 +11,7 @@ import {
 } from '../utils/flow-view-helpers.js';
 import { createCategoryGroup } from '../utils/flow-category-renderer.js';
 import { createFlowCard } from '../utils/flow-card-setup.js';
-import * as flowApi from '../services/flow-api.js';
+import flowApi from '../services/flow-api.js';
 
 
 export class FlowView extends ComponentBase {

--- a/src/components/git-changes-view.js
+++ b/src/components/git-changes-view.js
@@ -4,7 +4,7 @@ import { onClickStopped } from '../utils/event-helpers.js';
 import { STATUS_LABELS, CHEVRON, CHANGE_SECTIONS, computeTotalChanges, buildFileKey } from '../utils/git-changes-helpers.js';
 import { registerComponent, getComponent } from '../utils/component-registry.js';
 import { ComponentBase } from '../utils/component-base.js';
-import * as gitApi from '../services/git-api.js';
+import gitApi from '../services/git-api.js';
 
 export class GitChangesView extends ComponentBase {
   constructor(container) {

--- a/src/components/settings-configs.js
+++ b/src/components/settings-configs.js
@@ -7,7 +7,7 @@ import { CONFIG_ACTIONS, BOTTOM_CONFIG_BUTTONS, formatConfigMeta } from '../util
 import { buildSettingsSection, createActionBar } from '../utils/settings-section-builder.js';
 import { registerComponent } from '../utils/component-registry.js';
 import { createAsyncHandler } from '../utils/event-helpers.js';
-import * as configApi from '../services/config-api.js';
+import configApi from '../services/config-api.js';
 
 function _createConfigActions(config, tabManager, renderConfigsFn) {
   return createActionBar({

--- a/src/components/settings-update.js
+++ b/src/components/settings-update.js
@@ -5,7 +5,7 @@
 import { _el } from '../utils/settings-dom.js';
 import { createSettingsSection } from '../utils/settings-section-builder.js';
 import { registerComponent } from '../utils/component-registry.js';
-import * as updateApi from '../services/update-api.js';
+import updateApi from '../services/update-api.js';
 
 function _showCheckButton(area, onCheck) {
   area.replaceChildren();

--- a/src/components/skills-view.js
+++ b/src/components/skills-view.js
@@ -2,9 +2,9 @@ import { _el, renderList } from '../utils/workspace-dom.js';
 import { showPromptDialog, showConfirmDialog } from '../utils/dom-dialogs.js';
 import { registerComponent } from '../utils/component-registry.js';
 import { ComponentBase } from '../utils/component-base.js';
-import * as skillsApi from '../services/skills-api.js';
-import * as shellApi from '../services/shell-api.js';
-import * as dialogApi from '../services/dialog-api.js';
+import skillsApi from '../services/skills-api.js';
+import shellApi from '../services/shell-api.js';
+import dialogApi from '../services/dialog-api.js';
 
 export class SkillsView extends ComponentBase {
   constructor(container) {

--- a/src/components/tab-manager.js
+++ b/src/components/tab-manager.js
@@ -30,9 +30,9 @@ import {
   toggleNoShortcut as doToggleNoShortcut,
   buildPrApi, buildWorktreeApi, buildViewStore,
 } from '../utils/tab-facade.js';
-import * as gitApi from '../services/git-api.js';
-import * as fsApi from '../services/fs-api.js';
-import * as configApi from '../services/config-api.js';
+import gitApi from '../services/git-api.js';
+import fsApi from '../services/fs-api.js';
+import configApi from '../services/config-api.js';
 
 export class TabManager {
   constructor(tabBar, workspaceContainer) {

--- a/src/components/terminal-panel.js
+++ b/src/components/terminal-panel.js
@@ -15,9 +15,9 @@ import {
   splitTerminal,
   focusDirection as focusDirectionHelper,
 } from '../utils/terminal-subsystem.js';
-import * as shellApi from '../services/shell-api.js';
-import * as fsApi from '../services/fs-api.js';
-import * as ptyApi from '../services/terminal-api.js';
+import shellApi from '../services/shell-api.js';
+import fsApi from '../services/fs-api.js';
+import ptyApi from '../services/terminal-api.js';
 
 export class TerminalPanel {
   constructor(container, cwd) {

--- a/src/components/usage-view.js
+++ b/src/components/usage-view.js
@@ -2,7 +2,7 @@ import { _el } from '../utils/workspace-dom.js';
 import { TABS, getTabConfig, createSection } from '../utils/usage-view-helpers.js';
 import { registerComponent } from '../utils/component-registry.js';
 import { ComponentBase } from '../utils/component-base.js';
-import * as usageApi from '../services/usage-api.js';
+import usageApi from '../services/usage-api.js';
 
 // --- Component ---
 

--- a/src/components/webview-panel.js
+++ b/src/components/webview-panel.js
@@ -14,7 +14,7 @@ import {
   shortLevelLabel,
 } from '../utils/webview-helpers.js';
 import { registerComponent } from '../utils/component-registry.js';
-import * as shellApi from '../services/shell-api.js';
+import shellApi from '../services/shell-api.js';
 
 export class WebviewInstance {
   constructor(container, url) {

--- a/src/services/clipboard-api.js
+++ b/src/services/clipboard-api.js
@@ -3,6 +3,4 @@
  * Components should import from here instead of calling window.api.clipboard directly.
  */
 import { createApiService } from './create-api-service.js';
-const api = createApiService('clipboard');
-
-export const write = api.write;
+export default createApiService('clipboard');

--- a/src/services/config-api.js
+++ b/src/services/config-api.js
@@ -3,12 +3,4 @@
  * Components should import from here instead of calling window.api.config directly.
  */
 import { createApiService } from './create-api-service.js';
-const api = createApiService('config');
-
-export const save        = api.save;
-export const load        = api.load;
-export const list        = api.list;
-export const deleteConfig = api.delete;
-export const setDefault  = api.setDefault;
-export const getDefault  = api.getDefault;
-export const loadDefault = api.loadDefault;
+export default createApiService('config');

--- a/src/services/config-api.js
+++ b/src/services/config-api.js
@@ -3,4 +3,9 @@
  * Components should import from here instead of calling window.api.config directly.
  */
 import { createApiService } from './create-api-service.js';
-export default createApiService('config');
+const api = createApiService('config');
+
+// Alias: consumers use deleteConfig but the IPC method is delete
+api.deleteConfig = api.delete;
+
+export default api;

--- a/src/services/create-api-service.js
+++ b/src/services/create-api-service.js
@@ -5,6 +5,9 @@
  */
 export function createApiService(domain) {
   return new Proxy(/** @type {any} */ ({}), {
-    get: (_, method) => (...args) => window.api[domain][method](...args),
+    get: (target, method) =>
+      method in target
+        ? target[method]
+        : (...args) => window.api[domain][method](...args),
   });
 }

--- a/src/services/dialog-api.js
+++ b/src/services/dialog-api.js
@@ -3,6 +3,4 @@
  * Components should import from here instead of calling window.api.dialog directly.
  */
 import { createApiService } from './create-api-service.js';
-const api = createApiService('dialog');
-
-export const openFolder = api.openFolder;
+export default createApiService('dialog');

--- a/src/services/flow-api.js
+++ b/src/services/flow-api.js
@@ -3,4 +3,9 @@
  * Components should import from here instead of calling window.api.flow directly.
  */
 import { createApiService } from './create-api-service.js';
-export default createApiService('flow');
+const api = createApiService('flow');
+
+// Alias: consumers use deleteFlow but the IPC method is delete
+api.deleteFlow = api.delete;
+
+export default api;

--- a/src/services/flow-api.js
+++ b/src/services/flow-api.js
@@ -3,16 +3,4 @@
  * Components should import from here instead of calling window.api.flow directly.
  */
 import { createApiService } from './create-api-service.js';
-const api = createApiService('flow');
-
-export const list           = api.list;
-export const save           = api.save;
-export const deleteFlow     = api.delete;
-export const toggle         = api.toggle;
-export const runNow         = api.runNow;
-export const getRunning     = api.getRunning;
-export const getCategories  = api.getCategories;
-export const saveCategories = api.saveCategories;
-export const getRunLog      = api.getRunLog;
-export const onRunStarted   = api.onRunStarted;
-export const onRunComplete  = api.onRunComplete;
+export default createApiService('flow');

--- a/src/services/fs-api.js
+++ b/src/services/fs-api.js
@@ -3,17 +3,4 @@
  * Components should import from here instead of calling window.api.fs directly.
  */
 import { createApiService } from './create-api-service.js';
-const api = createApiService('fs');
-
-export const readdir   = api.readdir;
-export const readfile  = api.readfile;
-export const writefile = api.writefile;
-export const copy      = api.copy;
-export const copyTo    = api.copyTo;
-export const rename    = api.rename;
-export const mkdir     = api.mkdir;
-export const trash     = api.trash;
-export const watch     = api.watch;
-export const unwatch   = api.unwatch;
-export const onChanged = api.onChanged;
-export const homedir   = api.homedir;
+export default createApiService('fs');

--- a/src/services/git-api.js
+++ b/src/services/git-api.js
@@ -3,17 +3,4 @@
  * Components should import from here instead of calling window.api.git directly.
  */
 import { createApiService } from './create-api-service.js';
-const api = createApiService('git');
-
-export const branch         = api.branch;
-export const localChanges   = api.localChanges;
-export const fileDiff       = api.fileDiff;
-export const remoteUrl      = api.remoteUrl;
-export const pushBranch     = api.pushBranch;
-export const ghAvailable    = api.ghAvailable;
-export const ghPrCreate     = api.ghPrCreate;
-export const isRepo         = api.isRepo;
-export const listBranches   = api.listBranches;
-export const worktreeList   = api.worktreeList;
-export const worktreeAdd    = api.worktreeAdd;
-export const worktreeRemove = api.worktreeRemove;
+export default createApiService('git');

--- a/src/services/shell-api.js
+++ b/src/services/shell-api.js
@@ -3,8 +3,4 @@
  * Components should import from here instead of calling window.api.shell directly.
  */
 import { createApiService } from './create-api-service.js';
-const api = createApiService('shell');
-
-export const openExternal = api.openExternal;
-export const openPath     = api.openPath;
-export const showInFolder = api.showInFolder;
+export default createApiService('shell');

--- a/src/services/skills-api.js
+++ b/src/services/skills-api.js
@@ -3,4 +3,10 @@
  * Components should import from here instead of calling window.api.skills directly.
  */
 import { createApiService } from './create-api-service.js';
-export default createApiService('skills');
+const api = createApiService('skills');
+
+// Aliases: consumers use importSkill/deleteSkill but the IPC methods are import/delete
+api.importSkill = api.import;
+api.deleteSkill = api.delete;
+
+export default api;

--- a/src/services/skills-api.js
+++ b/src/services/skills-api.js
@@ -3,13 +3,4 @@
  * Components should import from here instead of calling window.api.skills directly.
  */
 import { createApiService } from './create-api-service.js';
-const api = createApiService('skills');
-
-export const list        = api.list;
-export const getRoot     = api.getRoot;
-export const setRoot     = api.setRoot;
-export const importSkill = api.import;
-export const create      = api.create;
-export const deleteSkill = api.delete;
-export const read        = api.read;
-export const write       = api.write;
+export default createApiService('skills');

--- a/src/services/terminal-api.js
+++ b/src/services/terminal-api.js
@@ -3,13 +3,4 @@
  * Components should import from here instead of calling window.api.pty directly.
  */
 import { createApiService } from './create-api-service.js';
-const api = createApiService('pty');
-
-export const create      = api.create;
-export const write       = api.write;
-export const resize      = api.resize;
-export const kill        = api.kill;
-export const getCwd      = api.getCwd;
-export const onData      = api.onData;
-export const onExit      = api.onExit;
-export const checkAgents = api.checkAgents;
+export default createApiService('pty');

--- a/src/services/update-api.js
+++ b/src/services/update-api.js
@@ -3,10 +3,4 @@
  * Components should import from here instead of calling window.api.update directly.
  */
 import { createApiService } from './create-api-service.js';
-const api = createApiService('update');
-
-export const check      = api.check;
-export const run        = api.run;
-export const relaunch   = api.relaunch;
-export const version    = api.version;
-export const onProgress = api.onProgress;
+export default createApiService('update');

--- a/src/services/usage-api.js
+++ b/src/services/usage-api.js
@@ -3,6 +3,4 @@
  * Components should import from here instead of calling window.api.usage directly.
  */
 import { createApiService } from './create-api-service.js';
-const api = createApiService('usage');
-
-export const getMetrics = api.getMetrics;
+export default createApiService('usage');

--- a/src/utils/tab-manager-api.js
+++ b/src/utils/tab-manager-api.js
@@ -8,8 +8,8 @@
  * All API access is routed through the service layer in src/services/.
  */
 
-import * as gitApi from '../services/git-api.js';
-import * as shellApi from '../services/shell-api.js';
+import gitApi from '../services/git-api.js';
+import shellApi from '../services/shell-api.js';
 
 /**
  * @typedef {{ branch: (cwd: string) => Promise<string|null>, remoteUrl: (cwd: string) => Promise<string|null>, pushBranch: (cwd: string, branch: string) => Promise<{ ok: boolean, error?: string }>, ghAvailable: () => Promise<boolean>, ghPrCreate: (cwd: string, baseBranch: string|null) => Promise<{ ok: boolean, url?: string, existed?: boolean, code?: string, error?: string }> }} GitApi


### PR DESCRIPTION
## Summary

- Each `src/services/*-api.js` file now exports the `createApiService` proxy as `export default` instead of listing every method individually (`export const x = api.x`)
- All 16 consumer files updated from `import * as xApi` to `import xApi` (default import)
- Net result: **-80 lines of boilerplate** that no longer need updating when API methods are added or removed

Closes #381

## Test plan

- [x] `npm run build` passes
- [x] `npm test` passes (387 tests, 25 suites)
- [ ] Manual smoke test of the app to verify all service calls still work at runtime

🤖 Generated with [Claude Code](https://claude.com/claude-code)