### PR TITLE
refactor: decompose 7 god-object constructors into init methods

### DIFF
--- a/src/components/board-view.js
+++ b/src/components/board-view.js
@@ -19,12 +19,15 @@ export class BoardView extends ComponentBase {
   constructor(container, tabManager) {
     super(container);
     this.tabManager = tabManager;
-    this.cards = new Map();
-    this._hiddenTerms = new Set();
-
+    this._initState();
     this.render();
     this._setupListeners();
     this._startPolling();
+  }
+
+  _initState() {
+    this.cards = new Map();
+    this._hiddenTerms = new Set();
   }
 
   render() {

--- a/src/components/diff-viewer.js
+++ b/src/components/diff-viewer.js
@@ -13,12 +13,20 @@ export class DiffViewer {
     this.container = container;
     this.diffText = diffText;
     this.filePath = filePath;
-    this.lang = detectLanguage(filePath);
+    this._initState();
+    this._parseDiff();
+    this.render();
+  }
+
+  _initState() {
+    this.lang = detectLanguage(this.filePath);
     this.viewMode = 'split';
     this.currentHunkIndex = -1;
     this.hunkElements = [];
+  }
 
-    const parsed = parseDiff(diffText);
+  _parseDiff() {
+    const parsed = parseDiff(this.diffText);
     this.headerLines = parsed.headerLines;
     this.hunks = parsed.hunks;
     this.rows = buildSideBySideRows(this.hunks);
@@ -26,8 +34,6 @@ export class DiffViewer {
     const stats = countDiffStats(this.hunks);
     this._additions = stats.additions;
     this._deletions = stats.deletions;
-
-    this.render();
   }
 
   render() {

--- a/src/components/file-tree.js
+++ b/src/components/file-tree.js
@@ -21,11 +21,20 @@ import * as clipboardApi from '../services/clipboard-api.js';
 export class FileTree extends ComponentBase {
   constructor(container) {
     super(container);
+    this._initState();
+    this._initApi();
+    this.render();
+    this.listenForChanges();
+  }
+
+  _initState() {
     this.termCwds = new Map();
     this.sections = new Map();
     this.debounceTimers = new Map();
     this._activeRow = null;
+  }
 
+  _initApi() {
     // Injected API methods for file-tree-drop and file-tree-context-menu utils
     this._contextMenuApi = {
       clipboardWrite: clipboardApi.write,
@@ -39,9 +48,6 @@ export class FileTree extends ComponentBase {
       mkdir: fsApi.mkdir,
       writefile: fsApi.writefile,
     };
-
-    this.render();
-    this.listenForChanges();
   }
 
   render() {

--- a/src/components/file-viewer.js
+++ b/src/components/file-viewer.js
@@ -27,6 +27,13 @@ export class FileViewer extends ComponentBase {
     super(container);
     this.isActive = isActive || (() => true);
     this._components = components;
+    this._initState();
+    this.render();
+    this._initWebviewManager();
+    this._initBusListeners();
+  }
+
+  _initState() {
     this.openFiles = new Map(); // path -> { name, content, savedContent, lang }
     this.activeFile = null;
     this.editorEl = null;
@@ -34,9 +41,6 @@ export class FileViewer extends ComponentBase {
     this.highlightLayer = null;
     this.mode = 'files'; // 'files' | 'git' | webview id
     this.gitChanges = null;
-    this.render();
-    this._initWebviewManager();
-    this._initBusListeners();
   }
 
   _initWebviewManager() {

--- a/src/components/flow-view.js
+++ b/src/components/flow-view.js
@@ -18,6 +18,13 @@ export class FlowView extends ComponentBase {
   constructor(container, tabManager) {
     super(container);
     this.tabManager = tabManager;
+    this._initState();
+    this._bindEvents();
+    this.render();
+    this._initRunning();
+  }
+
+  _initState() {
     this.flows = [];
     this.catData = { categories: [], order: {} };
     const FlowCardTerminalManager = getComponent('FlowCardTerminalManager');
@@ -28,7 +35,9 @@ export class FlowView extends ComponentBase {
 
     // Drag state (shared mutable object for use with setupCardDrag)
     this._drag = { flowId: null, catId: null };
+  }
 
+  _bindEvents() {
     this._track(flowApi.onRunStarted(({ flowId, ptyId }) => {
       this._runningMap[flowId] = ptyId;
       this._expandedCards.add(flowId);
@@ -40,9 +49,6 @@ export class FlowView extends ComponentBase {
       delete this._runningMap[flowId];
       this.refresh();
     }));
-
-    this.render();
-    this._initRunning();
   }
 
   async _initRunning() {

--- a/src/components/tab-manager.js
+++ b/src/components/tab-manager.js
@@ -38,6 +38,12 @@ export class TabManager {
   constructor(tabBar, workspaceContainer) {
     this.tabBar = tabBar;
     this.workspaceContainer = workspaceContainer;
+    this._initState();
+    this._initApi();
+    this.init();
+  }
+
+  _initState() {
     this.tabs = new Map();
     this.activeTabId = null;
     this.defaultCwd = null;
@@ -55,11 +61,11 @@ export class TabManager {
     this.sidebarMode = 'work';
     this.activeColorFilter = null; // null = show all, or a COLOR_GROUPS id
     this.excludedColors = new Set(); // COLOR_GROUPS ids to hide
+  }
 
+  _initApi() {
     // Injected API methods for workspace-layout utils
     this._api = { gitBranch: gitApi.branch };
-
-    this.init();
   }
 
   _prApi() { return buildPrApi(); }

--- a/src/components/terminal-panel.js
+++ b/src/components/terminal-panel.js
@@ -23,10 +23,19 @@ export class TerminalPanel {
   constructor(container, cwd) {
     this.container = container;
     this.cwd = cwd;
+    this._initState();
+    this._initApi();
+    this._initDragState();
+    this.init();
+  }
+
+  _initState() {
     this.root = null;
     this.activeTerminal = null;
     this.terminals = new Map();
+  }
 
+  _initApi() {
     // Injected API methods forwarded to TerminalInstance
     this._terminalApi = {
       openExternal: shellApi.openExternal,
@@ -40,12 +49,12 @@ export class TerminalPanel {
       ptyResize: ptyApi.resize,
       ptyKill: ptyApi.kill,
     };
+  }
 
+  _initDragState() {
     // Drag and drop state
     this._dragSourceId = null;
-    this._drop = new DropIndicatorManager(container);
-
-    this.init();
+    this._drop = new DropIndicatorManager(this.container);
   }
 
   // ===== DOM Helpers =====


### PR DESCRIPTION
## Summary

- Extracted inline initialization logic from the 7 constructors identified in #383 (file-tree, file-viewer, flow-view, tab-manager, board-view, terminal-panel, diff-viewer) into focused private methods (`_initState`, `_initApi`, `_bindEvents`, `_parseDiff`, `_initDragState`)
- Each constructor now delegates to named private methods, making initialization steps explicit and the constructor body concise (6-10 lines each)
- No logic, execution order, or public API changes — pure structural refactoring

Closes #383

## Test plan

- [x] `npm run build` passes
- [x] `npm test` passes (387/387 tests)
- [ ] Manual smoke test of each component (file tree, file viewer, flow view, tab manager, board view, terminal panel, diff viewer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)