### PR TITLE
refactor: reduce component coupling in tab-manager, flow-view, board-view

### DIFF
--- a/src/components/board-view.js
+++ b/src/components/board-view.js
@@ -1,6 +1,8 @@
-import { onTerminalCreated, onTerminalRemoved, onTerminalExited } from '../utils/terminal-events.js';
-import { _el, renderButtonBar, renderList } from '../utils/terminal-dom.js';
-import { _safeFit, createTerminal, disposeTerminal, disposeTerminalMap, setupTerminalAddons } from '../utils/terminal-factory.js';
+import {
+  onTerminalCreated, onTerminalRemoved, onTerminalExited,
+  _el, renderButtonBar, renderList,
+  _safeFit, createTerminal, disposeTerminal, disposeTerminalMap, setupTerminalAddons,
+} from '../utils/terminal-subsystem.js';
 import { registerComponent } from '../utils/component-registry.js';
 import { RendererPollingTimer } from '../utils/polling.js';
 import { ComponentBase } from '../utils/component-base.js';

--- a/src/components/flow-view.js
+++ b/src/components/flow-view.js
@@ -8,9 +8,8 @@ import {
   EMPTY_LIST_MESSAGE, UNCATEGORIZED, HEADER_BUTTONS,
   getFlowsForCategory, getUncategorizedFlows,
   removeFlowFromOrder, moveFlowInOrder, deleteCategoryData,
-} from '../utils/flow-view-helpers.js';
-import { createCategoryGroup } from '../utils/flow-category-renderer.js';
-import { createFlowCard } from '../utils/flow-card-setup.js';
+  createCategoryGroup, createFlowCard,
+} from '../utils/flow-view-subsystem.js';
 import flowApi from '../services/flow-api.js';
 
 

--- a/src/components/tab-manager.js
+++ b/src/components/tab-manager.js
@@ -4,12 +4,9 @@ import {
 } from '../utils/tab-manager-init.js';
 import {
   renderWorkspace as doRenderWorkspace, reattachLayout,
-} from '../utils/workspace-layout.js';
-import { capturePanelWidths } from '../utils/workspace-resize.js';
-import { disposeAllTabs } from '../utils/workspace-cleanup.js';
-import {
+  capturePanelWidths, disposeAllTabs,
   serialize as doSerialize, restoreConfig as doRestoreConfig,
-} from '../utils/workspace-serializer.js';
+} from '../utils/workspace-ops.js';
 import {
   renderActivityBar, detachSidebarView, changeSidebarMode,
   disposeSideView, disposeAllSideViews,

--- a/src/utils/flow-view-subsystem.js
+++ b/src/utils/flow-view-subsystem.js
@@ -1,0 +1,24 @@
+/**
+ * Flow View Subsystem Facade — single entry-point for flow-view.js
+ * to access helpers, category rendering, and card setup.
+ *
+ * Reduces the import surface of flow-view.js by consolidating
+ * flow-view-helpers, flow-category-renderer, and flow-card-setup.
+ *
+ * Created for issue #384 to reduce coupling in flow-view.js.
+ *
+ * @module flow-view-subsystem
+ */
+
+// ── flow-view-helpers ───────────────────────────────────────────────
+export {
+  EMPTY_LIST_MESSAGE, UNCATEGORIZED, HEADER_BUTTONS,
+  getFlowsForCategory, getUncategorizedFlows,
+  removeFlowFromOrder, moveFlowInOrder, deleteCategoryData,
+} from './flow-view-helpers.js';
+
+// ── flow-category-renderer ──────────────────────────────────────────
+export { createCategoryGroup } from './flow-category-renderer.js';
+
+// ── flow-card-setup ─────────────────────────────────────────────────
+export { createFlowCard } from './flow-card-setup.js';

--- a/src/utils/terminal-subsystem.js
+++ b/src/utils/terminal-subsystem.js
@@ -1,11 +1,14 @@
 /**
- * Terminal subsystem facade — single entry-point for the terminal-panel
- * component to access the split-layout, serialization, node-building,
- * drag-drop indicator, and terminal-split APIs.
+ * Terminal subsystem facade — single entry-point for terminal-panel
+ * and board-view components to access terminal infrastructure.
  *
- * Reduces the import surface of terminal-panel.js from 11 modules
- * down to ~5 (this facade + dom, drag-helpers, component-registry,
- * and the two event modules).
+ * Covers the split-layout, serialization, node-building, drag-drop
+ * indicator, terminal-split, terminal-events, terminal-dom, and
+ * terminal-factory APIs.
+ *
+ * Reduces the import surface of terminal-panel.js and board-view.js.
+ *
+ * Extended for issue #384 to reduce coupling in board-view.js.
  *
  * @module terminal-subsystem
  */
@@ -31,3 +34,17 @@ export { buildTopBar, createTerminalNode, buildFromTree } from './terminal-node-
 
 // ── terminal-split ──────────────────────────────────────────────────
 export { moveTerminal, splitTerminal, focusDirection } from './terminal-split.js';
+
+// ── terminal-events (board-view) ────────────────────────────────────
+export {
+  onTerminalCreated, onTerminalRemoved, onTerminalExited,
+} from './terminal-events.js';
+
+// ── terminal-dom (board-view) ───────────────────────────────────────
+export { _el, renderButtonBar, renderList } from './terminal-dom.js';
+
+// ── terminal-factory (board-view) ───────────────────────────────────
+export {
+  _safeFit, createTerminal, disposeTerminal, disposeTerminalMap,
+  setupTerminalAddons,
+} from './terminal-factory.js';

--- a/src/utils/workspace-ops.js
+++ b/src/utils/workspace-ops.js
@@ -1,10 +1,20 @@
 /**
  * Workspace Ops Facade — groups workspace-related imports for consumers
- * that depend on workspace-layout, workspace-resize, and workspace-cleanup.
+ * that depend on workspace-layout, workspace-resize, workspace-cleanup,
+ * and workspace-serializer.
  *
  * Created for issue #323 to reduce coupling in tab-lifecycle.js.
+ * Extended for issue #384 to reduce coupling in tab-manager.js.
  */
 
-export { reattachLayout, syncFileTree } from './workspace-layout.js';
+// ── workspace-layout ────────────────────────────────────────────────
+export { renderWorkspace, reattachLayout, syncFileTree } from './workspace-layout.js';
+
+// ── workspace-resize ────────────────────────────────────────────────
 export { capturePanelWidths } from './workspace-resize.js';
-export { disposeTab } from './workspace-cleanup.js';
+
+// ── workspace-cleanup ───────────────────────────────────────────────
+export { disposeTab, disposeAllTabs } from './workspace-cleanup.js';
+
+// ── workspace-serializer ────────────────────────────────────────────
+export { serialize, restoreConfig } from './workspace-serializer.js';


### PR DESCRIPTION
## Summary

- **tab-manager.js**: Consolidated 4 workspace imports (`workspace-layout`, `workspace-resize`, `workspace-cleanup`, `workspace-serializer`) into a single `workspace-ops.js` facade import. Reduced from 10 to 7 import statements.
- **flow-view.js**: Created new `flow-view-subsystem.js` facade to consolidate `flow-view-helpers`, `flow-category-renderer`, and `flow-card-setup`. Reduced from 10 to 8 import statements.
- **board-view.js**: Extended existing `terminal-subsystem.js` facade with re-exports from `terminal-events`, `terminal-dom`, and `terminal-factory`. Reduced from 10 to 8 import statements.

No business logic was changed. All changes are pure import re-routing through facade modules.

Closes #384

## Test plan

- [x] `npm run build` passes
- [x] `npm test` passes (25 test files, 388 tests)
- [ ] Verify tab-manager, flow-view, and board-view work correctly in the app

Generated with [Claude Code](https://claude.com/claude-code)