### PR TITLE
refactor: remove 4 unused exports

### DIFF
--- a/main/paths.js
+++ b/main/paths.js
@@ -7,7 +7,6 @@ const FLOWS_DIR = path.join(BASE_DIR, 'flows');
 const LOGS_DIR = path.join(FLOWS_DIR, 'logs');
 const SESSIONS_FILE = path.join(BASE_DIR, 'sessions.json');
 const META_FILE = path.join(BASE_DIR, 'meta.json');
-const FLOW_CATEGORIES_FILE = path.join(FLOWS_DIR, 'categories.json');
 const CLAUDE_PROJECTS_DIR = path.join(os.homedir(), '.claude', 'projects');
 
-module.exports = { BASE_DIR, CONFIG_DIR, FLOWS_DIR, LOGS_DIR, FLOW_CATEGORIES_FILE, SESSIONS_FILE, META_FILE, CLAUDE_PROJECTS_DIR };
+module.exports = { BASE_DIR, CONFIG_DIR, FLOWS_DIR, LOGS_DIR, SESSIONS_FILE, META_FILE, CLAUDE_PROJECTS_DIR };

--- a/src/utils/drag-helpers.js
+++ b/src/utils/drag-helpers.js
@@ -14,7 +14,7 @@
  * @param {string} [userSelect='none'] - CSS user-select value to apply
  * @returns {{ restore: () => void }}
  */
-export function withBodyStyle(cursor, userSelect = 'none') {
+function withBodyStyle(cursor, userSelect = 'none') {
   const prev = {
     cursor: document.body.style.cursor,
     userSelect: document.body.style.userSelect,

--- a/src/utils/file-tree-renderer.js
+++ b/src/utils/file-tree-renderer.js
@@ -18,7 +18,7 @@ function _parseSvg(svgStr) {
 }
 
 /** Parse all SVG icons once at module load from the declarative SVG_ICONS map. */
-export const PARSED_ICONS = Object.fromEntries(
+const PARSED_ICONS = Object.fromEntries(
   Object.entries(SVG_ICONS).map(([k, v]) => [k, _parseSvg(v)])
 );
 

--- a/src/utils/tab-manager-helpers.js
+++ b/src/utils/tab-manager-helpers.js
@@ -50,7 +50,7 @@ export function reorderEntries(entries, fromId, toId, before) {
  * @param {(item: T) => boolean} predicate — return true for a match
  * @returns {T|null} the first matching item, or null if none found
  */
-export function findCycleMatch(items, startIdx, step, predicate) {
+function findCycleMatch(items, startIdx, step, predicate) {
   const len = items.length;
   for (let i = 1; i < len; i++) {
     const item = items[(startIdx + step * i + len) % len];


### PR DESCRIPTION
## Refactoring

Suppression de 4 exports jamais importés par d'autres modules :

- **`FLOW_CATEGORIES_FILE`** (`main/paths.js`) : constante supprimée entièrement (jamais utilisée)
- **`withBodyStyle`** (`src/utils/drag-helpers.js`) : `export` retiré (utilisée uniquement en interne par `trackMouse`)
- **`PARSED_ICONS`** (`src/utils/file-tree-renderer.js`) : `export` retiré (utilisée uniquement en interne par `buildSectionActions`)
- **`findCycleMatch`** (`src/utils/tab-manager-helpers.js`) : `export` retiré (utilisée uniquement en interne par `findCycleTarget` et `findColorGroupTarget`)

Closes #389

## Fichier(s) modifié(s)

- `main/paths.js`
- `src/utils/drag-helpers.js`
- `src/utils/file-tree-renderer.js`
- `src/utils/tab-manager-helpers.js`

## Vérifications

- [x] Build OK
- [x] Tests OK (388/388)

---

📂 Path local : `/Users/rekta/projet/coding/refactor-pikagent`
🤖 PR créée automatiquement par l'Agent Refactor