### PR TITLE
refactor: fix disposeAllTabs duplication + use ensureDirOnce in skills-manager

### DIFF
--- a/main/skills-manager.js
+++ b/main/skills-manager.js
@@ -166,6 +166,7 @@ async function resetRoot() {
   return trySafe(async () => {
     await fsp.unlink(SETTINGS_FILE).catch(() => {});
     _rootCache = null;
+    _ensureRootDir = ensureDirOnce(DEFAULT_SKILLS_DIR);
     const root = await _loadRoot();
     return { success: true, root };
   }, { success: false }, { log, label: 'resetRoot' });

--- a/main/skills-manager.js
+++ b/main/skills-manager.js
@@ -3,7 +3,7 @@ const fsp = fs.promises;
 const path = require('path');
 const os = require('os');
 const { BASE_DIR } = require('./paths');
-const { readJson, writeJson } = require('./fs-utils');
+const { readJson, writeJson, ensureDirOnce } = require('./fs-utils');
 const { trySafe } = require('./logger');
 const { pathExists } = require('./fs-manager-helpers');
 const { JsonStore } = require('./json-store');
@@ -15,6 +15,7 @@ const DEFAULT_SKILLS_DIR = path.join(os.homedir(), '.claude', 'skills');
 const SETTINGS_FILE = path.join(BASE_DIR, 'skills-settings.json');
 
 let _rootCache = null;
+let _ensureRootDir = ensureDirOnce(DEFAULT_SKILLS_DIR);
 
 function parseFrontmatter(md) {
   if (!md.startsWith('---')) return {};
@@ -40,6 +41,7 @@ async function _saveRoot(newRoot) {
   await store.ensureDir();
   await writeJson(SETTINGS_FILE, { root: newRoot });
   _rootCache = newRoot;
+  _ensureRootDir = ensureDirOnce(newRoot);
 }
 
 async function _readSkillDir(rootDir, skillName) {
@@ -132,7 +134,7 @@ async function importFrom(srcDir) {
       return { success: false, error: 'No SKILL.md found in folder' };
     }
     const root = await _loadRoot();
-    await fsp.mkdir(root, { recursive: true });
+    await _ensureRootDir();
     const baseName = path.basename(srcDir);
     let destName = baseName;
     let destDir = path.join(root, destName);

--- a/src/components/tab-manager.js
+++ b/src/components/tab-manager.js
@@ -262,7 +262,7 @@ export class TabManager {
     for (const unsub of this._busListeners) unsub();
     this._busListeners = [];
     disposeAllSideViews(this._viewStore());
-    disposeAllTabs({ tabs: this.tabs, setActiveTabId: (id) => { this.activeTabId = id; } });
+    this._disposeAllTabs();
   }
 
   setTabColorGroup(id, colorGroupId) {


### PR DESCRIPTION
## Refactoring

2 corrections de duplication mineures :

1. **tab-manager.js** : `dispose()` appelait directement `disposeAllTabs(...)` avec les mêmes args que `_disposeAllTabs()`. Remplacé par un appel à `this._disposeAllTabs()`.

2. **skills-manager.js** : Utilise maintenant `ensureDirOnce` (cohérent avec JsonStore, SessionManager) pour le répertoire racine des skills, avec invalidation du cache quand `setRoot()` change le répertoire. Les `fsp.mkdir` pour les chemins dynamiques (write, create) restent inchangés.

Closes #390

## Fichier(s) modifié(s)

- `src/components/tab-manager.js`
- `main/skills-manager.js`

## Vérifications

- [x] Build OK
- [x] Tests OK (388/388)

---

📂 Path local : `/Users/rekta/projet/coding/refactor-pikagent`
🤖 PR créée automatiquement par l'Agent Refactor