### PR TITLE
refactor: deduplicate aggregation patterns (#347)

### DIFF
--- a/main/stats-helpers.js
+++ b/main/stats-helpers.js
@@ -1,4 +1,9 @@
-const { computeRate: genericComputeRate, groupAndAggregate, computeNumericStats } = require('../shared/aggregation-utils');
+const {
+  computeRate: genericComputeRate,
+  groupAndAggregate,
+  computeNumericStats,
+  initializeCounters,
+} = require('../shared/aggregation-utils');
 const { generateDateRange } = require('./date-utils');
 
 const DEFAULT_DAYS = 30;
@@ -10,10 +15,17 @@ const STATUS_CATEGORIES = {
   running: new Set(['running']),
 };
 
+/** Category keys derived once from STATUS_CATEGORIES. */
+const STATUS_KEYS = Object.keys(STATUS_CATEGORIES);
+
+/** Return only the per-status counts (no total/rate) for a set of items. */
 function countByStatus(items, field = 'status') {
   const { total, rate, ...counts } = genericComputeRate(items, STATUS_CATEGORIES, field);
   return counts;
 }
+
+/** Default zeroed status counts, used as spread defaults in perDay labels. */
+const EMPTY_STATUS_COUNTS = initializeCounters(STATUS_KEYS);
 
 function computeRate(items, statusField = 'status') {
   if (items.length === 0) return { total: 0, success: 0, error: 0, rate: 0 };
@@ -36,7 +48,7 @@ function perDay(items, dateExtractor, days = DEFAULT_DAYS) {
   return labels.map((day) => ({
     ...day,
     total: 0,
-    ...countByStatus([]),
+    ...EMPTY_STATUS_COUNTS,
     ...grouped[day.date],
   }));
 }

--- a/main/usage-helpers.js
+++ b/main/usage-helpers.js
@@ -10,7 +10,7 @@ const {
   mapFields,
   countBy,
   initializeCounters,
-  buildMetrics: genericBuildMetrics,
+  createDomainMetricsBuilder,
 } = require('../shared/aggregation-utils');
 
 // ===== Declarative configs =====
@@ -177,25 +177,14 @@ function getFlowRunDuration(run) {
 }
 
 /**
- * Domain-specific metrics builder — delegates to the generic shared buildMetrics
- * factory, injecting domain-specific rate and perDay functions.
- *
- * @param {Array<{ status?: string, [key: string]: unknown }>} items - The items to compute base metrics for
- * @param {{ durationMapper: (item: { status?: string, [key: string]: unknown }) => number|null,
- *           dateExtractor: (item: { status?: string, [key: string]: unknown }) => string,
- *           extra?: Record<string, unknown> }} opts
- * @returns {Record<string, unknown>}
+ * Domain-specific metrics builder — pre-configured with domain rate/perDay
+ * functions via createDomainMetricsBuilder, eliminating repeated config injection.
  */
-function buildMetrics(items, { durationMapper, dateExtractor, extra = {} }) {
-  return genericBuildMetrics(items, {
-    rateFn: computeRate,
-    durationMapper,
-    dateExtractor,
-    perDayFn: perDay,
-    days: DEFAULT_DAYS,
-    extra,
-  });
-}
+const buildMetrics = createDomainMetricsBuilder({
+  rateFn: computeRate,
+  perDayFn: perDay,
+  days: DEFAULT_DAYS,
+});
 
 function buildFlowMetrics(flows, flowRuns) {
   return buildMetrics(flowRuns, {

--- a/shared/aggregation-utils.js
+++ b/shared/aggregation-utils.js
@@ -200,6 +200,25 @@ function buildMetrics(items, { rateFn, durationMapper, dateExtractor, perDayFn, 
   };
 }
 
+/**
+ * Factory that pre-binds domain-specific rateFn, perDayFn and days into a
+ * simpler metrics builder.  Eliminates repeated config injection at each call site.
+ *
+ * Usage:
+ *   const buildMetrics = createDomainMetricsBuilder({ rateFn, perDayFn, days });
+ *   buildMetrics(items, { durationMapper, dateExtractor, extra });
+ *
+ * @param {{ rateFn: (items: Array) => Record<string, unknown>,
+ *           perDayFn: (items: Array, dateExtractor: Function, days: number) => Array,
+ *           days?: number }} domainConfig
+ * @returns {(items: Array, opts: { durationMapper: Function, dateExtractor: Function, extra?: Record<string, unknown> }) => Record<string, unknown>}
+ */
+function createDomainMetricsBuilder({ rateFn, perDayFn, days = 30 }) {
+  return function domainBuildMetrics(items, { durationMapper, dateExtractor, extra = {} }) {
+    return buildMetrics(items, { rateFn, durationMapper, dateExtractor, perDayFn, days, extra });
+  };
+}
+
 module.exports = {
   aggregateByKey,
   groupAndAggregate,
@@ -213,4 +232,5 @@ module.exports = {
   computeRate,
   computeNumericStats,
   buildMetrics,
+  createDomainMetricsBuilder,
 };


### PR DESCRIPTION
## Refactoring

Extracts shared aggregation utilities to eliminate duplicated patterns in usage-helpers.js and stats-helpers.js.

### Changes

- **`shared/aggregation-utils.js`**: Added `createDomainMetricsBuilder` factory that pre-binds domain-specific `rateFn`, `perDayFn`, and `days` into a simpler metrics builder, eliminating repeated config injection at each call site.
- **`main/usage-helpers.js`**: Replaced the local `buildMetrics` wrapper function with a factory-created version via `createDomainMetricsBuilder`, removing 11 lines of boilerplate.
- **`main/stats-helpers.js`**: Replaced `countByStatus([])` (which called `genericComputeRate` with an empty array just to get default zeros) with a pre-computed `EMPTY_STATUS_COUNTS` constant using `initializeCounters`, and extracted `STATUS_KEYS` for reuse.

Closes #347

## Vérifications
- [x] Build OK
- [x] Tests OK (388/388)

---
📂 Path local : `/Users/rekta/projet/coding/refactor-pikagent`
🤖 PR créée automatiquement par l'Agent Refactor