### PR TITLE
refactor: migrate services to createApiService factory (#381)

### DIFF
--- a/src/services/config-api.js
+++ b/src/services/config-api.js
@@ -3,9 +3,4 @@
  * Components should import from here instead of calling window.api.config directly.
  */
 import { createApiService } from './create-api-service.js';
-const api = createApiService('config');
-
-// Alias: consumers use deleteConfig but the IPC method is delete
-api.deleteConfig = api.delete;
-
-export default api;
+export default createApiService('config', { deleteConfig: 'delete' });

--- a/src/services/create-api-service.js
+++ b/src/services/create-api-service.js
@@ -2,12 +2,15 @@
  * Creates a proxy that delegates method calls to window.api[domain].
  * Centralizes the window.api access pattern for all service modules.
  * @param {string} domain — the window.api namespace (e.g. 'config', 'flow')
+ * @param {Record<string, string>} [aliases] — optional map of alias → IPC method
+ *   e.g. { deleteConfig: 'delete' } so proxy.deleteConfig delegates to window.api[domain].delete
  */
-export function createApiService(domain) {
+export function createApiService(domain, aliases) {
   return new Proxy(/** @type {any} */ ({}), {
-    get: (target, method) =>
-      method in target
-        ? target[method]
-        : (...args) => window.api[domain][method](...args),
+    get: (target, method) => {
+      if (method in target) return target[method];
+      const resolved = aliases?.[method] ?? method;
+      return (...args) => window.api[domain][resolved](...args);
+    },
   });
 }

--- a/src/services/flow-api.js
+++ b/src/services/flow-api.js
@@ -3,9 +3,4 @@
  * Components should import from here instead of calling window.api.flow directly.
  */
 import { createApiService } from './create-api-service.js';
-const api = createApiService('flow');
-
-// Alias: consumers use deleteFlow but the IPC method is delete
-api.deleteFlow = api.delete;
-
-export default api;
+export default createApiService('flow', { deleteFlow: 'delete' });

--- a/src/services/skills-api.js
+++ b/src/services/skills-api.js
@@ -3,10 +3,4 @@
  * Components should import from here instead of calling window.api.skills directly.
  */
 import { createApiService } from './create-api-service.js';
-const api = createApiService('skills');
-
-// Aliases: consumers use importSkill/deleteSkill but the IPC methods are import/delete
-api.importSkill = api.import;
-api.deleteSkill = api.delete;
-
-export default api;
+export default createApiService('skills', { importSkill: 'import', deleteSkill: 'delete' });


### PR DESCRIPTION
## Refactoring

Replaces manual pass-through API wrappers in src/services/ with the createApiService proxy factory, eliminating remaining boilerplate.

### Changes

- **`create-api-service.js`**: Added optional `aliases` parameter to map consumer-facing method names to IPC method names (e.g. `deleteConfig` → `delete`)
- **`config-api.js`**, **`flow-api.js`**, **`skills-api.js`**: Reduced from multi-line alias setup to single-line `createApiService(domain, aliases)` calls

Net result: -24 lines added, +11 lines — all 11 service files now follow a uniform one-liner pattern.

Closes #381

## Vérifications
- [x] Build OK
- [x] Tests OK (388 passed)

---
📂 Path local : `/Users/rekta/projet/coding/refactor-pikagent`
🤖 PR créée automatiquement par l'Agent Refactor