### PR TITLE
refactor: replace @type {any} with precise JSDoc type in create-api-service

### DIFF
--- a/src/services/create-api-service.js
+++ b/src/services/create-api-service.js
@@ -6,7 +6,7 @@
  *   e.g. { deleteConfig: 'delete' } so proxy.deleteConfig delegates to window.api[domain].delete
  */
 export function createApiService(domain, aliases) {
-  return new Proxy(/** @type {any} */ ({}), {
+  return new Proxy(/** @type {Record<string, (...args: unknown[]) => unknown>} */ ({}), {
     get: (target, method) => {
       if (method in target) return target[method];
       const resolved = aliases?.[method] ?? method;


### PR DESCRIPTION
## Refactoring

Remplace le type `@type {any}` par `@type {Record<string, (...args: unknown[]) => unknown>}` dans le Proxy de `create-api-service.js`, pour un typage plus précis du target.

**Note** : L'export `buildRecord` dans `record-helpers.js` est en fait utilisé par `session-helpers.js`, donc il n'a pas été retiré (l'analyse initiale était incorrecte).

Closes #399

## Fichier(s) modifié(s)

- `src/services/create-api-service.js`

## Vérifications

- [x] Build OK
- [x] Tests OK (388 passed)

---

📂 Path local : `/Users/rekta/projet/coding/refactor-pikagent`
🤖 PR créée automatiquement par l'Agent Refactor