### PR TITLE
refactor: decouple Git worktree logic from tab-lifecycle via event

### DIFF
--- a/src/components/tab-manager.js
+++ b/src/components/tab-manager.js
@@ -177,7 +177,6 @@ export class TabManager {
       activeTabId: this.activeTabId,
       renderTabBar: () => this.renderTabBar(),
       configManager: this.configManager,
-      worktreeApi: this._worktreeApi(),
     }, () => this.createTab(), (tabId) => this.switchTo(tabId), id);
   }
 

--- a/src/utils/tab-lifecycle.js
+++ b/src/utils/tab-lifecycle.js
@@ -10,7 +10,7 @@
  *
  * @typedef {{ tabs: Map<string, WorkspaceTab>, defaultCwd: string, activeColorFilter: string|null, renderTabBar: () => void, configManager: { scheduleAutoSave: () => void } }} CreateTabDeps
  *
- * @typedef {{ tabs: Map<string, WorkspaceTab>, activeTabId: string|null, renderTabBar: () => void, configManager: { scheduleAutoSave: () => void }, worktreeApi?: import('./worktree-flow.js').GitWorktreeApi }} CloseTabDeps
+ * @typedef {{ tabs: Map<string, WorkspaceTab>, activeTabId: string|null, renderTabBar: () => void, configManager: { scheduleAutoSave: () => void } }} CloseTabDeps
  *
  * @typedef {{ tabs: Map<string, WorkspaceTab>, getActiveTabId: () => string|null, setActiveTabId: (id: string) => void, getSidebarMode: () => string, setSidebarMode: (mode: string) => void, workspaceContainer: HTMLElement, renderTabBar: () => void, renderActivityBar: () => void, renderWorkspace: (tab: WorkspaceTab) => void, detachSidebarView: (mode: string) => void }} SwitchToDeps
  */
@@ -18,11 +18,11 @@
 import { generateId } from './id.js';
 import { _el } from './tab-dom.js';
 import { showConfirmDialog } from './dom-dialogs.js';
-import { emitWorkspaceActivated } from './workspace-events.js';
+import { emitWorkspaceActivated, emitTabWorktreeClosed } from './workspace-events.js';
 import { WorkspaceTab } from './tab-types.js';
 import { reattachLayout, syncFileTree, capturePanelWidths, disposeTab } from './workspace-ops.js';
 import { extractFolderName } from './file-tree-helpers.js';
-import { maybeRemoveWorktree } from './worktree-flow.js';
+
 
 // ── Tab creation ──
 
@@ -71,8 +71,8 @@ export async function closeTab(deps, createTabFn, switchToFn, id) {
   disposeTab(tab);
   deps.tabs.delete(id);
 
-  if (tab.worktree && deps.worktreeApi) {
-    await maybeRemoveWorktree(tab.worktree, tab.name, deps.worktreeApi);
+  if (tab.worktree) {
+    emitTabWorktreeClosed({ worktree: tab.worktree, tabName: tab.name });
   }
 
   if (deps.tabs.size === 0) {

--- a/src/utils/tab-manager-init.js
+++ b/src/utils/tab-manager-init.js
@@ -7,10 +7,10 @@
  */
 
 import { onTerminalCwdChanged as onTermCwdEvent, onTerminalCreated, onTerminalRemoved } from './terminal-events.js';
-import { onLayoutChanged, onWorkspaceOpenFromFolder, onWorkspaceCreateWorktree, onWorkspaceOpenPr } from './workspace-events.js';
+import { onLayoutChanged, onWorkspaceOpenFromFolder, onWorkspaceCreateWorktree, onWorkspaceOpenPr, onTabWorktreeClosed } from './workspace-events.js';
 import { extractFolderName } from './file-tree-helpers.js';
 import { findTabForTerminal, onTerminalCwdChanged } from './tab-lifecycle.js';
-import { createWorktreeFlow } from './worktree-flow.js';
+import { createWorktreeFlow, maybeRemoveWorktree } from './worktree-flow.js';
 import { openPrFlow } from './open-pr-flow.js';
 
 export { getComponent } from './component-registry.js';
@@ -101,6 +101,10 @@ export function setupBusListeners(deps) {
         api: deps.api.worktree,
         createTab: deps.createTab,
       }).catch((e) => console.warn('createWorktreeFlow failed:', e));
+    }),
+    onTabWorktreeClosed(({ worktree, tabName }) => {
+      maybeRemoveWorktree(worktree, tabName, deps.api.worktree)
+        .catch((e) => console.warn('maybeRemoveWorktree failed:', e));
     }),
     onWorkspaceOpenPr(({ repoCwd }) => {
       const tab = _findTabByCwd(deps.tabs, repoCwd);

--- a/src/utils/workspace-events.js
+++ b/src/utils/workspace-events.js
@@ -36,6 +36,11 @@ const { on: onWorkspaceCreateWorktree, emit: emitWorkspaceCreateWorktree } =
 const { on: onWorkspaceOpenPr, emit: emitWorkspaceOpenPr } =
   createTypedEvent('workspace:openPr');
 
+// ── tabWorktreeClosed ───────────────────────────────────────────────
+
+const { on: onTabWorktreeClosed, emit: emitTabWorktreeClosed } =
+  createTypedEvent('tab:worktreeClosed');
+
 // ── fileOpen ────────────────────────────────────────────────────────
 
 const { on: onFileOpen, emit: emitFileOpen } =
@@ -54,6 +59,8 @@ export {
   emitWorkspaceCreateWorktree,
   onWorkspaceOpenPr,
   emitWorkspaceOpenPr,
+  onTabWorktreeClosed,
+  emitTabWorktreeClosed,
   onFileOpen,
   emitFileOpen,
 };


### PR DESCRIPTION
## Refactoring

Découple la logique Git/worktree de `tab-lifecycle.js` en remplaçant l'import direct de `maybeRemoveWorktree` par un événement `tab:worktreeClosed`.

**Avant** : `tab-lifecycle.js` importait directement `maybeRemoveWorktree` depuis `worktree-flow.js` (couplage transversal Git ↔ Tab).

**Après** : `tab-lifecycle.js` émet `emitTabWorktreeClosed(...)`, et le listener dans `tab-manager-init.js` (qui gère déjà le wiring des événements worktree) appelle `maybeRemoveWorktree`.

Closes #398

## Fichier(s) modifié(s)

- `src/utils/workspace-events.js` — ajout de l'événement `tab:worktreeClosed`
- `src/utils/tab-lifecycle.js` — suppression de l'import, émission de l'événement
- `src/utils/tab-manager-init.js` — ajout du listener
- `src/components/tab-manager.js` — suppression du `worktreeApi` dans les deps de closeTab

## Vérifications

- [x] Build OK
- [x] Tests OK (388 passed)

---

📂 Path local : `/Users/rekta/projet/coding/refactor-pikagent`
🤖 PR créée automatiquement par l'Agent Refactor