### PR TITLE
refactor: extract rendering and category logic from SkillsView and FlowView

### DIFF
--- a/src/components/flow-view.js
+++ b/src/components/flow-view.js
@@ -1,14 +1,15 @@
-import { showPromptDialog } from '../utils/dom-dialogs.js';
-import { generateId } from '../utils/id.js';
 import { registerComponent, getComponent } from '../utils/component-registry.js';
 import { ComponentBase } from '../utils/component-base.js';
 import {
   EMPTY_LIST_MESSAGE, UNCATEGORIZED, HEADER_BUTTONS,
   getFlowsForCategory, getUncategorizedFlows,
-  removeFlowFromOrder, moveFlowInOrder, deleteCategoryData,
+  removeFlowFromOrder, moveFlowInOrder,
   createCategoryGroup, createFlowCard,
-  _el, renderButtonBar, startInlineRename,
+  _el, renderButtonBar,
 } from '../utils/flow-view-subsystem.js';
+import {
+  addCategory, renameCategoryInline, deleteCategory,
+} from '../utils/flow-view-categories.js';
 import flowApi from '../services/flow-api.js';
 
 
@@ -202,45 +203,18 @@ export class FlowView extends ComponentBase {
     this.refresh();
   }
 
-  // --- Category management ---
+  // --- Category management (delegated) ---
 
-  async _addCategory() {
-    const name = await showPromptDialog({
-      title: 'Nouvelle catégorie',
-      placeholder: 'Nom de la catégorie',
-      confirmLabel: 'Créer',
-      cancelLabel: 'Annuler',
-    });
-    if (!name) return;
-    const cat = { id: generateId('cat'), name };
-    this.catData.categories.push(cat);
-    this.catData.order[cat.id] = [];
-    await this._persistCategories();
-    this._renderList();
+  _addCategory() {
+    return addCategory(this.catData, () => this._persistCategories(), () => this._renderList());
   }
 
   _renameCategoryInline(catId, nameEl) {
-    const cat = this.catData.categories.find(c => c.id === catId);
-    if (!cat) return;
-
-    const finish = async (newName) => {
-      if (newName && newName !== cat.name) cat.name = newName;
-      await this._persistCategories();
-      this._renderList();
-    };
-
-    startInlineRename(nameEl, {
-      className: 'flow-category-name-input',
-      value: cat.name,
-      onCommit: finish,
-      onCancel: () => finish(null),
-    });
+    renameCategoryInline(this.catData, catId, nameEl, () => this._persistCategories(), () => this._renderList());
   }
 
-  async _deleteCategory(catId) {
-    if (!deleteCategoryData(this.catData, catId)) return;
-    await this._persistCategories();
-    this._renderList();
+  _deleteCategory(catId) {
+    return deleteCategory(this.catData, catId, () => this._persistCategories(), () => this._renderList());
   }
 
   // ===== Creation / Edit Modal =====

--- a/src/components/skills-view.js
+++ b/src/components/skills-view.js
@@ -1,7 +1,10 @@
-import { _el, renderList } from '../utils/workspace-dom.js';
+import { _el } from '../utils/workspace-dom.js';
 import { showPromptDialog, showConfirmDialog } from '../utils/dom-dialogs.js';
 import { registerComponent } from '../utils/component-registry.js';
 import { ComponentBase } from '../utils/component-base.js';
+import {
+  renderHeader, renderSkillList, renderEditorContent, renderEditorEmpty, updateDirtyBadge,
+} from '../utils/skills-view-renderer.js';
 import skillsApi from '../services/skills-api.js';
 import shellApi from '../services/shell-api.js';
 import dialogApi from '../services/dialog-api.js';
@@ -31,42 +34,17 @@ export class SkillsView extends ComponentBase {
     await this._renderEditor();
   }
 
-  async render() {
+  render() {
     this.el.replaceChildren();
 
-    const header = _el('div', 'skills-header',
-      _el('div', 'skills-header-left',
-        _el('h2', 'skills-title', 'Skills'),
-        this._rootBadge(),
-      ),
-      _el('div', 'skills-header-right',
-        _el('button', {
-          className: 'skills-btn skills-btn-secondary',
-          textContent: 'Configurer le chemin…',
-          onClick: () => this._configurePath(),
-        }),
-        _el('button', {
-          className: 'skills-btn skills-btn-secondary',
-          textContent: 'Ouvrir le dossier',
-          onClick: () => this._openRoot(),
-        }),
-        _el('button', {
-          className: 'skills-btn skills-btn-secondary',
-          textContent: 'Importer',
-          onClick: () => this._importSkill(),
-        }),
-        _el('button', {
-          className: 'skills-btn skills-btn-primary',
-          textContent: '+ Nouveau skill',
-          onClick: () => this._createSkill(),
-        }),
-        _el('button', {
-          className: 'skills-btn skills-btn-secondary',
-          textContent: 'Rafraîchir',
-          onClick: () => this.refresh(),
-        }),
-      ),
-    );
+    const { header, rootBadgeEl } = renderHeader(this.rootPath, {
+      onConfigurePath: () => this._configurePath(),
+      onOpenRoot: () => this._openRoot(),
+      onImport: () => this._importSkill(),
+      onCreate: () => this._createSkill(),
+      onRefresh: () => this.refresh(),
+    });
+    this._rootBadgeEl = rootBadgeEl;
     this.el.appendChild(header);
 
     const body = _el('div', 'skills-body');
@@ -76,17 +54,45 @@ export class SkillsView extends ComponentBase {
     body.appendChild(this.editorEl);
     this.el.appendChild(body);
 
-    await this.refresh();
+    this.refresh();
   }
 
-  _rootBadge() {
-    this._rootBadgeEl = _el('div', {
-      className: 'skills-root-badge',
-      title: 'Dossier des skills utilisateur',
-      textContent: this.rootPath || '…',
+  _renderList() {
+    if (!this.listEl) return;
+    if (this._rootBadgeEl) this._rootBadgeEl.textContent = this.rootPath;
+    renderSkillList(this.listEl, this.skills, this.selectedId, {
+      onSelect: (id) => this._selectSkill(id),
+      onDelete: (id) => this._deleteSkill(id),
     });
-    return this._rootBadgeEl;
   }
+
+  async _renderEditor() {
+    if (!this.editorEl) return;
+    if (!this.selectedId) { renderEditorEmpty(this.editorEl); return; }
+
+    const skill = this.skills.find((s) => s.id === this.selectedId);
+    if (!skill) return;
+
+    const content = await skillsApi.read(skill.path);
+    this.editorValue = content ?? '';
+    this.editorDirty = false;
+
+    const { dirtyBadgeEl } = renderEditorContent(this.editorEl, skill, this.editorValue, {
+      onSave: () => this._save(),
+      onInput: (value) => this._onEditorInput(value),
+    }, this.editorDirty);
+    this._dirtyBadgeEl = dirtyBadgeEl;
+  }
+
+  _onEditorInput(value) {
+    this.editorValue = value;
+    if (!this.editorDirty) {
+      this.editorDirty = true;
+      updateDirtyBadge(this._dirtyBadgeEl, true);
+    }
+  }
+
+  // --- Actions ---
 
   async _openRoot() {
     if (!this.rootPath) return;
@@ -152,34 +158,6 @@ export class SkillsView extends ComponentBase {
     await this.refresh();
   }
 
-  _renderList() {
-    if (!this.listEl) return;
-    if (this._rootBadgeEl) this._rootBadgeEl.textContent = this.rootPath;
-
-    renderList(this.listEl, this.skills, (skill) => _el('div', {
-      className: `skills-item ${this.selectedId === skill.id ? 'skills-item-active' : ''}`,
-      onClick: () => this._selectSkill(skill.id),
-    },
-      _el('div', 'skills-item-main',
-        _el('div', 'skills-item-name', skill.name),
-        skill.description && _el('div', 'skills-item-desc', skill.description),
-      ),
-      _el('div', 'skills-item-meta',
-        _el('div', 'skills-item-source', skill.source),
-      ),
-      _el('button', {
-        className: 'skills-item-delete',
-        title: 'Supprimer',
-        textContent: '\u2715',
-        onClick: (e) => { e.stopPropagation(); this._deleteSkill(skill.id); },
-      }),
-    ));
-
-    if (this.skills.length === 0) {
-      this.listEl.appendChild(_el('div', 'skills-empty', 'Aucun skill. Créez-en un pour commencer.'));
-    }
-  }
-
   async _selectSkill(id) {
     if (this.editorDirty) {
       const ok = await showConfirmDialog(
@@ -194,82 +172,13 @@ export class SkillsView extends ComponentBase {
     await this._renderEditor();
   }
 
-  async _renderEditor() {
-    if (!this.editorEl) return;
-    this.editorEl.replaceChildren();
-
-    if (!this.selectedId) {
-      this.editorEl.appendChild(_el('div', 'skills-editor-empty',
-        _el('div', 'skills-editor-empty-title', 'Sélectionnez un skill'),
-        _el('div', 'skills-editor-empty-sub', 'Cliquez sur un skill à gauche pour l\'éditer, ou créez-en un nouveau.'),
-      ));
-      return;
-    }
-
-    const skill = this.skills.find((s) => s.id === this.selectedId);
-    if (!skill) return;
-
-    const content = await skillsApi.read(skill.path);
-    this.editorValue = content ?? '';
-    this.editorDirty = false;
-
-    const toolbar = _el('div', 'skills-editor-toolbar',
-      _el('div', 'skills-editor-toolbar-left',
-        _el('div', 'skills-editor-name', skill.name),
-        _el('div', 'skills-editor-path', skill.path),
-      ),
-      _el('div', 'skills-editor-toolbar-right',
-        this._dirtyBadge(),
-        _el('button', {
-          className: 'skills-btn skills-btn-primary',
-          textContent: 'Enregistrer',
-          onClick: () => this._save(),
-        }),
-      ),
-    );
-
-    const textarea = _el('textarea', {
-      className: 'skills-editor-textarea',
-      spellcheck: false,
-      value: this.editorValue,
-      onInput: (e) => this._onEditorInput(e.target.value),
-    });
-    this._textareaEl = textarea;
-
-    this.editorEl.appendChild(toolbar);
-    this.editorEl.appendChild(textarea);
-  }
-
-  _dirtyBadge() {
-    this._dirtyBadgeEl = _el('div', {
-      className: `skills-editor-dirty ${this.editorDirty ? 'is-dirty' : ''}`,
-      textContent: this.editorDirty ? 'Modifié' : 'Enregistré',
-    });
-    return this._dirtyBadgeEl;
-  }
-
-  _onEditorInput(value) {
-    this.editorValue = value;
-    const nextDirty = true;
-    if (this.editorDirty !== nextDirty) {
-      this.editorDirty = nextDirty;
-      this._updateDirtyBadge();
-    }
-  }
-
-  _updateDirtyBadge() {
-    if (!this._dirtyBadgeEl) return;
-    this._dirtyBadgeEl.textContent = this.editorDirty ? 'Modifié' : 'Enregistré';
-    this._dirtyBadgeEl.classList.toggle('is-dirty', this.editorDirty);
-  }
-
   async _save() {
     const skill = this.skills.find((s) => s.id === this.selectedId);
     if (!skill) return;
     const res = await skillsApi.write(skill.path, this.editorValue);
     if (res && res.success) {
       this.editorDirty = false;
-      this._updateDirtyBadge();
+      updateDirtyBadge(this._dirtyBadgeEl, false);
       await this.refresh();
     }
   }

--- a/src/utils/flow-view-categories.js
+++ b/src/utils/flow-view-categories.js
@@ -1,0 +1,69 @@
+/**
+ * Flow view category management — extracted from FlowView component.
+ *
+ * Handles creation, renaming, deletion, and inline rename of flow categories.
+ */
+
+import { showPromptDialog } from './dom-dialogs.js';
+import { generateId } from './id.js';
+import { deleteCategoryData, startInlineRename } from './flow-view-subsystem.js';
+
+/**
+ * Prompt the user to create a new category, add it to catData, and persist.
+ * @param {{ categories: Array<{id: string, name: string}>, order: Record<string, string[]> }} catData
+ * @param {() => Promise<void>} persistFn
+ * @param {() => void} renderFn
+ */
+export async function addCategory(catData, persistFn, renderFn) {
+  const name = await showPromptDialog({
+    title: 'Nouvelle catégorie',
+    placeholder: 'Nom de la catégorie',
+    confirmLabel: 'Créer',
+    cancelLabel: 'Annuler',
+  });
+  if (!name) return;
+  const cat = { id: generateId('cat'), name };
+  catData.categories.push(cat);
+  catData.order[cat.id] = [];
+  await persistFn();
+  renderFn();
+}
+
+/**
+ * Start inline rename for a category.
+ * @param {{ categories: Array<{id: string, name: string}> }} catData
+ * @param {string} catId
+ * @param {HTMLElement} nameEl
+ * @param {() => Promise<void>} persistFn
+ * @param {() => void} renderFn
+ */
+export function renameCategoryInline(catData, catId, nameEl, persistFn, renderFn) {
+  const cat = catData.categories.find(c => c.id === catId);
+  if (!cat) return;
+
+  const finish = async (newName) => {
+    if (newName && newName !== cat.name) cat.name = newName;
+    await persistFn();
+    renderFn();
+  };
+
+  startInlineRename(nameEl, {
+    className: 'flow-category-name-input',
+    value: cat.name,
+    onCommit: finish,
+    onCancel: () => finish(null),
+  });
+}
+
+/**
+ * Delete a category from catData and persist.
+ * @param {{ categories: Array<{id: string, name: string}>, order: Record<string, string[]> }} catData
+ * @param {string} catId
+ * @param {() => Promise<void>} persistFn
+ * @param {() => void} renderFn
+ */
+export async function deleteCategory(catData, catId, persistFn, renderFn) {
+  if (!deleteCategoryData(catData, catId)) return;
+  await persistFn();
+  renderFn();
+}

--- a/src/utils/skills-view-renderer.js
+++ b/src/utils/skills-view-renderer.js
@@ -1,0 +1,166 @@
+/**
+ * Skills view rendering helpers — extracted from SkillsView component.
+ *
+ * Pure DOM-construction functions. State is passed in, never owned here.
+ */
+
+import { _el, renderList } from './workspace-dom.js';
+
+/**
+ * Build the top header bar with action buttons.
+ * @param {string} rootPath
+ * @param {{ onConfigurePath: () => void, onOpenRoot: () => void, onImport: () => void, onCreate: () => void, onRefresh: () => void }} handlers
+ * @returns {{ header: HTMLElement, rootBadgeEl: HTMLElement }}
+ */
+export function renderHeader(rootPath, handlers) {
+  const rootBadgeEl = _el('div', {
+    className: 'skills-root-badge',
+    title: 'Dossier des skills utilisateur',
+    textContent: rootPath || '…',
+  });
+
+  const header = _el('div', 'skills-header',
+    _el('div', 'skills-header-left',
+      _el('h2', 'skills-title', 'Skills'),
+      rootBadgeEl,
+    ),
+    _el('div', 'skills-header-right',
+      _el('button', {
+        className: 'skills-btn skills-btn-secondary',
+        textContent: 'Configurer le chemin…',
+        onClick: handlers.onConfigurePath,
+      }),
+      _el('button', {
+        className: 'skills-btn skills-btn-secondary',
+        textContent: 'Ouvrir le dossier',
+        onClick: handlers.onOpenRoot,
+      }),
+      _el('button', {
+        className: 'skills-btn skills-btn-secondary',
+        textContent: 'Importer',
+        onClick: handlers.onImport,
+      }),
+      _el('button', {
+        className: 'skills-btn skills-btn-primary',
+        textContent: '+ Nouveau skill',
+        onClick: handlers.onCreate,
+      }),
+      _el('button', {
+        className: 'skills-btn skills-btn-secondary',
+        textContent: 'Rafraîchir',
+        onClick: handlers.onRefresh,
+      }),
+    ),
+  );
+
+  return { header, rootBadgeEl };
+}
+
+/**
+ * Render the skill list into the given container.
+ * @param {HTMLElement} listEl
+ * @param {Array<{id: string, name: string, description?: string, source: string}>} skills
+ * @param {string|null} selectedId
+ * @param {{ onSelect: (id: string) => void, onDelete: (id: string) => void }} handlers
+ */
+export function renderSkillList(listEl, skills, selectedId, handlers) {
+  renderList(listEl, skills, (skill) => _el('div', {
+    className: `skills-item ${selectedId === skill.id ? 'skills-item-active' : ''}`,
+    onClick: () => handlers.onSelect(skill.id),
+  },
+    _el('div', 'skills-item-main',
+      _el('div', 'skills-item-name', skill.name),
+      skill.description && _el('div', 'skills-item-desc', skill.description),
+    ),
+    _el('div', 'skills-item-meta',
+      _el('div', 'skills-item-source', skill.source),
+    ),
+    _el('button', {
+      className: 'skills-item-delete',
+      title: 'Supprimer',
+      textContent: '\u2715',
+      onClick: (e) => { e.stopPropagation(); handlers.onDelete(skill.id); },
+    }),
+  ));
+
+  if (skills.length === 0) {
+    listEl.appendChild(_el('div', 'skills-empty', 'Aucun skill. Créez-en un pour commencer.'));
+  }
+}
+
+/**
+ * Render the editor panel for a selected skill.
+ * @param {HTMLElement} editorEl
+ * @param {{ name: string, path: string }} skill
+ * @param {string} content
+ * @param {{ onSave: () => void, onInput: (value: string) => void }} handlers
+ * @param {boolean} isDirty
+ * @returns {{ dirtyBadgeEl: HTMLElement, textareaEl: HTMLElement }}
+ */
+export function renderEditorContent(editorEl, skill, content, handlers, isDirty) {
+  editorEl.replaceChildren();
+
+  const dirtyBadgeEl = createDirtyBadge(isDirty);
+
+  const toolbar = _el('div', 'skills-editor-toolbar',
+    _el('div', 'skills-editor-toolbar-left',
+      _el('div', 'skills-editor-name', skill.name),
+      _el('div', 'skills-editor-path', skill.path),
+    ),
+    _el('div', 'skills-editor-toolbar-right',
+      dirtyBadgeEl,
+      _el('button', {
+        className: 'skills-btn skills-btn-primary',
+        textContent: 'Enregistrer',
+        onClick: handlers.onSave,
+      }),
+    ),
+  );
+
+  const textareaEl = _el('textarea', {
+    className: 'skills-editor-textarea',
+    spellcheck: false,
+    value: content,
+    onInput: (e) => handlers.onInput(e.target.value),
+  });
+
+  editorEl.appendChild(toolbar);
+  editorEl.appendChild(textareaEl);
+
+  return { dirtyBadgeEl, textareaEl };
+}
+
+/**
+ * Render the empty editor placeholder.
+ * @param {HTMLElement} editorEl
+ */
+export function renderEditorEmpty(editorEl) {
+  editorEl.replaceChildren();
+  editorEl.appendChild(_el('div', 'skills-editor-empty',
+    _el('div', 'skills-editor-empty-title', 'Sélectionnez un skill'),
+    _el('div', 'skills-editor-empty-sub', 'Cliquez sur un skill à gauche pour l\'éditer, ou créez-en un nouveau.'),
+  ));
+}
+
+/**
+ * Create a dirty/saved badge element.
+ * @param {boolean} isDirty
+ * @returns {HTMLElement}
+ */
+export function createDirtyBadge(isDirty) {
+  return _el('div', {
+    className: `skills-editor-dirty ${isDirty ? 'is-dirty' : ''}`,
+    textContent: isDirty ? 'Modifié' : 'Enregistré',
+  });
+}
+
+/**
+ * Update the dirty badge state.
+ * @param {HTMLElement} el
+ * @param {boolean} isDirty
+ */
+export function updateDirtyBadge(el, isDirty) {
+  if (!el) return;
+  el.textContent = isDirty ? 'Modifié' : 'Enregistré';
+  el.classList.toggle('is-dirty', isDirty);
+}


### PR DESCRIPTION
## Refactoring

Réduit la taille des composants UI les plus volumineux en extrayant la logique DOM et métier vers des modules dédiés :

### SkillsView (283 → 192 lignes, -32%)
- Nouveau module `src/utils/skills-view-renderer.js` (166 lignes)
- Extraction de : `renderHeader()`, `renderSkillList()`, `renderEditorContent()`, `renderEditorEmpty()`, `createDirtyBadge()`, `updateDirtyBadge()`
- La classe ne conserve que l'état et l'orchestration des actions

### FlowView (278 → 252 lignes, -9%)
- Nouveau module `src/utils/flow-view-categories.js` (69 lignes)
- Extraction de : `addCategory()`, `renameCategoryInline()`, `deleteCategory()`

### FileViewer, FileTree, TabManager — non modifiés
Ces 3 classes (269-295 lignes) délèguent déjà quasi-intégralement à leurs subsystems respectifs (`file-viewer-subsystem.js`, `file-tree-subsystem.js`, `tab-facade.js`). Leurs méthodes sont principalement des wrappers de 1-5 lignes. Toute extraction supplémentaire créerait de l'indirection artificielle sans bénéfice réel.

Closes #397

## Fichier(s) modifié(s)

- `src/components/skills-view.js` (réduit)
- `src/components/flow-view.js` (réduit)
- `src/utils/skills-view-renderer.js` (nouveau)
- `src/utils/flow-view-categories.js` (nouveau)

## Vérifications

- [x] Build OK
- [x] Tests OK (390 passed)

---

📂 Path local : `/Users/rekta/projet/coding/refactor-pikagent`
🤖 PR créée automatiquement par l'Agent Refactor