### PR TITLE
refactor: extract setupResizeHandler to centralize resize pattern

### DIFF
--- a/src/components/terminal-panel.js
+++ b/src/components/terminal-panel.js
@@ -1,7 +1,7 @@
 import { emitTerminalRemoved } from '../utils/terminal-events.js';
 import { emitLayoutChanged } from '../utils/workspace-events.js';
 import { _el } from '../utils/terminal-dom.js';
-import { trackMouse } from '../utils/drag-helpers.js';
+import { trackMouse, setupResizeHandler } from '../utils/drag-helpers.js';
 import { registerComponent } from '../utils/component-registry.js';
 import {
   SplitNode, RESIZE_CURSOR, doResize,
@@ -196,13 +196,11 @@ export class TerminalPanel {
   }
 
   setupResizeHandle(handle, splitEl, direction) {
-    handle.addEventListener('mousedown', (e) => {
-      e.preventDefault();
-      trackMouse(RESIZE_CURSOR[direction],
-        (ev) => doResize(ev, handle, splitEl, direction, () => this.fitAll()),
-        /** @fires layout:changed {undefined} — resize complete */
-        () => emitLayoutChanged(),
-      );
+    setupResizeHandler(handle, {
+      cursor: RESIZE_CURSOR[direction],
+      onMove: (ev) => doResize(ev, handle, splitEl, direction, () => this.fitAll()),
+      /** @fires layout:changed {undefined} — resize complete */
+      onDone: () => emitLayoutChanged(),
     });
   }
 

--- a/src/components/webview-panel.js
+++ b/src/components/webview-panel.js
@@ -1,6 +1,6 @@
 import { _el } from '../utils/workspace-dom.js';
 import { onKeyAction } from '../utils/event-helpers.js';
-import { trackMouse } from '../utils/drag-helpers.js';
+import { setupResizeHandler } from '../utils/drag-helpers.js';
 import {
   MAX_LOGS,
   WEBVIEW_NAV_ACTIONS,
@@ -179,17 +179,10 @@ export class WebviewInstance {
   }
 
   _setupConsoleResize() {
-    let startY = 0;
-    let startHeight = 0;
-
-    this._consoleHandle.addEventListener('mousedown', (e) => {
-      e.preventDefault();
-      startY = e.clientY;
-      startHeight = this._consolePanel.getBoundingClientRect().height;
-      trackMouse('row-resize',
-        (ev) => { this._consolePanel.style.height = `${clampConsoleHeight(startHeight, startY - ev.clientY)}px`; },
-        () => {},
-      );
+    setupResizeHandler(this._consoleHandle, {
+      cursor: 'row-resize',
+      onStart: (e) => ({ startY: e.clientY, startHeight: this._consolePanel.getBoundingClientRect().height }),
+      onMove: (ev, ctx) => { this._consolePanel.style.height = `${clampConsoleHeight(ctx.startHeight, ctx.startY - ev.clientY)}px`; },
     });
   }
 

--- a/src/utils/drag-helpers.js
+++ b/src/utils/drag-helpers.js
@@ -97,6 +97,25 @@ export function addListener(target, type, handler, options) {
 }
 
 /**
+ * Attach a mousedown → trackMouse resize handler to a handle element.
+ * Eliminates the repeated mousedown + preventDefault + capture-state + trackMouse
+ * boilerplate found in panel/terminal/console resize code.
+ *
+ * @param {HTMLElement} handle  — the resize handle element
+ * @param {{ cursor: string, onStart?: (e: MouseEvent) => unknown, onMove: (e: MouseEvent, ctx: unknown) => void, onDone?: (ctx: unknown) => void }} opts
+ */
+export function setupResizeHandler(handle, { cursor, onStart, onMove, onDone }) {
+  handle.addEventListener('mousedown', (e) => {
+    e.preventDefault();
+    const ctx = onStart ? onStart(e) : undefined;
+    trackMouse(cursor,
+      (ev) => onMove(ev, ctx),
+      () => { if (onDone) onDone(ctx); },
+    );
+  });
+}
+
+/**
  * Build dragstart / dragend handlers that toggle a CSS class on the element
  * and set / clear a key on a shared state object.
  *

--- a/src/utils/workspace-resize.js
+++ b/src/utils/workspace-resize.js
@@ -7,7 +7,7 @@
  */
 
 import { _el } from './workspace-dom.js';
-import { trackMouse } from './drag-helpers.js';
+import { setupResizeHandler } from './drag-helpers.js';
 import { PANEL_MIN_WIDTH, FIT_DELAY_MS, WORKSPACE_PANELS } from './tab-constants.js';
 import { clampPanelWidth, panelArrowState } from './tab-manager-helpers.js';
 
@@ -79,23 +79,17 @@ export function buildCenterPanel(deps, tab, leftPanel, rightPanel) {
  * @param {string} side
  */
 function setupPanelResize({ getActiveTab, scheduleAutoSave }, handle, panel, side) {
-  let startX = 0;
-  let startWidth = 0;
-
-  handle.addEventListener('mousedown', (e) => {
-    e.preventDefault();
-    startX = e.clientX;
-    startWidth = panel.getBoundingClientRect().width;
-    trackMouse('col-resize',
-      (ev) => {
-        const dx = ev.clientX - startX;
-        const newWidth = side === 'left' ? startWidth + dx : startWidth - dx;
-        panel.style.width = `${clampPanelWidth(newWidth, side)}px`;
-        panel.style.flex = 'none';
-        getActiveTab()?.terminalPanel?.fitAll();
-      },
-      () => scheduleAutoSave(),
-    );
+  setupResizeHandler(handle, {
+    cursor: 'col-resize',
+    onStart: (e) => ({ startX: e.clientX, startWidth: panel.getBoundingClientRect().width }),
+    onMove: (ev, ctx) => {
+      const dx = ev.clientX - ctx.startX;
+      const newWidth = side === 'left' ? ctx.startWidth + dx : ctx.startWidth - dx;
+      panel.style.width = `${clampPanelWidth(newWidth, side)}px`;
+      panel.style.flex = 'none';
+      getActiveTab()?.terminalPanel?.fitAll();
+    },
+    onDone: () => scheduleAutoSave(),
   });
 }
 


### PR DESCRIPTION
## Refactoring

Ajout de `setupResizeHandler` dans `drag-helpers.js` pour centraliser le pattern `mousedown → preventDefault → capture state → trackMouse` utilisé par les resize handles.

3 call sites refactorisés :
- **workspace-resize.js** : panel resize (left/right)
- **terminal-panel.js** : split handle resize
- **webview-panel.js** : console panel resize

Le drag & drop des terminaux (`setupDrag`) et le tab drag (`tab-drag.js`) ne sont pas concernés car ils utilisent des patterns différents (side effects, threshold system).

Closes #403

## Fichier(s) modifié(s)

- `src/utils/drag-helpers.js` — ajout de `setupResizeHandler`
- `src/utils/workspace-resize.js` — utilise `setupResizeHandler`
- `src/components/terminal-panel.js` — utilise `setupResizeHandler` pour `setupResizeHandle`
- `src/components/webview-panel.js` — utilise `setupResizeHandler` pour `_setupConsoleResize`

## Vérifications

- [x] Build OK
- [x] Tests OK (390 tests, 25 fichiers)

---

📂 Path local : `/Users/rekta/projet/coding/refactor-pikagent`
🤖 PR créée automatiquement par l'Agent Refactor