### PR TITLE
refactor: extract section DOM from FileTree (290→246 lines)

### DIFF
--- a/src/components/file-tree.js
+++ b/src/components/file-tree.js
@@ -1,19 +1,16 @@
 import { _el } from '../utils/file-dom.js';
-import { buildChevronRow } from '../utils/chevron-row.js';
 import { registerComponent } from '../utils/component-registry.js';
-import { attachContextMenu } from '../utils/context-menu.js';
-import { emitWorkspaceCreateWorktree, emitWorkspaceOpenPr } from '../utils/workspace-events.js';
 import { ComponentBase } from '../utils/component-base.js';
 import {
   CHEVRON_EXPANDED, CHEVRON_COLLAPSED,
-  extractFolderName, resolveWatchCwd,
-  buildDirContextItems,
-  renderDirEntry, renderFileEntry, buildSectionActions,
+  resolveWatchCwd,
+  renderDirEntry, renderFileEntry,
   setupDropZone, handleFileDrop,
   promptRename as doPromptRename,
   promptNewEntry as doPromptNewEntry,
   listenForChanges, startWatch, stopWatch,
 } from '../utils/file-tree-subsystem.js';
+import { rebuildSectionDOM } from '../utils/file-tree-section-dom.js';
 import fsApi from '../services/fs-api.js';
 import shellApi from '../services/shell-api.js';
 import clipboardApi from '../services/clipboard-api.js';
@@ -134,54 +131,13 @@ export class FileTree extends ComponentBase {
   }
 
   _rebuildSectionDOM(section, cwd) {
-    const wasCollapsed =
-      section.sectionEl.querySelector('.file-tree-section-content.collapsed') !== null;
-    section.sectionEl.replaceChildren();
-
-    const contentEl = _el('div', { className: `file-tree-section-content${wasCollapsed ? ' collapsed' : ''}` });
-    const { header } = this._buildSectionHeader(cwd, contentEl, wasCollapsed, section.expandedDirs);
-    section.sectionEl.append(header, contentEl);
-
-    this._setupDropZone(header, cwd);
-    this._setupDropZone(contentEl, cwd);
-    return contentEl;
-  }
-
-  _buildSectionHeader(cwd, contentEl, wasCollapsed, expandedDirs) {
-    const actionsContainer = buildSectionActions({
-      newFile:     () => this.promptNewEntry(cwd, contentEl, 0, expandedDirs, 'file'),
-      newFolder:   () => this.promptNewEntry(cwd, contentEl, 0, expandedDirs, 'folder'),
-      newWorktree: () => emitWorkspaceCreateWorktree({ repoCwd: cwd }),
-      openPr:      () => emitWorkspaceOpenPr({ repoCwd: cwd }),
-      refresh:     () => this.refreshSection(cwd),
+    return rebuildSectionDOM(section, cwd, {
+      setupDropZone: (el, targetDir) => this._setupDropZone(el, targetDir),
+      promptNewEntry: (dirPath, cEl, depth, eDirs, type) => this.promptNewEntry(dirPath, cEl, depth, eDirs, type),
+      promptRename: (path, nameEl) => this.promptRename(path, nameEl),
+      refreshSection: (c) => this.refreshSection(c),
+      contextMenuApi: this._contextMenuApi,
     });
-
-    const { chevron, name: labelEl, row: header } = buildChevronRow({
-      chevronClass: 'file-tree-section-chevron',
-      chevronText: wasCollapsed ? CHEVRON_COLLAPSED : CHEVRON_EXPANDED,
-      nameClass: 'file-tree-section-label',
-      name: extractFolderName(cwd),
-      containerClass: 'file-tree-section-header',
-      extraChildren: [actionsContainer],
-    });
-    labelEl.title = cwd;
-
-    header.addEventListener('click', () => {
-      const collapsed = contentEl.classList.toggle('collapsed');
-      chevron.textContent = collapsed ? CHEVRON_COLLAPSED : CHEVRON_EXPANDED;
-    });
-
-    this._attachSectionContextMenu(header, cwd, contentEl, expandedDirs);
-    return { chevron, header };
-  }
-
-  _attachSectionContextMenu(header, cwd, contentEl, expandedDirs) {
-    attachContextMenu(header, () => buildDirContextItems(
-      cwd, cwd, contentEl, 0, expandedDirs, null,
-      (path, nameEl) => this.promptRename(path, nameEl),
-      (dirPath, cEl, depth, eDirs, type) => this.promptNewEntry(dirPath, cEl, depth, eDirs, type),
-      this._contextMenuApi,
-    ));
   }
 
   // --- Context menu helpers ---

--- a/src/utils/file-tree-section-dom.js
+++ b/src/utils/file-tree-section-dom.js
@@ -1,0 +1,83 @@
+/**
+ * File-tree section DOM building — extracted from FileTree to keep the
+ * component focused on state management and rendering orchestration.
+ *
+ * Handles building section headers (chevron, label, action buttons)
+ * and the associated context menu attachment.
+ *
+ * @typedef {{ setupDropZone: (el: HTMLElement, targetDir: string|(() => string|null)) => void, promptNewEntry: (dirPath: string, cEl: HTMLElement, depth: number, eDirs: Set<string>, type: string) => void, promptRename: (path: string, nameEl: HTMLElement) => void, refreshSection: (cwd: string) => void, contextMenuApi: unknown }} SectionDOMCallbacks
+ */
+
+import { _el } from './file-dom.js';
+import { buildChevronRow } from './chevron-row.js';
+import { attachContextMenu } from './context-menu.js';
+import { emitWorkspaceCreateWorktree, emitWorkspaceOpenPr } from './workspace-events.js';
+import {
+  CHEVRON_EXPANDED, CHEVRON_COLLAPSED,
+  extractFolderName, buildSectionActions, buildDirContextItems,
+} from './file-tree-subsystem.js';
+
+/**
+ * Rebuild the DOM for a file-tree section: header + content container.
+ * Preserves collapsed state across refreshes.
+ *
+ * @param {{ sectionEl: HTMLElement, expandedDirs: Set<string> }} section
+ * @param {string} cwd
+ * @param {SectionDOMCallbacks} callbacks
+ * @returns {HTMLElement} the content element to render directory entries into
+ */
+export function rebuildSectionDOM(section, cwd, callbacks) {
+  const wasCollapsed =
+    section.sectionEl.querySelector('.file-tree-section-content.collapsed') !== null;
+  section.sectionEl.replaceChildren();
+
+  const contentEl = _el('div', { className: `file-tree-section-content${wasCollapsed ? ' collapsed' : ''}` });
+  const { header } = _buildSectionHeader(cwd, contentEl, wasCollapsed, section.expandedDirs, callbacks);
+  section.sectionEl.append(header, contentEl);
+
+  callbacks.setupDropZone(header, cwd);
+  callbacks.setupDropZone(contentEl, cwd);
+  return contentEl;
+}
+
+/**
+ * Build a section header with chevron toggle, label, and action buttons.
+ * @param {string} cwd
+ * @param {HTMLElement} contentEl
+ * @param {boolean} wasCollapsed
+ * @param {Set<string>} expandedDirs
+ * @param {SectionDOMCallbacks} callbacks
+ */
+function _buildSectionHeader(cwd, contentEl, wasCollapsed, expandedDirs, callbacks) {
+  const actionsContainer = buildSectionActions({
+    newFile:     () => callbacks.promptNewEntry(cwd, contentEl, 0, expandedDirs, 'file'),
+    newFolder:   () => callbacks.promptNewEntry(cwd, contentEl, 0, expandedDirs, 'folder'),
+    newWorktree: () => emitWorkspaceCreateWorktree({ repoCwd: cwd }),
+    openPr:      () => emitWorkspaceOpenPr({ repoCwd: cwd }),
+    refresh:     () => callbacks.refreshSection(cwd),
+  });
+
+  const { chevron, name: labelEl, row: header } = buildChevronRow({
+    chevronClass: 'file-tree-section-chevron',
+    chevronText: wasCollapsed ? CHEVRON_COLLAPSED : CHEVRON_EXPANDED,
+    nameClass: 'file-tree-section-label',
+    name: extractFolderName(cwd),
+    containerClass: 'file-tree-section-header',
+    extraChildren: [actionsContainer],
+  });
+  labelEl.title = cwd;
+
+  header.addEventListener('click', () => {
+    const collapsed = contentEl.classList.toggle('collapsed');
+    chevron.textContent = collapsed ? CHEVRON_COLLAPSED : CHEVRON_EXPANDED;
+  });
+
+  attachContextMenu(header, () => buildDirContextItems(
+    cwd, cwd, contentEl, 0, expandedDirs, null,
+    callbacks.promptRename,
+    callbacks.promptNewEntry,
+    callbacks.contextMenuApi,
+  ));
+
+  return { chevron, header };
+}


### PR DESCRIPTION
## Refactoring

Extraction de la construction DOM des sections du FileTree dans un module dédié `file-tree-section-dom.js`.

**Ce qui est extrait :**
- `_rebuildSectionDOM` → `rebuildSectionDOM()` (reconstruction DOM avec préservation collapsed state)
- `_buildSectionHeader` → `_buildSectionHeader()` (chevron, label, boutons d'actions)
- `_attachSectionContextMenu` → intégré dans `_buildSectionHeader()`

**Résultat :**
- `file-tree.js` : 290 → 246 lignes
- Nouveau module `file-tree-section-dom.js` : 87 lignes (responsabilité cohérente)

**Note :** Les autres composants (file-viewer.js 290L, tab-manager.js 294L, flow-view.js 252L) sont déjà bien décomposés — leurs méthodes sont des délégations de 1-5 lignes vers des modules helpers/subsystem. Un découpage supplémentaire ajouterait de l'indirection sans bénéfice.

Closes #397

## Fichier(s) modifié(s)

- `src/components/file-tree.js` — délègue la construction section DOM
- `src/utils/file-tree-section-dom.js` — nouveau module (section header + context menu)

## Vérifications

- [x] Build OK
- [x] Tests OK (391 tests, 25 fichiers)

---

📂 Path local : `/Users/rekta/projet/coding/refactor-pikagent`
🤖 PR créée automatiquement par l'Agent Refactor