### PR TITLE
refactor: remove dead cleanup export from ipc-handlers

### DIFF
--- a/main/ipc-handlers.js
+++ b/main/ipc-handlers.js
@@ -1,10 +1,9 @@
 const { ipcMain } = require('electron');
-const { registerManagerHandlers, safeSend, getRegisteredChannels } = require('./ipc-helpers');
+const { registerManagerHandlers, safeSend } = require('./ipc-helpers');
 const { createSafeHandler } = require('./safe-handler');
 
 /**
  * Channels with custom handlers (registered manually in `register()`).
- * Kept at module scope so `cleanup()` can reference them.
  */
 const CUSTOM_CHANNELS = ['pty:create', 'fs:watch', 'fs:trash', 'dialog:openFolder'];
 
@@ -62,22 +61,4 @@ function register(getWindow, { targets, ptyManager, sessionManager }) {
   });
 }
 
-/**
- * Remove all IPC handlers registered by `register()`.
- *
- * Called during `before-quit` to ensure a clean shutdown and avoid
- * stale handler references.
- */
-function cleanup() {
-  // Remove custom handlers
-  for (const channel of CUSTOM_CHANNELS) {
-    ipcMain.removeHandler(channel);
-  }
-
-  // Remove declaratively registered handlers
-  for (const channel of getRegisteredChannels()) {
-    ipcMain.removeHandler(channel);
-  }
-}
-
-module.exports = { register, cleanup };
+module.exports = { register };

--- a/main/ipc-helpers.js
+++ b/main/ipc-helpers.js
@@ -43,24 +43,6 @@ function buildTablesFromSchema(schema) {
 const { forward: FORWARD_TABLE, spread: SPREAD_TABLE } = buildTablesFromSchema(API_SCHEMA);
 
 /**
- * Return the list of all declaratively registered IPC channel names.
- * Used by `ipc-handlers.cleanup()` to remove handlers on shutdown.
- *
- * @param {Set<string>} [skip] - Channels to exclude (custom handlers managed separately)
- * @returns {string[]}
- */
-function getRegisteredChannels(skip = new Set()) {
-  const channels = [];
-  for (const [channel] of FORWARD_TABLE) {
-    if (!skip.has(channel)) channels.push(channel);
-  }
-  for (const [channel] of SPREAD_TABLE) {
-    if (!skip.has(channel)) channels.push(channel);
-  }
-  return channels;
-}
-
-/**
  * @internal
  * Generic handler registration — loops over entries and registers an
  * `ipc.handle` for each one, using `buildCallback` to create the handler.
@@ -125,7 +107,7 @@ function registerManagerHandlers(ipc, targets, skip = new Set()) {
   );
 }
 
-module.exports = { safeSend, registerManagerHandlers, getRegisteredChannels };
+module.exports = { safeSend, registerManagerHandlers };
 
 /** @internal — exposed for unit tests only; not part of the public API. */
 module.exports._internals = { buildTablesFromSchema, registerForward, registerSpread };


### PR DESCRIPTION
## Refactoring

Suppression de la fonction `cleanup()` morte dans `ipc-handlers.js` et du helper `getRegisteredChannels()` associé dans `ipc-helpers.js`, qui n'étaient appelés nulle part.

Closes #407

## Fichier(s) modifié(s)

- `main/ipc-handlers.js` — suppression de `cleanup()` et de son export
- `main/ipc-helpers.js` — suppression de `getRegisteredChannels()` et de son export

## Vérifications

- [x] Build OK
- [x] Tests OK (391/391)

---

📂 Path local : `/Users/rekta/projet/coding/refactor-pikagent`
🤖 PR créée automatiquement par l'Agent Refactor