### PR TITLE
refactor: extract _getFlowCards helper in flow-category-renderer

### DIFF
--- a/src/utils/flow-category-renderer.js
+++ b/src/utils/flow-category-renderer.js
@@ -99,10 +99,14 @@ function _setupCategoryDropZone(items, catId, onDropFlow, dragState) {
 
 // --- Drop indicator helpers ---
 
+function _getFlowCards(container) {
+  return [...container.querySelectorAll(':scope > .flow-card')];
+}
+
 function _updateDropIndicator(container, clientY) {
   clearIndicators(container, '.flow-drop-indicator');
 
-  const cards = [...container.querySelectorAll(':scope > .flow-card')];
+  const cards = _getFlowCards(container);
   if (cards.length === 0) return;
 
   const idx = computeInsertionIndex(cards, clientY, 'y');
@@ -117,6 +121,5 @@ function _updateDropIndicator(container, clientY) {
 }
 
 function _getDropIndex(container, clientY) {
-  const cards = [...container.querySelectorAll(':scope > .flow-card')];
-  return computeInsertionIndex(cards, clientY, 'y');
+  return computeInsertionIndex(_getFlowCards(container), clientY, 'y');
 }


### PR DESCRIPTION
## Refactoring

Extraction d'un helper `_getFlowCards(container)` dans `flow-category-renderer.js` pour dédupliquer la query DOM identique partagée entre `_updateDropIndicator` et `_getDropIndex`.

Les deux autres patterns mentionnés dans #406 (select factory et visibility toggling) ne sont pas de vrais doublons après inspection :
- **Select factory** : données de formes différentes (`Record<string,string>` vs tableau de strings), modules `_el` différents
- **Visibility** : `_vis` utilise `flex/none` vs `''/none` dans worktree-dialog — incompatible sans casser l'affichage des inputs

Closes #406

## Fichier(s) modifié(s)

- `src/utils/flow-category-renderer.js`

## Vérifications

- [x] Build OK
- [x] Tests OK (391/391)

---

📂 Path local : `/Users/rekta/projet/coding/refactor-pikagent`
🤖 PR créée automatiquement par l'Agent Refactor