### PR TITLE
refactor: remove dead cleanup export from ipc-handlers

### DIFF
--- a/main/ipc-handlers.js
+++ b/main/ipc-handlers.js
@@ -1,10 +1,9 @@
 const { ipcMain } = require('electron');
-const { registerManagerHandlers, safeSend, getRegisteredChannels } = require('./ipc-helpers');
+const { registerManagerHandlers, safeSend } = require('./ipc-helpers');
 const { createSafeHandler } = require('./safe-handler');
 
 /**
  * Channels with custom handlers (registered manually in `register()`).
- * Kept at module scope so `cleanup()` can reference them.
  */
 const CUSTOM_CHANNELS = ['pty:create', 'fs:watch', 'fs:trash', 'dialog:openFolder'];
 
@@ -62,22 +61,4 @@ function register(getWindow, { targets, ptyManager, sessionManager }) {
   });
 }
 
-/**
- * Remove all IPC handlers registered by `register()`.
- *
- * Called during `before-quit` to ensure a clean shutdown and avoid
- * stale handler references.
- */
-function cleanup() {
-  // Remove custom handlers
-  for (const channel of CUSTOM_CHANNELS) {
-    ipcMain.removeHandler(channel);
-  }
-
-  // Remove declaratively registered handlers
-  for (const channel of getRegisteredChannels()) {
-    ipcMain.removeHandler(channel);
-  }
-}
-
-module.exports = { register, cleanup };
+module.exports = { register };

--- a/main/ipc-helpers.js
+++ b/main/ipc-helpers.js
@@ -44,7 +44,7 @@ const { forward: FORWARD_TABLE, spread: SPREAD_TABLE } = buildTablesFromSchema(A
 
 /**
  * Return the list of all declaratively registered IPC channel names.
- * Used by `ipc-handlers.cleanup()` to remove handlers on shutdown.
+ * Returns all declaratively registered IPC channel names.
  *
  * @param {Set<string>} [skip] - Channels to exclude (custom handlers managed separately)
  * @returns {string[]}


### PR DESCRIPTION
## Refactoring

Suppression de l'export mort `cleanup` dans `main/ipc-handlers.js`. Cette fonction n'est jamais importée ni appelée par aucun module du projet.

Closes #407

## Fichier(s) modifié(s)

- `main/ipc-handlers.js`
- `main/ipc-helpers.js` (mise à jour d'un commentaire faisant référence à `cleanup`)

## Vérifications

- [x] Build OK
- [x] Tests OK (391 tests passed)

---

📂 Path local : `/Users/rekta/projet/coding/refactor-pikagent`
🤖 PR créée automatiquement par l'Agent Refactor