### PR TITLE
refactor: deduplicate mousedown/drag pattern into setupDragHandler

### DIFF
--- a/src/components/terminal-panel.js
+++ b/src/components/terminal-panel.js
@@ -1,7 +1,7 @@
 import { emitTerminalRemoved } from '../utils/terminal-events.js';
 import { emitLayoutChanged } from '../utils/workspace-events.js';
 import { _el } from '../utils/terminal-dom.js';
-import { trackMouse, setupResizeHandler } from '../utils/drag-helpers.js';
+import { setupDragHandler, setupResizeHandler } from '../utils/drag-helpers.js';
 import { registerComponent } from '../utils/component-registry.js';
 import {
   SplitNode, RESIZE_CURSOR, doResize,
@@ -127,27 +127,26 @@ export class TerminalPanel {
   // ===== Drag & Drop =====
 
   setupDrag(handle, sourceNode) {
-    handle.addEventListener('mousedown', (e) => {
-      if (this.terminals.size < 2) return;
-      e.preventDefault();
-      e.stopPropagation();
-
-      this._dragSourceId = sourceNode.terminal.id;
-      sourceNode.element.classList.add('dragging');
-      this._drop.create();
-
-      trackMouse('grabbing',
-        (ev) => this._drop.update(ev.clientX, ev.clientY, this.terminals, this._dragSourceId),
-        () => {
-          sourceNode.element.classList.remove('dragging');
-          const { targetId, side } = this._drop;
-          this._drop.remove();
-          if (targetId && side && targetId !== this._dragSourceId) {
-            this.moveTerminal(this._dragSourceId, targetId, side);
-          }
-          this._dragSourceId = null;
-        },
-      );
+    setupDragHandler(handle, {
+      guard: () => this.terminals.size >= 2,
+      stopPropagation: true,
+      cursor: 'grabbing',
+      bodyClass: 'dragging',
+      onStart: () => {
+        this._dragSourceId = sourceNode.terminal.id;
+        sourceNode.element.classList.add('dragging');
+        this._drop.create();
+      },
+      onMove: (ev) => this._drop.update(ev.clientX, ev.clientY, this.terminals, this._dragSourceId),
+      onEnd: () => {
+        sourceNode.element.classList.remove('dragging');
+        const { targetId, side } = this._drop;
+        this._drop.remove();
+        if (targetId && side && targetId !== this._dragSourceId) {
+          this.moveTerminal(this._dragSourceId, targetId, side);
+        }
+        this._dragSourceId = null;
+      },
     });
   }
 

--- a/src/utils/drag-helpers.js
+++ b/src/utils/drag-helpers.js
@@ -97,22 +97,44 @@ export function addListener(target, type, handler, options) {
 }
 
 /**
+ * Attach a mousedown → trackMouse drag handler to an element.
+ * Generalises the repeated mousedown + preventDefault + optional stopPropagation
+ * + capture-state + trackMouse + cleanup boilerplate.
+ *
+ * @param {HTMLElement} element — the element to listen on
+ * @param {{
+ *   cursor?: string,
+ *   onStart?: (e: MouseEvent) => unknown,
+ *   onMove: (e: MouseEvent, ctx: unknown) => void,
+ *   onEnd?: (ctx: unknown) => void,
+ *   guard?: (e: MouseEvent) => boolean,
+ *   stopPropagation?: boolean,
+ *   bodyClass?: string
+ * }} opts
+ */
+export function setupDragHandler(element, { cursor = 'default', onStart, onMove, onEnd, guard, stopPropagation = false, bodyClass = 'resizing' }) {
+  element.addEventListener('mousedown', (e) => {
+    if (guard && !guard(e)) return;
+    e.preventDefault();
+    if (stopPropagation) e.stopPropagation();
+    const ctx = onStart ? onStart(e) : undefined;
+    trackMouse(cursor,
+      (ev) => onMove(ev, ctx),
+      () => { if (onEnd) onEnd(ctx); },
+      { bodyClass },
+    );
+  });
+}
+
+/**
  * Attach a mousedown → trackMouse resize handler to a handle element.
- * Eliminates the repeated mousedown + preventDefault + capture-state + trackMouse
- * boilerplate found in panel/terminal/console resize code.
+ * Convenience wrapper around setupDragHandler for resize interactions.
  *
  * @param {HTMLElement} handle  — the resize handle element
  * @param {{ cursor: string, onStart?: (e: MouseEvent) => unknown, onMove: (e: MouseEvent, ctx: unknown) => void, onDone?: (ctx: unknown) => void }} opts
  */
 export function setupResizeHandler(handle, { cursor, onStart, onMove, onDone }) {
-  handle.addEventListener('mousedown', (e) => {
-    e.preventDefault();
-    const ctx = onStart ? onStart(e) : undefined;
-    trackMouse(cursor,
-      (ev) => onMove(ev, ctx),
-      () => { if (onDone) onDone(ctx); },
-    );
-  });
+  setupDragHandler(handle, { cursor, onStart, onMove, onEnd: onDone });
 }
 
 /**


### PR DESCRIPTION
## Summary

- Created `setupDragHandler` in `src/utils/drag-helpers.js` — a general-purpose helper that encapsulates the repeated mousedown + `preventDefault` + optional `stopPropagation` + capture-state + `trackMouse` + cleanup boilerplate
- Refactored `setupResizeHandler` to be a thin convenience wrapper delegating to `setupDragHandler`
- Replaced the raw `addEventListener('mousedown')` + `trackMouse` pattern in `TerminalPanel.setupDrag` (`src/components/terminal-panel.js`) with a `setupDragHandler` call

The helper accepts `{ guard, onStart, onMove, onEnd, cursor, stopPropagation, bodyClass }` making it flexible enough for both resize and drag-to-move interactions.

Closes #403

## Test plan

- [x] `node build.js` passes
- [x] `npx vitest run` — 25 test files, 391 tests all passing
- [ ] Manual: verify terminal panel drag-to-move still works
- [ ] Manual: verify panel resize (workspace, terminal splits, webview console) still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)