### PR TITLE
refactor: deduplicate select factory, visibility toggling and drop indicator

### DIFF
--- a/src/utils/dom.js
+++ b/src/utils/dom.js
@@ -2,7 +2,7 @@
  * Core DOM utilities.
  *
  * This module keeps only the essential DOM factories:
- *   _el, createActionButton, renderButtonBar, renderList
+ *   _el, _vis, createActionButton, renderButtonBar, renderList
  *
  * The following helpers have been extracted to dedicated modules — import
  * them directly from there instead of going through this file:
@@ -121,6 +121,16 @@ export function renderButtonBar({ containerClass, configs, handlers }) {
  * @param {Array<unknown>} items
  * @param {(item: unknown, index: number) => HTMLElement|null} renderItem
  */
+/**
+ * Toggle element visibility by setting display style.
+ * @param {HTMLElement} el
+ * @param {boolean} show
+ * @param {string} [display=''] - Display value when visible (e.g. 'flex', 'block').
+ */
+export function _vis(el, show, display = '') {
+  el.style.display = show ? display : 'none';
+}
+
 export function renderList(container, items, renderItem) {
   container.replaceChildren();
   for (let i = 0; i < items.length; i++) {

--- a/src/utils/flow-category-renderer.js
+++ b/src/utils/flow-category-renderer.js
@@ -99,10 +99,15 @@ function _setupCategoryDropZone(items, catId, onDropFlow, dragState) {
 
 // --- Drop indicator helpers ---
 
+/** Return all direct .flow-card children of the given container. */
+function _getFlowCards(container) {
+  return [...container.querySelectorAll(':scope > .flow-card')];
+}
+
 function _updateDropIndicator(container, clientY) {
   clearIndicators(container, '.flow-drop-indicator');
 
-  const cards = [...container.querySelectorAll(':scope > .flow-card')];
+  const cards = _getFlowCards(container);
   if (cards.length === 0) return;
 
   const idx = computeInsertionIndex(cards, clientY, 'y');
@@ -117,6 +122,5 @@ function _updateDropIndicator(container, clientY) {
 }
 
 function _getDropIndex(container, clientY) {
-  const cards = [...container.querySelectorAll(':scope > .flow-card')];
-  return computeInsertionIndex(cards, clientY, 'y');
+  return computeInsertionIndex(_getFlowCards(container), clientY, 'y');
 }

--- a/src/utils/flow-modal-helpers.js
+++ b/src/utils/flow-modal-helpers.js
@@ -1,4 +1,5 @@
 import { _el } from './flow-dom.js';
+import { _vis as _visGeneric } from './dom.js';
 import { SCHEDULE_TYPE_CONFIG } from './flow-schedule-helpers.js';
 import { AGENT_OPTIONS } from '../../shared/agent-registry.js';
 
@@ -30,8 +31,9 @@ export const SKIP_PERM_CONFIG = {
 
 // --- Pure helpers ---
 
+/** Flow-specific visibility toggle (uses 'flex' display). */
 export function _vis(el, show) {
-  el.style.display = show ? 'flex' : 'none';
+  _visGeneric(el, show, 'flex');
 }
 
 /**

--- a/src/utils/form-helpers.js
+++ b/src/utils/form-helpers.js
@@ -8,6 +8,30 @@ import { _el } from './dom.js';
 import { onClickStopped, onKeyAction } from './event-helpers.js';
 
 /**
+ * Create a <select> element from an array of option values.
+ *
+ * Each entry in `items` can be a string (used as both value and label)
+ * or an `{ value, label, disabled, selected }` descriptor.
+ *
+ * @param {Array<string|{ value: string, label?: string, disabled?: boolean, selected?: boolean }>} items
+ * @param {{ className?: string, selected?: string }} [opts]
+ * @returns {HTMLSelectElement}
+ */
+export function buildSelect(items, { className, selected } = {}) {
+  const select = _el('select', { className: className || '' });
+  for (const item of items) {
+    const isObj = typeof item === 'object';
+    const val = isObj ? item.value : item;
+    const label = isObj && item.label ? item.label : val;
+    const opt = _el('option', { value: val, textContent: label });
+    if (isObj && item.disabled) opt.disabled = true;
+    if ((isObj && item.selected) || val === selected) opt.selected = true;
+    select.appendChild(opt);
+  }
+  return select;
+}
+
+/**
  * Create a guard that ensures `fn` is called at most once.
  * Subsequent calls are silently ignored.
  * @param {(...args: unknown[]) => void} fn

--- a/src/utils/git-dom.js
+++ b/src/utils/git-dom.js
@@ -5,4 +5,4 @@
  * DOM primitives through this facade instead of reaching into the core dom.js
  * hub directly.  This reduces dom.js fan-in.
  */
-export { _el, createActionButton } from './dom.js';
+export { _el, createActionButton, _vis } from './dom.js';

--- a/src/utils/worktree-dialog.js
+++ b/src/utils/worktree-dialog.js
@@ -9,10 +9,11 @@
  * Returns a Promise<{ branch, createBranch, targetPath } | null>.
  */
 
-import { _el, createActionButton } from './git-dom.js';
+import { _el, createActionButton, _vis } from './git-dom.js';
 import { createDialogBase } from './dom-dialogs.js';
 import { onKeyAction } from './event-helpers.js';
 import { sanitizeSegment } from '../../shared/string-utils.js';
+import { buildSelect } from './form-helpers.js';
 
 /** Build the default target path for a worktree given the host repo cwd. */
 function defaultWorktreePath(repoCwd, branch) {
@@ -29,22 +30,21 @@ function buildBranchInput() {
 
 /** Build the base-branch <select> for "new branch" mode. */
 function buildBaseSelect(allBranches, currentBranch) {
-  const baseSelect = _el('select', { className: 'prompt-dialog-input worktree-dialog-select' });
-  for (const b of allBranches) {
-    const opt = _el('option', null, b);
-    opt.value = b;
-    if (b === currentBranch) opt.selected = true;
-    baseSelect.appendChild(opt);
-  }
-  return baseSelect;
+  return buildSelect(allBranches, {
+    className: 'prompt-dialog-input worktree-dialog-select',
+    selected: currentBranch,
+  });
 }
 
 /** Build the existing-branch <select> for "existing branch" mode. */
 function buildExistingSelect(existingBranches) {
-  const existingSelect = _el('select', { className: 'prompt-dialog-input worktree-dialog-select' });
-  for (const b of existingBranches) existingSelect.appendChild(_el('option', null, b));
-  if (!existingBranches.length) existingSelect.appendChild(_el('option', { disabled: true }, 'No other branches'));
-  existingSelect.style.display = 'none';
+  const items = existingBranches.length
+    ? existingBranches
+    : [{ value: '', label: 'No other branches', disabled: true }];
+  const existingSelect = buildSelect(items, {
+    className: 'prompt-dialog-input worktree-dialog-select',
+  });
+  _vis(existingSelect, false);
   return existingSelect;
 }
 
@@ -72,10 +72,10 @@ function buildActionButtons(cancel, confirm) {
 /** Apply visibility for the given mode to the form elements. */
 function applyModeVisibility(mode, { newInput, baseSelect, baseLabel, existingSelect }) {
   const isNew = mode === 'new';
-  newInput.style.display = isNew ? '' : 'none';
-  baseSelect.style.display = isNew ? '' : 'none';
-  baseLabel.style.display = isNew ? '' : 'none';
-  existingSelect.style.display = isNew ? 'none' : '';
+  _vis(newInput, isNew);
+  _vis(baseSelect, isNew);
+  _vis(baseLabel, isNew);
+  _vis(existingSelect, !isNew);
   return isNew;
 }
 


### PR DESCRIPTION
## Summary

- **Select factory**: Extracted `buildSelect()` into `form-helpers.js` and replaced hand-rolled `<select>` construction in `worktree-dialog.js` (`buildBaseSelect` / `buildExistingSelect`)
- **Visibility toggling**: Moved `_vis()` to `dom.js` as a generic helper with configurable display value; `flow-modal-helpers.js` wraps it with `'flex'`; `worktree-dialog.js` now uses `_vis()` via `git-dom.js` instead of inline `style.display` assignments
- **Drop indicator**: Extracted `_getFlowCards(container)` in `flow-category-renderer.js` to deduplicate the `querySelectorAll(':scope > .flow-card')` call shared by `_updateDropIndicator` and `_getDropIndex`

Closes #406

## Test plan

- [x] `node build.js` passes
- [x] `npx vitest run` — 25 test files, 391 tests pass
- [ ] Manual: verify worktree dialog mode switching (new/existing) shows/hides fields correctly
- [ ] Manual: verify flow category drag-drop indicator appears at correct position

🤖 Generated with [Claude Code](https://claude.com/claude-code)