### PR TITLE
refactor: deduplicate button bar and sanitization patterns

### DIFF
--- a/main/config-helpers.js
+++ b/main/config-helpers.js
@@ -4,12 +4,9 @@
  */
 
 const { buildTimestampedRecord } = require('./record-helpers');
+const { sanitizeName } = require('../shared/string-utils');
 
 const DEFAULT_META = { defaultConfig: null };
-
-function sanitizeName(name) {
-  return name.replace(/[^a-zA-Z0-9_\- ]/g, '_').substring(0, 64);
-}
 
 function buildConfigRecord(name, data, existing, now = new Date().toISOString()) {
   return buildTimestampedRecord({ ...data, name }, existing, now);

--- a/shared/string-utils.js
+++ b/shared/string-utils.js
@@ -1,0 +1,30 @@
+/**
+ * Shared string sanitization utilities used by both main and renderer processes.
+ * CommonJS format so main/ can require() it directly;
+ * esbuild resolves it for the renderer bundle.
+ */
+
+/**
+ * Sanitize a name by replacing non-alphanumeric characters (except dash,
+ * underscore, and space) with underscores, then truncating to 64 characters.
+ * Used for config names and similar identifiers.
+ * @param {string} name
+ * @returns {string}
+ */
+function sanitizeName(name) {
+  return name.replace(/[^a-zA-Z0-9_\- ]/g, '_').substring(0, 64);
+}
+
+/**
+ * Sanitize a string into a filesystem-safe path segment by replacing
+ * non-alphanumeric characters (except dot, underscore, dash) with hyphens
+ * and trimming leading/trailing hyphens.
+ * Used for branch names and worktree paths.
+ * @param {string} name
+ * @returns {string}
+ */
+function sanitizeSegment(name) {
+  return name.replace(/[^a-zA-Z0-9._-]+/g, '-').replace(/^-+|-+$/g, '');
+}
+
+module.exports = { sanitizeName, sanitizeSegment };

--- a/src/components/flow-view.js
+++ b/src/components/flow-view.js
@@ -5,7 +5,7 @@ import {
   getFlowsForCategory, getUncategorizedFlows,
   removeFlowFromOrder, moveFlowInOrder,
   createCategoryGroup, createFlowCard,
-  _el, renderButtonBar,
+  _el, buildDomainButtonBar,
 } from '../utils/flow-view-subsystem.js';
 import {
   addCategory, renameCategoryInline, deleteCategory,
@@ -87,12 +87,7 @@ export class FlowView extends ComponentBase {
     header.appendChild(_el('h2', 'flow-title', 'Flows'));
 
     const headerHandlers = { addCategory: () => this._addCategory(), addFlow: () => this._openModal() };
-    const configs = HEADER_BUTTONS.map(({ label, action }) => ({
-      label,
-      cls: 'flow-add-btn',
-      action,
-    }));
-    const headerRight = renderButtonBar({ containerClass: 'flow-header-right', configs, handlers: headerHandlers });
+    const headerRight = buildDomainButtonBar('flow-add-btn', 'flow-header-right', HEADER_BUTTONS, headerHandlers);
     headerRight.style.display = 'flex';
     headerRight.style.gap = '8px';
 

--- a/src/utils/flow-view-helpers.js
+++ b/src/utils/flow-view-helpers.js
@@ -32,8 +32,8 @@ export const UNCATEGORIZED = '_uncategorized';
 
 // --- Header button configuration ---
 export const HEADER_BUTTONS = [
-  { label: '+ Catégorie', action: 'addCategory' },
-  { label: '+ Nouveau', action: 'addFlow' },
+  { text: '+ Catégorie', action: 'addCategory' },
+  { text: '+ Nouveau', action: 'addFlow' },
 ];
 
 // --- Category action button configuration ---

--- a/src/utils/flow-view-subsystem.js
+++ b/src/utils/flow-view-subsystem.js
@@ -24,7 +24,7 @@ export { createCategoryGroup } from './flow-category-renderer.js';
 export { createFlowCard } from './flow-card-setup.js';
 
 // ── flow-dom (DOM primitives for the flow domain) ───────────────────
-export { _el, renderButtonBar } from './flow-dom.js';
+export { _el, buildDomainButtonBar } from './flow-dom.js';
 
 // ── form-helpers (inline rename used by category management) ────────
 export { startInlineRename } from './form-helpers.js';

--- a/src/utils/worktree-dialog.js
+++ b/src/utils/worktree-dialog.js
@@ -12,11 +12,7 @@
 import { _el, createActionButton } from './git-dom.js';
 import { createDialogBase } from './dom-dialogs.js';
 import { onKeyAction } from './event-helpers.js';
-
-/** Sanitize a branch name into a filesystem-safe segment. */
-function sanitizeSegment(name) {
-  return name.replace(/[^a-zA-Z0-9._-]+/g, '-').replace(/^-+|-+$/g, '');
-}
+import { sanitizeSegment } from '../../shared/string-utils.js';
 
 /** Build the default target path for a worktree given the host repo cwd. */
 function defaultWorktreePath(repoCwd, branch) {


### PR DESCRIPTION
## Summary

- **Sanitization dedup**: Extracted `sanitizeName` and `sanitizeSegment` into `shared/string-utils.js` (CommonJS, consumed by both `main/config-helpers.js` via `require()` and `src/utils/worktree-dialog.js` via ESM import through esbuild).
- **Button bar dedup**: `flow-view.js` now uses `buildDomainButtonBar` from the flow-dom facade instead of manually mapping HEADER_BUTTONS and calling `renderButtonBar`. Normalized `HEADER_BUTTONS` to `{ text, action }` format for consistency with `buildDomainButtonBar`'s API.

Closes #415

## Test plan

- [x] `node build.js` passes
- [x] `npx vitest run` — 391 tests pass (25 test files)
- [x] Existing `sanitizeName` tests in `tests/main/config-helpers.test.js` still pass (they import from `config-helpers.js` which now delegates to `shared/string-utils.js`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)