### PR TITLE
refactor: split 5 large component classes into focused modules

### DIFF
--- a/src/components/file-tree.js
+++ b/src/components/file-tree.js
@@ -58,7 +58,7 @@ export class FileTree extends ComponentBase {
   }
 
   async setTerminalRoot(termId, dirPath) {
-    await doSetTerminalRoot(this, termId, dirPath, fsApi.watch, (c) => this.refreshSection(c));
+    await doSetTerminalRoot(this, termId, dirPath, fsApi.watch, (c) => this.refreshSection(c), fsApi.unwatch);
   }
 
   removeTerminal(termId) { doRemoveTerminal(this, termId, fsApi.unwatch); }

--- a/src/components/file-tree.js
+++ b/src/components/file-tree.js
@@ -2,15 +2,18 @@ import { _el } from '../utils/file-dom.js';
 import { registerComponent } from '../utils/component-registry.js';
 import { ComponentBase } from '../utils/component-base.js';
 import {
-  CHEVRON_EXPANDED, CHEVRON_COLLAPSED,
-  resolveWatchCwd,
-  renderDirEntry, renderFileEntry,
   setupDropZone, handleFileDrop,
   promptRename as doPromptRename,
   promptNewEntry as doPromptNewEntry,
-  listenForChanges, startWatch, stopWatch,
+  listenForChanges, stopWatch,
 } from '../utils/file-tree-subsystem.js';
 import { rebuildSectionDOM } from '../utils/file-tree-section-dom.js';
+import {
+  renderDir as doRenderDir,
+  setTerminalRoot as doSetTerminalRoot,
+  removeTerminal as doRemoveTerminal,
+  refreshSection as doRefreshSection,
+} from '../utils/file-tree-dir-ops.js';
 import { fsApi, shellApi, clipboardApi } from '../utils/file-tree-services.js';
 
 export class FileTree extends ComponentBase {
@@ -30,18 +33,13 @@ export class FileTree extends ComponentBase {
   }
 
   _initApi() {
-    // Injected API methods for file-tree-drop and file-tree-context-menu utils
     this._contextMenuApi = {
-      clipboardWrite: clipboardApi.write,
-      fsCopy: fsApi.copy,
-      showInFolder: shellApi.showInFolder,
-      fsTrash: fsApi.trash,
+      clipboardWrite: clipboardApi.write, fsCopy: fsApi.copy,
+      showInFolder: shellApi.showInFolder, fsTrash: fsApi.trash,
     };
     this._dropApi = {
-      copyTo: fsApi.copyTo,
-      rename: fsApi.rename,
-      mkdir: fsApi.mkdir,
-      writefile: fsApi.writefile,
+      copyTo: fsApi.copyTo, rename: fsApi.rename,
+      mkdir: fsApi.mkdir, writefile: fsApi.writefile,
     };
   }
 
@@ -49,7 +47,6 @@ export class FileTree extends ComponentBase {
     this.container.replaceChildren();
     this.treeEl = _el('div', { className: 'file-tree-content' });
     this.container.appendChild(this.treeEl);
-
     this._setupDropZone(this.container, () => {
       const firstCwd = this.sections.keys().next().value;
       return firstCwd || null;
@@ -61,84 +58,14 @@ export class FileTree extends ComponentBase {
   }
 
   async setTerminalRoot(termId, dirPath) {
-    const prevCwd = this.termCwds.get(termId);
-    if (prevCwd === dirPath) return;
-
-    if (prevCwd) {
-      this._removeTermFromSection(termId, prevCwd);
-    }
-
-    this.termCwds.set(termId, dirPath);
-
-    const existing = this.sections.get(dirPath);
-    if (existing) {
-      existing.termIds.add(termId);
-      return;
-    }
-
-    const sectionEl = _el('div', { className: 'file-tree-section' });
-    const expandedDirs = new Set([dirPath]);
-    const watchId = startWatch(dirPath, { watch: fsApi.watch });
-    this.sections.set(dirPath, { termIds: new Set([termId]), sectionEl, expandedDirs, watchId });
-    this.treeEl.appendChild(sectionEl);
-    await this.refreshSection(dirPath);
+    await doSetTerminalRoot(this, termId, dirPath, fsApi.watch, (c) => this.refreshSection(c));
   }
 
-  removeTerminal(termId) {
-    const cwd = this.termCwds.get(termId);
-    if (!cwd) return;
-    this.termCwds.delete(termId);
-    this._removeTermFromSection(termId, cwd);
-  }
-
-  _removeTermFromSection(termId, cwd) {
-    const section = this.sections.get(cwd);
-    if (!section) return;
-
-    section.termIds.delete(termId);
-
-    if (section.termIds.size === 0) {
-      stopWatch(section.watchId, { unwatch: fsApi.unwatch });
-      section.sectionEl.remove();
-      this.sections.delete(cwd);
-    }
-  }
+  removeTerminal(termId) { doRemoveTerminal(this, termId, fsApi.unwatch); }
 
   async refreshSection(watchIdOrCwd) {
-    const cwd = resolveWatchCwd(watchIdOrCwd);
-    const section = this.sections.get(cwd);
-    if (!section) return;
-
-    if (section._refreshing) {
-      section._pendingRefresh = true;
-      return;
-    }
-    section._refreshing = true;
-
-    const contentEl = this._rebuildSectionDOM(section, cwd);
-
-    try {
-      await this.renderDir(cwd, contentEl, 0, section.expandedDirs);
-    } finally {
-      section._refreshing = false;
-      if (section._pendingRefresh) {
-        section._pendingRefresh = false;
-        this.refreshSection(cwd).catch(() => {});
-      }
-    }
+    await doRefreshSection(this, watchIdOrCwd, (dp, pe, d, ed) => this.renderDir(dp, pe, d, ed));
   }
-
-  _rebuildSectionDOM(section, cwd) {
-    return rebuildSectionDOM(section, cwd, {
-      setupDropZone: (el, targetDir) => this._setupDropZone(el, targetDir),
-      promptNewEntry: (dirPath, cEl, depth, eDirs, type) => this.promptNewEntry(dirPath, cEl, depth, eDirs, type),
-      promptRename: (path, nameEl) => this.promptRename(path, nameEl),
-      refreshSection: (c) => this.refreshSection(c),
-      contextMenuApi: this._contextMenuApi,
-    });
-  }
-
-  // --- Context menu helpers ---
 
   findRootCwd(entryPath) {
     for (const [cwd] of this.sections) {
@@ -147,95 +74,22 @@ export class FileTree extends ComponentBase {
     return '';
   }
 
-  // --- Rename inline input ---
-
-  promptRename(entryPath, nameEl) {
-    doPromptRename(entryPath, nameEl, { rename: this._dropApi.rename });
-  }
-
-  // --- New File / Folder inline input ---
-
-  promptNewEntry(dirPath, parentContentEl, depth, expandedDirs, type) {
-    doPromptNewEntry(dirPath, parentContentEl, depth, expandedDirs, type, { mkdir: this._dropApi.mkdir, writefile: this._dropApi.writefile });
-  }
-
-  // --- Drag & Drop ---
+  promptRename(entryPath, nameEl) { doPromptRename(entryPath, nameEl, { rename: this._dropApi.rename }); }
+  promptNewEntry(dirPath, parentContentEl, depth, expandedDirs, type) { doPromptNewEntry(dirPath, parentContentEl, depth, expandedDirs, type, { mkdir: this._dropApi.mkdir, writefile: this._dropApi.writefile }); }
 
   _setupDropZone(el, getTargetDir) {
     const api = this._dropApi;
     setupDropZone(el, getTargetDir, (files, destDir) => handleFileDrop(files, destDir, { copyTo: api.copyTo }));
   }
 
-  // --- Directory expand/collapse ---
-
-  async _expandDir(dirPath, childContainer, chevron, depth, expandedDirs) {
-    expandedDirs.add(dirPath);
-    chevron.textContent = CHEVRON_EXPANDED;
-    chevron.classList.add('expanded');
-    await this.renderDir(dirPath, childContainer, depth + 1, expandedDirs);
-  }
-
-  _collapseDir(dirPath, childContainer, chevron, expandedDirs) {
-    expandedDirs.delete(dirPath);
-    childContainer.replaceChildren();
-    chevron.textContent = CHEVRON_COLLAPSED;
-    chevron.classList.remove('expanded');
-  }
-
-  // --- Render directory entries ---
-
-  _getDirEntryCallbacks(expandedDirs) {
-    return {
-      setupDropZone: (el, targetDir) => this._setupDropZone(el, targetDir),
-      expandDir: (dirPath, childContainer, chevron, depth, eDirs) =>
-        this._expandDir(dirPath, childContainer, chevron, depth, eDirs),
-      collapseDir: (dirPath, childContainer, chevron, eDirs) =>
-        this._collapseDir(dirPath, childContainer, chevron, eDirs),
-      renderDir: (dirPath, parentEl, depth, eDirs) =>
-        this.renderDir(dirPath, parentEl, depth, eDirs),
-      findRootCwd: (entryPath) => this.findRootCwd(entryPath),
-      promptRename: (path, nameEl) => this.promptRename(path, nameEl),
-      promptNewEntry: (dirPath, cEl, depth, eDirs, type) =>
-        this.promptNewEntry(dirPath, cEl, depth, eDirs, type),
-      contextMenuApi: this._contextMenuApi,
-    };
-  }
-
-  async _renderDirEntry(entry, parentEl, depth, expandedDirs) {
-    await renderDirEntry(entry, parentEl, depth, expandedDirs, this._getDirEntryCallbacks(expandedDirs));
-  }
-
-  _renderFileEntry(entry, parentEl, depth) {
-    const self = this;
-    const activeRowRef = {
-      get current() { return self._activeRow; },
-      set current(v) { self._activeRow = v; },
-    };
-    renderFileEntry(entry, parentEl, depth, {
-      activeRowRef,
-      findRootCwd: (entryPath) => this.findRootCwd(entryPath),
-      promptRename: (path, nameEl) => this.promptRename(path, nameEl),
-      contextMenuApi: this._contextMenuApi,
-    });
-  }
-
   async renderDir(dirPath, parentEl, depth, expandedDirs) {
-    const entries = await fsApi.readdir(dirPath);
-    for (const entry of entries) {
-      if (entry.isDirectory) {
-        await this._renderDirEntry(entry, parentEl, depth, expandedDirs);
-      } else {
-        this._renderFileEntry(entry, parentEl, depth);
-      }
-    }
+    await doRenderDir(this, dirPath, parentEl, depth, expandedDirs, fsApi.readdir);
   }
 
   dispose() {
     super.dispose();
     const unwatchApi = { unwatch: fsApi.unwatch };
-    for (const [, section] of this.sections) {
-      stopWatch(section.watchId, unwatchApi);
-    }
+    for (const [, section] of this.sections) stopWatch(section.watchId, unwatchApi);
     this.sections.clear();
     this.termCwds.clear();
   }

--- a/src/components/file-viewer.js
+++ b/src/components/file-viewer.js
@@ -1,28 +1,26 @@
 import { emitLayoutChanged } from '../utils/workspace-events.js';
-import { _el } from '../utils/file-dom.js';
-import { EMPTY_MESSAGE, MODE_CONFIG, ALL_STATIC_ELEMENTS, MODE_ACTIVATE, pinnedFiles } from '../utils/editor-helpers.js';
-import {
-  updateLineNumbers, updateHighlight, updateStatusBar, saveFile,
-  initCodeEditor,
-  createMarkdownPreviewDOM, updatePreviewStatusBar,
-  renderTabs as renderTabsHelper,
-  renderModeBar,
-  setupFileViewerListeners,
-} from '../utils/file-viewer-subsystem.js';
+import { pinnedFiles } from '../utils/editor-helpers.js';
+import { renderModeBar, setupFileViewerListeners } from '../utils/file-viewer-subsystem.js';
 import {
   openFileEntry, isModified as isFileModified, isPinned as isFilePinned,
   togglePin as toggleFilePin, isMarkdown as isFileMarkdown, closeFileEntry,
 } from '../utils/file-viewer-files.js';
+import {
+  renderFileViewerShell, renderEditor as doRenderEditor,
+  showEmpty as doShowEmpty,
+  updateLineNumbers as doUpdateLineNumbers,
+  updateHighlight as doUpdateHighlight,
+  updateStatusBar as doUpdateStatusBar,
+  saveActive as doSaveActive,
+  switchMode as doSwitchMode,
+  renderTabs as doRenderTabs,
+  loadPinnedFiles as doLoadPinnedFiles,
+} from '../utils/file-viewer-editor.js';
 import { registerComponent } from '../utils/component-registry.js';
 import { ComponentBase } from '../utils/component-base.js';
 import fsApi from '../services/fs-api.js';
 
 export class FileViewer extends ComponentBase {
-  /**
-   * @param {HTMLElement} container
-   * @param {() => boolean} [isActive]
-   * @param {{ WebviewManager?: Function, GitChangesView?: Function }} [components]
-   */
   constructor(container, isActive, components = {}) {
     super(container);
     this.isActive = isActive || (() => true);
@@ -34,106 +32,42 @@ export class FileViewer extends ComponentBase {
   }
 
   _initState() {
-    this.openFiles = new Map(); // path -> { name, content, savedContent, lang }
-    this.activeFile = null;
-    this.editorEl = null;
-    this.lineNumbers = null;
-    this.highlightLayer = null;
-    this.mode = 'files'; // 'files' | 'git' | webview id
+    this.openFiles = new Map();
+    this.activeFile = this.editorEl = this.lineNumbers = this.highlightLayer = null;
+    this.mode = 'files';
     this.gitChanges = null;
   }
 
   _initWebviewManager() {
     const { WebviewManager } = this._components;
-    this._webviewMgr = new WebviewManager(
-      this.container, this.statusBar,
-      (mode) => this.switchMode(mode),
-      () => this._renderModeBar(),
-    );
+    this._webviewMgr = new WebviewManager(this.container, this.statusBar, (m) => this.switchMode(m), () => this._renderModeBar());
     this._renderModeBar();
   }
 
   _initBusListeners() {
-    const busListeners = setupFileViewerListeners(
+    const unsubs = setupFileViewerListeners(
       { isActive: () => this.isActive() },
-      {
-        switchMode: (m) => this.switchMode(m),
-        openFile: (p, n) => this.openFile(p, n),
-        gitChanges: this.gitChanges,
-        getMode: () => this.mode,
-        loadPinnedFiles: () => this.loadPinnedFiles(),
-      },
+      { switchMode: (m) => this.switchMode(m), openFile: (p, n) => this.openFile(p, n), gitChanges: this.gitChanges, getMode: () => this.mode, loadPinnedFiles: () => this.loadPinnedFiles() },
     );
-    for (const unsub of busListeners) this._track(unsub);
+    for (const unsub of unsubs) this._track(unsub);
   }
 
   static get pinnedFiles() { return pinnedFiles; }
 
-  render() {
-    this.container.replaceChildren();
-
-    this.modeBar = _el('div', 'file-viewer-mode-bar');
-    this.container.appendChild(this.modeBar);
-
-    this.tabsBar = _el('div', 'file-viewer-tabs');
-    this.container.appendChild(this.tabsBar);
-
-    this.breadcrumb = _el('div', 'file-viewer-breadcrumb');
-    this.container.appendChild(this.breadcrumb);
-
-    this.editorWrapper = _el('div', 'editor-wrapper');
-    this.container.appendChild(this.editorWrapper);
-
-    this.gitViewEl = _el('div', 'git-changes-view');
-    this.gitViewEl.style.display = 'none';
-    this.container.appendChild(this.gitViewEl);
-    const { GitChangesView } = this._components;
-    this.gitChanges = new GitChangesView(this.gitViewEl);
-
-    this.statusBar = _el('div', 'editor-status-bar');
-    this.container.appendChild(this.statusBar);
-
-    this.showEmpty();
-  }
-
-  async loadPinnedFiles() {
-    for (const [path, info] of pinnedFiles) {
-      if (!this.openFiles.has(path)) {
-        await this.openFile(path, info.name);
-      }
-    }
-  }
+  render() { Object.assign(this, renderFileViewerShell(this.container, this._components)); this.showEmpty(); }
+  async loadPinnedFiles() { await doLoadPinnedFiles(this); }
 
   isPinned(filePath) { return isFilePinned(filePath); }
+  togglePin(filePath) { toggleFilePin(this.openFiles, filePath); this.renderTabs(); }
+  isModified(filePath) { return isFileModified(this.openFiles, filePath); }
+  isMarkdown(filePath) { return isFileMarkdown(this.openFiles, filePath); }
 
-  togglePin(filePath) {
-    toggleFilePin(this.openFiles, filePath);
-    this.renderTabs();
-  }
-
-  _setModeVisibility(mode) {
-    const visible = new Set(MODE_CONFIG[mode]?.elements || []);
-    for (const key of ALL_STATIC_ELEMENTS) {
-      this[key].style.display = visible.has(key) ? '' : 'none';
-    }
-    this._webviewMgr.setModeVisibility(mode);
-  }
-
-  switchMode(mode) {
-    this.mode = mode;
-    this._setModeVisibility(mode);
-    this._renderModeBar();
-    MODE_ACTIVATE[mode]?.(this);
-  }
-
-  // ===== Files Mode =====
+  switchMode(mode) { doSwitchMode(this, mode, this._webviewMgr, () => this._renderModeBar()); }
 
   async openFile(filePath, fileName) {
     await openFileEntry(this.openFiles, filePath, fileName, { readfile: fsApi.readfile });
     this.setActiveTab(filePath);
   }
-
-  isMarkdown(filePath) { return isFileMarkdown(this.openFiles, filePath); }
 
   toggleViewMode(filePath) {
     const file = this.openFiles.get(filePath);
@@ -143,96 +77,26 @@ export class FileViewer extends ComponentBase {
     this.renderTabs();
   }
 
-  setActiveTab(filePath) {
-    this.activeFile = filePath;
-    this.renderTabs();
-    this.renderEditor();
-  }
-
-  isModified(filePath) { return isFileModified(this.openFiles, filePath); }
-
-  renderTabs() {
-    renderTabsHelper(this.tabsBar, this.openFiles, this.activeFile,
-      (p) => this.isPinned(p),
-      (p) => this.isModified(p),
-      {
-        onClose: (p) => this.closeFile(p),
-        onActivate: (p) => this.setActiveTab(p),
-        onTogglePin: (p) => this.togglePin(p),
-        isMarkdown: (p) => this.isMarkdown(p),
-        getViewMode: (p) => this.openFiles.get(p)?.viewMode,
-        onToggleViewMode: (p) => this.toggleViewMode(p),
-      },
-    );
-  }
+  setActiveTab(filePath) { this.activeFile = filePath; this.renderTabs(); this.renderEditor(); }
+  renderTabs() { doRenderTabs(this); }
 
   renderEditor() {
-    this.editorWrapper.replaceChildren();
-    this.statusBar.replaceChildren();
-
-    const file = this.openFiles.get(this.activeFile);
-    if (!file) { this.showEmpty(); return; }
-
-    this.breadcrumb.textContent = this.activeFile;
-
-    if (file.error) {
-      this.editorWrapper.replaceChildren(_el('div', 'file-viewer-error', file.error));
-      return;
-    }
-
-    if (file.lang === 'markdown' && file.viewMode === 'preview') {
-      this._renderMarkdownPreview(file);
-      return;
-    }
-
-    this._renderCodeEditor(file);
-  }
-
-  _renderMarkdownPreview(file) {
-    this.lineNumbers = null;
-    this.highlightLayer = null;
-    this.editorEl = null;
-    createMarkdownPreviewDOM(this.editorWrapper, file);
-    updatePreviewStatusBar(this.statusBar, file);
-  }
-
-  _renderCodeEditor(file) {
-    const { lineNumbers, highlightLayer, editorEl } = initCodeEditor(this.editorWrapper, file, {
+    const r = doRenderEditor(this, {
       onUpdate: () => { this.updateLineNumbers(); this.updateHighlight(); this.renderTabs(); this.updateStatusBar(); },
       onSave: () => this.saveActive(),
     });
-    this.lineNumbers = lineNumbers;
-    this.highlightLayer = highlightLayer;
-    this.editorEl = editorEl;
-    this.updateStatusBar();
-    this.editorEl.focus();
+    this.lineNumbers = r.lineNumbers;
+    this.highlightLayer = r.highlightLayer;
+    this.editorEl = r.editorEl;
   }
 
-  updateLineNumbers() {
-    updateLineNumbers(this.lineNumbers, this.editorEl);
-  }
-
-  updateHighlight() {
-    const file = this.openFiles.get(this.activeFile);
-    if (!file) return;
-    updateHighlight(this.highlightLayer, this.editorEl, file.lang);
-  }
-
-  updateStatusBar() {
-    if (!this.statusBar || !this.editorEl) return;
-    const file = this.openFiles.get(this.activeFile);
-    if (!file) { this.statusBar.replaceChildren(); return; }
-    updateStatusBar(this.statusBar, this.editorEl, file);
-  }
+  updateLineNumbers() { doUpdateLineNumbers(this.lineNumbers, this.editorEl); }
+  updateHighlight() { doUpdateHighlight(this.highlightLayer, this.editorEl, this.openFiles, this.activeFile); }
+  updateStatusBar() { doUpdateStatusBar(this.statusBar, this.editorEl, this.openFiles, this.activeFile); }
 
   async saveActive() {
-    const file = this.openFiles.get(this.activeFile);
-    await saveFile(this.activeFile, file, this.statusBar, {
-      onSuccess: () => {
-        this.renderTabs();
-        this.updateStatusBar();
-      },
-    }, { writefile: fsApi.writefile });
+    await doSaveActive(this.openFiles, this.activeFile, this.statusBar,
+      { onSuccess: () => { this.renderTabs(); this.updateStatusBar(); } }, fsApi.writefile);
   }
 
   closeFile(filePath) {
@@ -243,48 +107,21 @@ export class FileViewer extends ComponentBase {
     else this.renderTabs();
   }
 
-  _resetEditor() {
-    this.activeFile = null;
-    this.renderTabs();
-    this.breadcrumb.textContent = '';
-    this.showEmpty();
-  }
+  _resetEditor() { this.activeFile = null; this.renderTabs(); this.breadcrumb.textContent = ''; this.showEmpty(); }
+  showEmpty() { doShowEmpty(this.editorWrapper, this.statusBar); }
+  _renderModeBar() { renderModeBar(this.modeBar, this.mode, { switchMode: (m) => this.switchMode(m) }, this._webviewMgr); }
 
-  showEmpty() {
-    this.editorWrapper.replaceChildren(_el('div', 'file-viewer-empty', EMPTY_MESSAGE));
-    this.statusBar.replaceChildren();
-  }
-
-  _renderModeBar() {
-    renderModeBar(this.modeBar, this.mode, { switchMode: (m) => this.switchMode(m) }, this._webviewMgr);
-  }
-
-  // ===== Webview Management (delegated) =====
-
-  addWebview(label, url) {
-    this._webviewMgr.addWebview(label, url);
-  }
-
+  addWebview(label, url) { this._webviewMgr.addWebview(label, url); }
   removeWebview(webviewId) {
     const removedId = this._webviewMgr.removeWebview(webviewId);
     if (this.mode === removedId) this.switchMode('files');
     else this._renderModeBar();
-    /** @fires layout:changed {undefined} — webview removed from file-viewer */
     emitLayoutChanged();
   }
+  getWebviewTabs() { return this._webviewMgr.getWebviewTabs(); }
+  setWebviewTabs(tabs) { this._webviewMgr.setWebviewTabs(tabs); }
 
-  getWebviewTabs() {
-    return this._webviewMgr.getWebviewTabs();
-  }
-
-  setWebviewTabs(tabs) {
-    this._webviewMgr.setWebviewTabs(tabs);
-  }
-
-  dispose() {
-    super.dispose();
-    this._webviewMgr.dispose();
-  }
+  dispose() { super.dispose(); this._webviewMgr.dispose(); }
 }
 
 registerComponent('FileViewer', FileViewer);

--- a/src/components/flow-view.js
+++ b/src/components/flow-view.js
@@ -1,15 +1,13 @@
 import { registerComponent, getComponent } from '../utils/component-registry.js';
 import { ComponentBase } from '../utils/component-base.js';
-import {
-  EMPTY_LIST_MESSAGE, UNCATEGORIZED, HEADER_BUTTONS,
-  getFlowsForCategory, getUncategorizedFlows,
-  removeFlowFromOrder, moveFlowInOrder,
-  createCategoryGroup, createFlowCard,
-  _el, buildDomainButtonBar,
-} from '../utils/flow-view-subsystem.js';
+import { moveFlowInOrder } from '../utils/flow-view-subsystem.js';
 import {
   addCategory, renameCategoryInline, deleteCategory,
 } from '../utils/flow-view-categories.js';
+import {
+  renderFlowViewShell, buildGroupParams, buildFlowCard,
+  renderFlowList, handleOpenModal, deleteFlow,
+} from '../utils/flow-view-rendering.js';
 import flowApi from '../services/flow-api.js';
 
 
@@ -31,8 +29,6 @@ export class FlowView extends ComponentBase {
     this._expandedCards = new Set();
     this._collapsedCategories = new Set();
     this._runningMap = {};
-
-    // Drag state (shared mutable object for use with setupCardDrag)
     this._drag = { flowId: null, catId: null };
   }
 
@@ -42,7 +38,6 @@ export class FlowView extends ComponentBase {
       this._expandedCards.add(flowId);
       this.refresh();
     }));
-
     this._track(flowApi.onRunComplete(({ flowId }) => {
       this._termManager.disposeLiveTerminal(flowId);
       delete this._runningMap[flowId];
@@ -52,9 +47,7 @@ export class FlowView extends ComponentBase {
 
   async _initRunning() {
     this._runningMap = await flowApi.getRunning();
-    for (const flowId of Object.keys(this._runningMap)) {
-      this._expandedCards.add(flowId);
-    }
+    for (const flowId of Object.keys(this._runningMap)) this._expandedCards.add(flowId);
     await this.refresh();
   }
 
@@ -65,183 +58,84 @@ export class FlowView extends ComponentBase {
     this._renderList();
   }
 
-  async _persistCategories() {
-    await flowApi.saveCategories(this.catData);
-  }
-
-  // --- Category helpers ---
+  async _persistCategories() { await flowApi.saveCategories(this.catData); }
 
   _moveFlowToCategory(flowId, targetCatId, insertIndex = -1) {
     moveFlowInOrder(this.catData.order, flowId, targetCatId, insertIndex);
     this._persistCategories();
   }
 
-  // --- Rendering ---
-
   render() {
-    this.container.replaceChildren();
-
-    const wrapper = _el('div', 'flow-container');
-
-    const header = _el('div', 'flow-header');
-    header.appendChild(_el('h2', 'flow-title', 'Flows'));
-
-    const headerHandlers = { addCategory: () => this._addCategory(), addFlow: () => this._openModal() };
-    const headerRight = buildDomainButtonBar('flow-add-btn', 'flow-header-right', HEADER_BUTTONS, headerHandlers);
-    headerRight.style.display = 'flex';
-    headerRight.style.gap = '8px';
-
-    header.appendChild(headerRight);
-    wrapper.appendChild(header);
-
-    this.listEl = _el('div', 'flow-list');
-    wrapper.appendChild(this.listEl);
-
-    this.container.appendChild(wrapper);
+    const { listEl } = renderFlowViewShell(this.container, {
+      onAddCategory: () => this._addCategory(),
+      onAddFlow: () => this._openModal(),
+    });
+    this.listEl = listEl;
   }
 
-  /** Build the shared groupParams object for a category section. */
   _buildGroupParams(cat, flows, isUncat = false) {
-    return {
-      cat,
-      flows,
-      isUncategorized: isUncat,
+    return buildGroupParams({
+      cat, flows, isUncat,
       collapsedCategories: this._collapsedCategories,
       createCard: (flow, catId) => this._createCard(flow, catId),
       onToggleCollapse: (catId) => this._toggleCollapse(catId),
       onRenameCategory: (catId, nameEl) => this._renameCategoryInline(catId, nameEl),
       onDeleteCategory: (catId) => this._deleteCategory(catId),
-      onDropFlow: (flowId, catId, insertIndex) => {
-        this._moveFlowToCategory(flowId, catId, insertIndex);
-        this._renderList();
-      },
+      onDropFlow: (flowId, catId, insertIndex) => { this._moveFlowToCategory(flowId, catId, insertIndex); this._renderList(); },
       dragState: {
         getDragFlowId: () => this._drag.flowId,
         clearDrag: () => { this._drag.flowId = null; this._drag.catId = null; },
       },
-    };
-  }
-
-  /** Render named category groups into the list element. */
-  _renderCategorizedGroups() {
-    for (const cat of this.catData.categories) {
-      const flows = getFlowsForCategory(this.flows, this.catData.order, cat.id);
-      this.listEl.appendChild(createCategoryGroup(this._buildGroupParams(cat, flows)));
-    }
-  }
-
-  /** Render the uncategorized section into the list element. */
-  _renderUncategorizedSection(uncatFlows, hasCats) {
-    if (uncatFlows.length === 0 && !hasCats) return;
-    if (hasCats) {
-      this.listEl.appendChild(createCategoryGroup(
-        this._buildGroupParams({ id: UNCATEGORIZED, name: 'Sans catégorie' }, uncatFlows, true)
-      ));
-    } else {
-      for (const flow of uncatFlows) {
-        this.listEl.appendChild(this._createCard(flow, UNCATEGORIZED));
-      }
-    }
+    });
   }
 
   _renderList() {
-    if (!this.listEl) return;
-
-    this._termManager.cleanupStaleLiveTerminals(this._runningMap);
-    this._termManager.disposeAllLogTerminals();
-
-    this.listEl.replaceChildren();
-
-    const hasCats = this.catData.categories.length > 0;
-    const uncatFlows = getUncategorizedFlows(this.flows, this.catData.order);
-
-    if (this.flows.length === 0 && !hasCats) {
-      this.listEl.appendChild(_el('div', 'flow-empty', EMPTY_LIST_MESSAGE));
-      return;
-    }
-
-    this._renderCategorizedGroups();
-    this._renderUncategorizedSection(uncatFlows, hasCats);
+    renderFlowList({
+      listEl: this.listEl, flows: this.flows, catData: this.catData,
+      termManager: this._termManager, runningMap: this._runningMap,
+      buildParams: (cat, flows, isUncat) => this._buildGroupParams(cat, flows, isUncat),
+      createCard: (flow, catId) => this._createCard(flow, catId),
+    });
   }
 
   _toggleCollapse(catId) {
-    if (this._collapsedCategories.has(catId)) {
-      this._collapsedCategories.delete(catId);
-    } else {
-      this._collapsedCategories.add(catId);
-    }
+    if (this._collapsedCategories.has(catId)) this._collapsedCategories.delete(catId);
+    else this._collapsedCategories.add(catId);
     this._renderList();
   }
 
   _createCard(flow, catId) {
-    return createFlowCard({
-      runningMap: this._runningMap,
-      expandedCards: this._expandedCards,
-      drag: this._drag,
-      termManager: this._termManager,
+    return buildFlowCard({
+      runningMap: this._runningMap, expandedCards: this._expandedCards,
+      drag: this._drag, termManager: this._termManager,
       onRenderList: () => this._renderList(),
-      onShowLog: (f, run) => this._termManager.showRunLog(f, run),
-      onRun: (flowId) => flowApi.runNow(flowId),
-      onToggle: (flowId) => flowApi.toggle(flowId),
+      onRun: (fId) => flowApi.runNow(fId),
+      onToggle: (fId) => flowApi.toggle(fId),
       onRefresh: () => this.refresh(),
       onOpenModal: (f) => this._openModal(f),
       onDeleteFlow: (id) => this._deleteFlow(id),
     }, flow, catId);
   }
 
-
   async _deleteFlow(flowId) {
-    this._termManager.disposeLiveTerminal(flowId);
-    removeFlowFromOrder(this.catData.order, flowId);
-    await this._persistCategories();
-    await flowApi.deleteFlow(flowId);
-    this.refresh();
+    await deleteFlow({
+      termManager: this._termManager, catDataOrder: this.catData.order,
+      persistCategories: () => this._persistCategories(), refresh: () => this.refresh(),
+    }, flowId, flowApi);
   }
 
-  // --- Category management (delegated) ---
-
-  _addCategory() {
-    return addCategory(this.catData, () => this._persistCategories(), () => this._renderList());
-  }
-
-  _renameCategoryInline(catId, nameEl) {
-    renameCategoryInline(this.catData, catId, nameEl, () => this._persistCategories(), () => this._renderList());
-  }
-
-  _deleteCategory(catId) {
-    return deleteCategory(this.catData, catId, () => this._persistCategories(), () => this._renderList());
-  }
-
-  // ===== Creation / Edit Modal =====
+  _addCategory() { return addCategory(this.catData, () => this._persistCategories(), () => this._renderList()); }
+  _renameCategoryInline(catId, nameEl) { renameCategoryInline(this.catData, catId, nameEl, () => this._persistCategories(), () => this._renderList()); }
+  _deleteCategory(catId) { return deleteCategory(this.catData, catId, () => this._persistCategories(), () => this._renderList()); }
 
   async _openModal(existing = null) {
-    const openFlowModal = getComponent('openFlowModal');
-    const flow = await openFlowModal(existing, this.catData.categories);
-    if (flow) {
-      const catId = flow._category;
-      delete flow._category;
-
-      await flowApi.save(flow);
-
-      if (catId) {
-        this._moveFlowToCategory(flow.id, catId);
-      } else if (!existing) {
-        if (!this.catData.order[UNCATEGORIZED]) this.catData.order[UNCATEGORIZED] = [];
-        const allOrdered = new Set(Object.values(this.catData.order).flat());
-        if (!allOrdered.has(flow.id)) {
-          this.catData.order[UNCATEGORIZED].push(flow.id);
-          await this._persistCategories();
-        }
-      }
-
-      this.refresh();
-    }
+    await handleOpenModal(
+      { existing, catData: this.catData, moveFlowToCategory: (fId, cId) => this._moveFlowToCategory(fId, cId), persistCategories: () => this._persistCategories(), refresh: () => this.refresh() },
+      () => getComponent('openFlowModal'), flowApi,
+    );
   }
 
-  dispose() {
-    super.dispose();
-    this._termManager.disposeAll();
-  }
+  dispose() { super.dispose(); this._termManager.disposeAll(); }
 }
 
 registerComponent('FlowView', FlowView);

--- a/src/components/skills-view.js
+++ b/src/components/skills-view.js
@@ -1,10 +1,13 @@
 import { _el } from '../utils/workspace-dom.js';
-import { showPromptDialog, showConfirmDialog } from '../utils/dom-dialogs.js';
 import { registerComponent } from '../utils/component-registry.js';
 import { ComponentBase } from '../utils/component-base.js';
 import {
   renderHeader, renderSkillList, renderEditorContent, renderEditorEmpty, updateDirtyBadge,
 } from '../utils/skills-view-renderer.js';
+import {
+  openRoot, configurePath, importSkill, createSkill,
+  deleteSkill, selectSkill, save,
+} from '../utils/skills-view-actions.js';
 import { skillsApi, shellApi, dialogApi } from '../utils/skills-services.js';
 
 export class SkillsView extends ComponentBase {
@@ -34,7 +37,6 @@ export class SkillsView extends ComponentBase {
 
   render() {
     this.el.replaceChildren();
-
     const { header, rootBadgeEl } = renderHeader(this.rootPath, {
       onConfigurePath: () => this._configurePath(),
       onOpenRoot: () => this._openRoot(),
@@ -51,7 +53,6 @@ export class SkillsView extends ComponentBase {
     body.appendChild(this.listEl);
     body.appendChild(this.editorEl);
     this.el.appendChild(body);
-
     this.refresh();
   }
 
@@ -67,14 +68,11 @@ export class SkillsView extends ComponentBase {
   async _renderEditor() {
     if (!this.editorEl) return;
     if (!this.selectedId) { renderEditorEmpty(this.editorEl); return; }
-
     const skill = this.skills.find((s) => s.id === this.selectedId);
     if (!skill) return;
-
     const content = await skillsApi.read(skill.path);
     this.editorValue = content ?? '';
     this.editorDirty = false;
-
     const { dirtyBadgeEl } = renderEditorContent(this.editorEl, skill, this.editorValue, {
       onSave: () => this._save(),
       onInput: (value) => this._onEditorInput(value),
@@ -84,107 +82,19 @@ export class SkillsView extends ComponentBase {
 
   _onEditorInput(value) {
     this.editorValue = value;
-    if (!this.editorDirty) {
-      this.editorDirty = true;
-      updateDirtyBadge(this._dirtyBadgeEl, true);
-    }
+    if (!this.editorDirty) { this.editorDirty = true; updateDirtyBadge(this._dirtyBadgeEl, true); }
   }
 
-  // --- Actions ---
+  // --- Actions (delegated) ---
+  async _openRoot() { await openRoot(this.rootPath, shellApi); }
+  async _configurePath() { await configurePath(this, { dialogApi, skillsApi }); }
+  async _importSkill() { await importSkill(this, { dialogApi, skillsApi }); }
+  async _createSkill() { await createSkill(this, skillsApi); }
+  async _deleteSkill(id) { await deleteSkill(this, id, skillsApi); }
+  async _selectSkill(id) { await selectSkill(this, id); }
+  async _save() { await save(this, skillsApi); }
 
-  async _openRoot() {
-    if (!this.rootPath) return;
-    await shellApi.openPath(this.rootPath);
-  }
-
-  async _configurePath() {
-    const picked = await dialogApi.openFolder();
-    if (!picked) return;
-    const res = await skillsApi.setRoot(picked);
-    if (res && res.success) {
-      this.rootPath = res.root;
-      this.selectedId = null;
-      this.editorDirty = false;
-      await this.refresh();
-    }
-  }
-
-  async _importSkill() {
-    const picked = await dialogApi.openFolder();
-    if (!picked) return;
-    const res = await skillsApi.importSkill(picked);
-    if (res && res.success) {
-      this.selectedId = res.id;
-      await this.refresh();
-    } else {
-      await showConfirmDialog(
-        `Import impossible : ${res?.error || 'erreur inconnue'}. Le dossier doit contenir un fichier SKILL.md.`,
-        { confirmLabel: 'OK', cancelLabel: 'Fermer' },
-      );
-    }
-  }
-
-  async _createSkill() {
-    const id = await showPromptDialog({
-      title: 'Nouveau skill',
-      placeholder: 'identifiant-du-skill',
-      confirmLabel: 'Créer',
-      cancelLabel: 'Annuler',
-    });
-    if (!id) return;
-    const description = await showPromptDialog({
-      title: 'Description',
-      placeholder: 'Quand activer ce skill ?',
-      confirmLabel: 'Créer',
-      cancelLabel: 'Annuler',
-    });
-    const res = await skillsApi.create({ id, description: description || '' });
-    if (res && res.success) {
-      this.selectedId = res.id;
-      await this.refresh();
-    }
-  }
-
-  async _deleteSkill(id) {
-    const ok = await showConfirmDialog(
-      `Supprimer le skill "${id}" ? Cette action est irréversible.`,
-      { confirmLabel: 'Supprimer', cancelLabel: 'Annuler' },
-    );
-    if (!ok) return;
-    await skillsApi.deleteSkill(id);
-    if (this.selectedId === id) this.selectedId = null;
-    await this.refresh();
-  }
-
-  async _selectSkill(id) {
-    if (this.editorDirty) {
-      const ok = await showConfirmDialog(
-        'Modifications non enregistrées. Abandonner les changements en cours ?',
-        { confirmLabel: 'Abandonner', cancelLabel: 'Rester' },
-      );
-      if (!ok) return;
-    }
-    this.selectedId = id;
-    this.editorDirty = false;
-    this._renderList();
-    await this._renderEditor();
-  }
-
-  async _save() {
-    const skill = this.skills.find((s) => s.id === this.selectedId);
-    if (!skill) return;
-    const res = await skillsApi.write(skill.path, this.editorValue);
-    if (res && res.success) {
-      this.editorDirty = false;
-      updateDirtyBadge(this._dirtyBadgeEl, false);
-      await this.refresh();
-    }
-  }
-
-  dispose() {
-    super.dispose();
-    this.el.remove();
-  }
+  dispose() { super.dispose(); this.el.remove(); }
 }
 
 registerComponent('SkillsView', SkillsView);

--- a/src/components/tab-manager.js
+++ b/src/components/tab-manager.js
@@ -22,7 +22,7 @@ import {
   setSidebarMode as doSetSidebarMode,
   renderWorkspace as doRenderWorkspace,
   buildSwitchToDeps,
-  disposeAllSideViews, disposeAllTabs,
+  disposeSideView, disposeAllSideViews, disposeAllTabs,
 } from '../utils/tab-manager-sidebar.js';
 import {
   renderTabBar as doRenderTabBar,
@@ -135,6 +135,9 @@ export class TabManager {
   prevTab() { doPrevTab(this.tabs, this.activeTabId, (id) => this.switchTo(id)); }
 
   // --- Dispose ---
+
+  _disposeSideView(mode) { disposeSideView(this, mode); }
+  _disposeAllTabs() { disposeAllTabs(this); }
 
   dispose() {
     for (const unsub of this._busListeners) unsub();

--- a/src/components/tab-manager.js
+++ b/src/components/tab-manager.js
@@ -3,21 +3,11 @@ import {
   getComponent,
 } from '../utils/tab-manager-init.js';
 import {
-  renderWorkspace as doRenderWorkspace, reattachLayout,
-  capturePanelWidths, disposeAllTabs,
   serialize as doSerialize, restoreConfig as doRestoreConfig,
 } from '../utils/workspace-ops.js';
 import {
-  renderActivityBar, detachSidebarView, changeSidebarMode,
-  disposeSideView, disposeAllSideViews,
-} from '../utils/sidebar-manager.js';
-import {
-  inlineRenameTab,
-  renderTabBar as doRenderTabBar,
   isTabVisible,
-  createTab as doCreateTab, closeTab as doCloseTab,
   switchTo as doSwitchTo,
-  reorderEntries,
   setColorFilter as doSetColorFilter,
   toggleExcludeColor as doToggleExcludeColor,
   ensureVisibleTabActive as doEnsureVisibleTabActive,
@@ -27,6 +17,20 @@ import {
   toggleNoShortcut as doToggleNoShortcut,
   buildPrApi, buildWorktreeApi, buildViewStore,
 } from '../utils/tab-facade.js';
+import {
+  renderActivityBar as doRenderActivityBar,
+  setSidebarMode as doSetSidebarMode,
+  renderWorkspace as doRenderWorkspace,
+  buildSwitchToDeps,
+  disposeAllSideViews, disposeAllTabs,
+} from '../utils/tab-manager-sidebar.js';
+import {
+  renderTabBar as doRenderTabBar,
+  createTab as doCreateTab,
+  closeTab as doCloseTab,
+  reorderTab as doReorderTab,
+  renameTab as doRenameTab,
+} from '../utils/tab-manager-tab-ops.js';
 import { gitApi, fsApi, configApi } from '../utils/tab-services.js';
 
 export class TabManager {
@@ -40,32 +44,22 @@ export class TabManager {
 
   _initState() {
     this.tabs = new Map();
-    this.activeTabId = null;
-    this.defaultCwd = null;
-    this.onOpenSettings = null;
-    const ConfigManager = getComponent('ConfigManager');
-    this.configManager = new ConfigManager(this);
-    this.boardView = null;
-    this._boardContainerEl = null;
-    this.flowView = null;
-    this._flowContainerEl = null;
-    this.usageView = null;
-    this._usageContainerEl = null;
-    this.skillsView = null;
-    this._skillsContainerEl = null;
+    this.activeTabId = this.defaultCwd = this.onOpenSettings = null;
+    this.configManager = new (getComponent('ConfigManager'))(this);
+    this.boardView = this._boardContainerEl = null;
+    this.flowView = this._flowContainerEl = null;
+    this.usageView = this._usageContainerEl = null;
+    this.skillsView = this._skillsContainerEl = null;
     this.sidebarMode = 'work';
-    this.activeColorFilter = null; // null = show all, or a COLOR_GROUPS id
-    this.excludedColors = new Set(); // COLOR_GROUPS ids to hide
+    this.activeColorFilter = null;
+    this.excludedColors = new Set();
   }
 
-  _initApi() {
-    // Injected API methods for workspace-layout utils
-    this._api = { gitBranch: gitApi.branch };
-  }
-
+  _initApi() { this._api = { gitBranch: gitApi.branch }; }
   _prApi() { return buildPrApi(); }
   _worktreeApi() { return buildWorktreeApi(); }
   _viewStore() { return buildViewStore(this); }
+  _activeTab() { return this.tabs.get(this.activeTabId); }
 
   async init() {
     this.defaultCwd = await initTabManager({
@@ -76,74 +70,24 @@ export class TabManager {
       setDefaultCwd: (cwd) => { this.defaultCwd = cwd; },
       api: { homedir: fsApi.homedir, getDefault: configApi.getDefault, loadDefault: configApi.loadDefault },
     });
-
     this._busListeners = setupBusListeners({
       tabs: this.tabs,
       getActiveTabId: () => this.activeTabId,
       configManager: this.configManager,
       createTab: (name, cwd) => this.createTab(name, cwd),
       renderTabBar: () => this.renderTabBar(),
-      api: {
-        gitBranch: gitApi.branch,
-        worktree: this._worktreeApi(),
-        pr: this._prApi(),
-      },
+      api: { gitBranch: gitApi.branch, worktree: this._worktreeApi(), pr: this._prApi() },
     });
   }
 
-  _activeTab() {
-    return this.tabs.get(this.activeTabId);
-  }
+  // --- Sidebar & Workspace (delegated) ---
 
-  renderActivityBar() {
-    renderActivityBar({
-      sidebarMode: this.sidebarMode,
-      setSidebarMode: (mode) => this.setSidebarMode(mode),
-      onOpenSettings: this.onOpenSettings,
-    });
-  }
-
-  setSidebarMode(mode) {
-    if (mode === this.sidebarMode) return;
-
-    changeSidebarMode({
-      getActiveTab: () => this._activeTab(),
-      capturePanelWidths,
-      viewStore: this._viewStore(),
-      workspaceContainer: this.workspaceContainer,
-      reattachLayout,
-      renderWorkspace: (tab) => this.renderWorkspace(tab),
-      tabManager: this,
-      resolveComponent: getComponent,
-    }, this.sidebarMode, mode);
-    this.sidebarMode = mode;
-
-    this.renderActivityBar();
-  }
-
+  renderActivityBar() { doRenderActivityBar(this); }
+  setSidebarMode(mode) { doSetSidebarMode(this, mode); }
   switchToBoard() { this.setSidebarMode('board'); }
+  async renderWorkspace(tab) { return doRenderWorkspace(this, tab, this._api); }
 
-  async renderWorkspace(tab) {
-    return doRenderWorkspace({
-      workspaceContainer: this.workspaceContainer,
-      getActiveTabId: () => this.activeTabId,
-      getActiveTab: () => this._activeTab(),
-      scheduleAutoSave: () => this.configManager.scheduleAutoSave(),
-    }, tab, this._api, {
-      FileTree: getComponent('FileTree'),
-      FileViewer: getComponent('FileViewer'),
-      TerminalPanel: getComponent('TerminalPanel'),
-      WebviewManager: getComponent('WebviewManager'),
-      GitChangesView: getComponent('GitChangesView'),
-    });
-  }
-
-  serialize() {
-    return doSerialize({
-      tabs: this.tabs,
-      activeTabId: this.activeTabId,
-    });
-  }
+  serialize() { return doSerialize({ tabs: this.tabs, activeTabId: this.activeTabId }); }
 
   async restoreConfig(config) {
     return doRestoreConfig({
@@ -159,134 +103,43 @@ export class TabManager {
 
   autoSave() { return this.configManager.autoSave(); }
 
-  createTab(name = null, cwd = null) {
-    return doCreateTab({
-      tabs: this.tabs,
-      defaultCwd: this.defaultCwd,
-      activeColorFilter: this.activeColorFilter,
-      renderTabBar: () => this.renderTabBar(),
-      configManager: this.configManager,
-    }, (id) => this.switchTo(id), name, cwd);
-  }
+  // --- Tab lifecycle (delegated) ---
 
-  closeTab(id) {
-    return doCloseTab({
-      tabs: this.tabs,
-      activeTabId: this.activeTabId,
-      renderTabBar: () => this.renderTabBar(),
-      configManager: this.configManager,
-    }, () => this.createTab(), (tabId) => this.switchTo(tabId), id);
-  }
+  createTab(name = null, cwd = null) { return doCreateTab(this, (id) => this.switchTo(id), name, cwd); }
+  closeTab(id) { return doCloseTab(this, () => this.createTab(), (tabId) => this.switchTo(tabId), id); }
 
-  switchTo(id) {
-    return doSwitchTo({
-      tabs: this.tabs,
-      getActiveTabId: () => this.activeTabId,
-      setActiveTabId: (newId) => { this.activeTabId = newId; },
-      getSidebarMode: () => this.sidebarMode,
-      setSidebarMode: (mode) => { this.sidebarMode = mode; },
-      workspaceContainer: this.workspaceContainer,
-      renderTabBar: () => this.renderTabBar(),
-      renderActivityBar: () => this.renderActivityBar(),
-      renderWorkspace: (tab) => this.renderWorkspace(tab),
-      detachSidebarView: (mode) => detachSidebarView({
-        getActiveTab: () => this._activeTab(),
-        capturePanelWidths,
-        viewStore: this._viewStore(),
-      }, mode),
-    }, id);
-  }
+  switchTo(id) { return doSwitchTo(buildSwitchToDeps(this), id); }
 
-  setColorFilter(colorGroupId) {
-    doSetColorFilter(this, colorGroupId, () => this.renderTabBar(), () => this._ensureVisibleTabActive());
-  }
+  renderTabBar() { this._tabElements = doRenderTabBar(this); }
+  reorderTab(fromId, toId, before) { doReorderTab(this, fromId, toId, before); }
+  renameTab(id, nameEl) { doRenameTab(this, id)(nameEl); }
 
-  toggleExcludeColor(colorGroupId) {
-    doToggleExcludeColor(this, colorGroupId, () => this.renderTabBar(), () => this._ensureVisibleTabActive());
-  }
+  // --- Color filters ---
 
-  _isTabVisible(tab) {
-    return isTabVisible(tab, this.activeColorFilter, this.excludedColors);
-  }
+  setColorFilter(cg) { doSetColorFilter(this, cg, () => this.renderTabBar(), () => this._ensureVisibleTabActive()); }
+  toggleExcludeColor(cg) { doToggleExcludeColor(this, cg, () => this.renderTabBar(), () => this._ensureVisibleTabActive()); }
+  _isTabVisible(tab) { return isTabVisible(tab, this.activeColorFilter, this.excludedColors); }
+  _ensureVisibleTabActive() { doEnsureVisibleTabActive(this.tabs, () => this._activeTab(), this.activeColorFilter, this.excludedColors, (id) => this.switchTo(id)); }
 
-  _ensureVisibleTabActive() {
-    doEnsureVisibleTabActive(this.tabs, () => this._activeTab(), this.activeColorFilter, this.excludedColors, (id) => this.switchTo(id));
-  }
+  setTabColorGroup(id, cg) { doSetTabColorGroup(this.tabs, id, cg, () => this.renderTabBar(), this.configManager); }
+  toggleNoShortcut(id) { doToggleNoShortcut(this.tabs, id, () => this.renderTabBar(), this.configManager); }
+  goToColorGroup(cg) { doGoToColorGroup(this.tabs, this.activeTabId, cg, (id) => this.switchTo(id)); }
 
-  renderTabBar() {
-    this._tabElements = doRenderTabBar({
-      tabBar: this.tabBar,
-      tabs: this.tabs,
-      activeTabId: this.activeTabId,
-      activeColorFilter: this.activeColorFilter,
-      excludedColors: this.excludedColors,
-      switchTo: (id) => this.switchTo(id),
-      closeTab: (id) => this.closeTab(id),
-      renameTab: (id, nameEl) => this.renameTab(id, nameEl),
-      setTabColorGroup: (id, cg) => this.setTabColorGroup(id, cg),
-      toggleNoShortcut: (id) => this.toggleNoShortcut(id),
-      setColorFilter: (id) => this.setColorFilter(id),
-      toggleExcludeColor: (id) => this.toggleExcludeColor(id),
-      clearColorFilters: () => { this.activeColorFilter = null; this.excludedColors.clear(); },
-      createTab: () => this.createTab(),
-      reorderTab: (fromId, toId, before) => this.reorderTab(fromId, toId, before),
-      isTabVisible: (tab) => this._isTabVisible(tab),
-      renderTabBar: () => this.renderTabBar(),
-    });
-  }
-
-  reorderTab(fromId, toId, before) {
-    if (fromId === toId) return;
-    this.tabs = new Map(reorderEntries(Array.from(this.tabs.entries()), fromId, toId, before));
-    this.renderTabBar();
-    this.configManager.scheduleAutoSave();
-  }
-
-  renameTab(id, nameEl) {
-    const tab = this.tabs.get(id);
-    inlineRenameTab(tab, nameEl,
-      () => { this.renderTabBar(); this.configManager.scheduleAutoSave(); },
-      () => this.renderTabBar(),
-    );
-  }
-
-  _disposeSideView(mode) { disposeSideView(this._viewStore(), mode); }
-  _disposeAllTabs() {
-    disposeAllTabs({ tabs: this.tabs, setActiveTabId: (id) => { this.activeTabId = id; } });
-  }
-
-  dispose() {
-    for (const unsub of this._busListeners) unsub();
-    this._busListeners = [];
-    disposeAllSideViews(this._viewStore());
-    this._disposeAllTabs();
-  }
-
-  setTabColorGroup(id, colorGroupId) {
-    doSetTabColorGroup(this.tabs, id, colorGroupId, () => this.renderTabBar(), this.configManager);
-  }
-
-  goToColorGroup(colorGroupId) {
-    doGoToColorGroup(this.tabs, this.activeTabId, colorGroupId, (id) => this.switchTo(id));
-  }
-
-  toggleNoShortcut(id) {
-    doToggleNoShortcut(this.tabs, id, () => this.renderTabBar(), this.configManager);
-  }
+  // --- Navigation ---
 
   isActiveNoShortcut() { return this._activeTab()?.noShortcut ?? false; }
   splitHorizontal() { this._activeTab()?.terminalPanel?.splitActive('horizontal'); }
   splitVertical() { this._activeTab()?.terminalPanel?.splitActive('vertical'); }
+  focusDirection(dir) { doFocusDirection(dir, this.sidebarMode, this.boardView, () => this._activeTab()); }
+  nextTab() { doNextTab(this.tabs, this.activeTabId, (id) => this.switchTo(id)); }
+  prevTab() { doPrevTab(this.tabs, this.activeTabId, (id) => this.switchTo(id)); }
 
-  focusDirection(direction) {
-    doFocusDirection(direction, this.sidebarMode, this.boardView, () => this._activeTab());
-  }
+  // --- Dispose ---
 
-  nextTab() {
-    doNextTab(this.tabs, this.activeTabId, (id) => this.switchTo(id));
-  }
-
-  prevTab() {
-    doPrevTab(this.tabs, this.activeTabId, (id) => this.switchTo(id));
+  dispose() {
+    for (const unsub of this._busListeners) unsub();
+    this._busListeners = [];
+    disposeAllSideViews(this);
+    disposeAllTabs(this);
   }
 }

--- a/src/utils/file-tree-dir-ops.js
+++ b/src/utils/file-tree-dir-ops.js
@@ -1,0 +1,172 @@
+/**
+ * FileTree directory operations — extracted from FileTree component.
+ *
+ * Handles expand/collapse, directory entry rendering callbacks, section
+ * management (setTerminalRoot, removeTerminal, refreshSection).
+ */
+
+import { _el } from './file-dom.js';
+import {
+  CHEVRON_EXPANDED, CHEVRON_COLLAPSED,
+  resolveWatchCwd,
+  renderDirEntry, renderFileEntry,
+  startWatch, stopWatch,
+} from './file-tree-subsystem.js';
+import { rebuildSectionDOM } from './file-tree-section-dom.js';
+
+/**
+ * Expand a directory in the tree.
+ */
+export async function expandDir(dirPath, childContainer, chevron, depth, expandedDirs, renderDirFn) {
+  expandedDirs.add(dirPath);
+  chevron.textContent = CHEVRON_EXPANDED;
+  chevron.classList.add('expanded');
+  await renderDirFn(dirPath, childContainer, depth + 1, expandedDirs);
+}
+
+/**
+ * Collapse a directory in the tree.
+ */
+export function collapseDir(dirPath, childContainer, chevron, expandedDirs) {
+  expandedDirs.delete(dirPath);
+  childContainer.replaceChildren();
+  chevron.textContent = CHEVRON_COLLAPSED;
+  chevron.classList.remove('expanded');
+}
+
+/**
+ * Build the callbacks object for renderDirEntry.
+ * @param {object} ft - FileTree instance
+ * @param {Set<string>} expandedDirs
+ */
+export function getDirEntryCallbacks(ft, expandedDirs) {
+  return {
+    setupDropZone: (el, targetDir) => ft._setupDropZone(el, targetDir),
+    expandDir: (dirPath, childContainer, chevron, depth, eDirs) =>
+      expandDir(dirPath, childContainer, chevron, depth, eDirs, (dp, pe, d, ed) => ft.renderDir(dp, pe, d, ed)),
+    collapseDir: (dirPath, childContainer, chevron, eDirs) =>
+      collapseDir(dirPath, childContainer, chevron, eDirs),
+    renderDir: (dirPath, parentEl, depth, eDirs) =>
+      ft.renderDir(dirPath, parentEl, depth, eDirs),
+    findRootCwd: (entryPath) => ft.findRootCwd(entryPath),
+    promptRename: (path, nameEl) => ft.promptRename(path, nameEl),
+    promptNewEntry: (dirPath, cEl, depth, eDirs, type) =>
+      ft.promptNewEntry(dirPath, cEl, depth, eDirs, type),
+    contextMenuApi: ft._contextMenuApi,
+  };
+}
+
+/**
+ * Render a single directory entry.
+ */
+export async function renderDirEntryWrap(ft, entry, parentEl, depth, expandedDirs) {
+  await renderDirEntry(entry, parentEl, depth, expandedDirs, getDirEntryCallbacks(ft, expandedDirs));
+}
+
+/**
+ * Render a single file entry.
+ */
+export function renderFileEntryWrap(ft, entry, parentEl, depth) {
+  const activeRowRef = {
+    get current() { return ft._activeRow; },
+    set current(v) { ft._activeRow = v; },
+  };
+  renderFileEntry(entry, parentEl, depth, {
+    activeRowRef,
+    findRootCwd: (entryPath) => ft.findRootCwd(entryPath),
+    promptRename: (path, nameEl) => ft.promptRename(path, nameEl),
+    contextMenuApi: ft._contextMenuApi,
+  });
+}
+
+/**
+ * Render all entries in a directory.
+ */
+export async function renderDir(ft, dirPath, parentEl, depth, expandedDirs, fsReaddir) {
+  const entries = await fsReaddir(dirPath);
+  for (const entry of entries) {
+    if (entry.isDirectory) {
+      await renderDirEntryWrap(ft, entry, parentEl, depth, expandedDirs);
+    } else {
+      renderFileEntryWrap(ft, entry, parentEl, depth);
+    }
+  }
+}
+
+/**
+ * Set a terminal root and create/reuse a section.
+ */
+export async function setTerminalRoot(ft, termId, dirPath, fsWatch, refreshSectionFn) {
+  const prevCwd = ft.termCwds.get(termId);
+  if (prevCwd === dirPath) return;
+
+  if (prevCwd) removeTermFromSection(ft, termId, prevCwd);
+
+  ft.termCwds.set(termId, dirPath);
+
+  const existing = ft.sections.get(dirPath);
+  if (existing) { existing.termIds.add(termId); return; }
+
+  const sectionEl = _el('div', { className: 'file-tree-section' });
+  const expandedDirs = new Set([dirPath]);
+  const watchId = startWatch(dirPath, { watch: fsWatch });
+  ft.sections.set(dirPath, { termIds: new Set([termId]), sectionEl, expandedDirs, watchId });
+  ft.treeEl.appendChild(sectionEl);
+  await refreshSectionFn(dirPath);
+}
+
+/**
+ * Remove a terminal from the tree.
+ */
+export function removeTerminal(ft, termId, fsUnwatch) {
+  const cwd = ft.termCwds.get(termId);
+  if (!cwd) return;
+  ft.termCwds.delete(termId);
+  removeTermFromSection(ft, termId, cwd, fsUnwatch);
+}
+
+/**
+ * Remove a terminal from its section, and cleanup if section is empty.
+ */
+export function removeTermFromSection(ft, termId, cwd, fsUnwatch) {
+  const section = ft.sections.get(cwd);
+  if (!section) return;
+
+  section.termIds.delete(termId);
+
+  if (section.termIds.size === 0) {
+    stopWatch(section.watchId, { unwatch: fsUnwatch || (() => {}) });
+    section.sectionEl.remove();
+    ft.sections.delete(cwd);
+  }
+}
+
+/**
+ * Refresh a section's DOM.
+ */
+export async function refreshSection(ft, watchIdOrCwd, renderDirFn) {
+  const cwd = resolveWatchCwd(watchIdOrCwd);
+  const section = ft.sections.get(cwd);
+  if (!section) return;
+
+  if (section._refreshing) { section._pendingRefresh = true; return; }
+  section._refreshing = true;
+
+  const contentEl = rebuildSectionDOM(section, cwd, {
+    setupDropZone: (el, targetDir) => ft._setupDropZone(el, targetDir),
+    promptNewEntry: (dirPath, cEl, depth, eDirs, type) => ft.promptNewEntry(dirPath, cEl, depth, eDirs, type),
+    promptRename: (path, nameEl) => ft.promptRename(path, nameEl),
+    refreshSection: (c) => ft.refreshSection(c),
+    contextMenuApi: ft._contextMenuApi,
+  });
+
+  try {
+    await renderDirFn(cwd, contentEl, 0, section.expandedDirs);
+  } finally {
+    section._refreshing = false;
+    if (section._pendingRefresh) {
+      section._pendingRefresh = false;
+      ft.refreshSection(cwd).catch(() => {});
+    }
+  }
+}

--- a/src/utils/file-tree-dir-ops.js
+++ b/src/utils/file-tree-dir-ops.js
@@ -96,11 +96,11 @@ export async function renderDir(ft, dirPath, parentEl, depth, expandedDirs, fsRe
 /**
  * Set a terminal root and create/reuse a section.
  */
-export async function setTerminalRoot(ft, termId, dirPath, fsWatch, refreshSectionFn) {
+export async function setTerminalRoot(ft, termId, dirPath, fsWatch, refreshSectionFn, fsUnwatch) {
   const prevCwd = ft.termCwds.get(termId);
   if (prevCwd === dirPath) return;
 
-  if (prevCwd) removeTermFromSection(ft, termId, prevCwd);
+  if (prevCwd) removeTermFromSection(ft, termId, prevCwd, fsUnwatch);
 
   ft.termCwds.set(termId, dirPath);
 

--- a/src/utils/file-viewer-editor.js
+++ b/src/utils/file-viewer-editor.js
@@ -1,0 +1,169 @@
+/**
+ * FileViewer editor rendering helpers — extracted from FileViewer component.
+ *
+ * Handles the render() shell, editor rendering (code/markdown), status bar,
+ * line numbers, and file close logic.  State is passed in, never owned here.
+ */
+
+import { _el } from './file-dom.js';
+import { EMPTY_MESSAGE, MODE_CONFIG, ALL_STATIC_ELEMENTS, MODE_ACTIVATE } from './editor-helpers.js';
+import { pinnedFiles } from './editor-helpers.js';
+import {
+  updateLineNumbers as doUpdateLineNumbers,
+  updateHighlight as doUpdateHighlight,
+  updateStatusBar as doUpdateStatusBar,
+  saveFile as doSaveFile,
+  initCodeEditor,
+  createMarkdownPreviewDOM, updatePreviewStatusBar,
+  renderTabs as doRenderTabs,
+} from './file-viewer-subsystem.js';
+
+/**
+ * Build the FileViewer shell DOM inside `container`.
+ * @param {HTMLElement} container
+ * @param {{ GitChangesView: Function }} components
+ * @returns {{ modeBar: HTMLElement, tabsBar: HTMLElement, breadcrumb: HTMLElement, editorWrapper: HTMLElement, gitViewEl: HTMLElement, gitChanges: object, statusBar: HTMLElement }}
+ */
+export function renderFileViewerShell(container, components) {
+  container.replaceChildren();
+
+  const modeBar = _el('div', 'file-viewer-mode-bar');
+  container.appendChild(modeBar);
+
+  const tabsBar = _el('div', 'file-viewer-tabs');
+  container.appendChild(tabsBar);
+
+  const breadcrumb = _el('div', 'file-viewer-breadcrumb');
+  container.appendChild(breadcrumb);
+
+  const editorWrapper = _el('div', 'editor-wrapper');
+  container.appendChild(editorWrapper);
+
+  const gitViewEl = _el('div', 'git-changes-view');
+  gitViewEl.style.display = 'none';
+  container.appendChild(gitViewEl);
+  const gitChanges = new components.GitChangesView(gitViewEl);
+
+  const statusBar = _el('div', 'editor-status-bar');
+  container.appendChild(statusBar);
+
+  return { modeBar, tabsBar, breadcrumb, editorWrapper, gitViewEl, gitChanges, statusBar };
+}
+
+/**
+ * Render the active editor content (code, markdown preview, or error).
+ * @param {object} fv - FileViewer-like state: { editorWrapper, statusBar, breadcrumb, openFiles, activeFile }
+ * @param {{ onUpdate: () => void, onSave: () => void }} callbacks
+ * @returns {{ lineNumbers: HTMLElement|null, highlightLayer: HTMLElement|null, editorEl: HTMLElement|null }}
+ */
+export function renderEditor(fv, callbacks) {
+  fv.editorWrapper.replaceChildren();
+  fv.statusBar.replaceChildren();
+
+  const file = fv.openFiles.get(fv.activeFile);
+  if (!file) {
+    showEmpty(fv.editorWrapper, fv.statusBar);
+    return { lineNumbers: null, highlightLayer: null, editorEl: null, isEmpty: true };
+  }
+
+  fv.breadcrumb.textContent = fv.activeFile;
+
+  if (file.error) {
+    fv.editorWrapper.replaceChildren(_el('div', 'file-viewer-error', file.error));
+    return { lineNumbers: null, highlightLayer: null, editorEl: null };
+  }
+
+  if (file.lang === 'markdown' && file.viewMode === 'preview') {
+    createMarkdownPreviewDOM(fv.editorWrapper, file);
+    updatePreviewStatusBar(fv.statusBar, file);
+    return { lineNumbers: null, highlightLayer: null, editorEl: null };
+  }
+
+  const result = initCodeEditor(fv.editorWrapper, file, callbacks);
+  doUpdateStatusBar(fv.statusBar, result.editorEl, file);
+  result.editorEl.focus();
+  return result;
+}
+
+/**
+ * Show the empty state.
+ */
+export function showEmpty(editorWrapper, statusBar) {
+  editorWrapper.replaceChildren(_el('div', 'file-viewer-empty', EMPTY_MESSAGE));
+  statusBar.replaceChildren();
+}
+
+/**
+ * Update line numbers.
+ */
+export function updateLineNumbers(lineNumbers, editorEl) {
+  doUpdateLineNumbers(lineNumbers, editorEl);
+}
+
+/**
+ * Update syntax highlight layer.
+ */
+export function updateHighlight(highlightLayer, editorEl, openFiles, activeFile) {
+  const file = openFiles.get(activeFile);
+  if (!file) return;
+  doUpdateHighlight(highlightLayer, editorEl, file.lang);
+}
+
+/**
+ * Update status bar.
+ */
+export function updateStatusBar(statusBar, editorEl, openFiles, activeFile) {
+  if (!statusBar || !editorEl) return;
+  const file = openFiles.get(activeFile);
+  if (!file) { statusBar.replaceChildren(); return; }
+  doUpdateStatusBar(statusBar, editorEl, file);
+}
+
+/**
+ * Save the active file.
+ */
+export async function saveActive(openFiles, activeFile, statusBar, callbacks, fsWritefile) {
+  const file = openFiles.get(activeFile);
+  await doSaveFile(activeFile, file, statusBar, callbacks, { writefile: fsWritefile });
+}
+
+/**
+ * Set mode visibility on FileViewer DOM elements.
+ */
+export function setModeVisibility(fv, mode, webviewMgr) {
+  const visible = new Set(MODE_CONFIG[mode]?.elements || []);
+  for (const key of ALL_STATIC_ELEMENTS) {
+    fv[key].style.display = visible.has(key) ? '' : 'none';
+  }
+  webviewMgr.setModeVisibility(mode);
+}
+
+/**
+ * Switch mode helper.
+ */
+export function switchMode(fv, mode, webviewMgr, renderModeBar) {
+  fv.mode = mode;
+  setModeVisibility(fv, mode, webviewMgr);
+  renderModeBar();
+  MODE_ACTIVATE[mode]?.(fv);
+}
+
+/**
+ * Render file tabs bar.
+ * @param {object} fv - FileViewer instance (for callbacks)
+ */
+export function renderTabs(fv) {
+  doRenderTabs(fv.tabsBar, fv.openFiles, fv.activeFile,
+    (p) => fv.isPinned(p), (p) => fv.isModified(p),
+    { onClose: (p) => fv.closeFile(p), onActivate: (p) => fv.setActiveTab(p), onTogglePin: (p) => fv.togglePin(p), isMarkdown: (p) => fv.isMarkdown(p), getViewMode: (p) => fv.openFiles.get(p)?.viewMode, onToggleViewMode: (p) => fv.toggleViewMode(p) },
+  );
+}
+
+/**
+ * Load pinned files.
+ */
+export async function loadPinnedFiles(fv) {
+  for (const [path, info] of pinnedFiles) {
+    if (!fv.openFiles.has(path)) await fv.openFile(path, info.name);
+  }
+}

--- a/src/utils/flow-view-rendering.js
+++ b/src/utils/flow-view-rendering.js
@@ -1,0 +1,166 @@
+/**
+ * FlowView rendering helpers — extracted from FlowView component.
+ *
+ * Pure orchestration functions for building the list of flow categories
+ * and cards. State is passed in, never owned here.
+ */
+
+import {
+  EMPTY_LIST_MESSAGE, UNCATEGORIZED, HEADER_BUTTONS,
+  getFlowsForCategory, getUncategorizedFlows,
+  removeFlowFromOrder,
+  createCategoryGroup, createFlowCard,
+  _el, renderButtonBar,
+} from './flow-view-subsystem.js';
+
+/**
+ * Build the outer shell DOM for the FlowView (wrapper + header + listEl).
+ * @param {HTMLElement} container
+ * @param {{ onAddCategory: () => void, onAddFlow: () => void }} handlers
+ * @returns {{ listEl: HTMLElement }}
+ */
+export function renderFlowViewShell(container, handlers) {
+  container.replaceChildren();
+  const wrapper = _el('div', 'flow-container');
+  const header = _el('div', 'flow-header');
+  header.appendChild(_el('h2', 'flow-title', 'Flows'));
+
+  const headerHandlers = { addCategory: handlers.onAddCategory, addFlow: handlers.onAddFlow };
+  const configs = HEADER_BUTTONS.map(({ label, action }) => ({ label, cls: 'flow-add-btn', action }));
+  const headerRight = renderButtonBar({ containerClass: 'flow-header-right', configs, handlers: headerHandlers });
+  headerRight.style.display = 'flex';
+  headerRight.style.gap = '8px';
+
+  header.appendChild(headerRight);
+  wrapper.appendChild(header);
+  const listEl = _el('div', 'flow-list');
+  wrapper.appendChild(listEl);
+  container.appendChild(wrapper);
+  return { listEl };
+}
+
+/**
+ * Build the shared groupParams object for a category section.
+ * @param {{ cat: object, flows: Array, isUncat: boolean, collapsedCategories: Set<string>, createCard: Function, onToggleCollapse: Function, onRenameCategory: Function, onDeleteCategory: Function, onDropFlow: Function, dragState: object }} opts
+ */
+export function buildGroupParams(opts) {
+  const { cat, flows, isUncat, collapsedCategories, createCard, onToggleCollapse, onRenameCategory, onDeleteCategory, onDropFlow, dragState } = opts;
+  return {
+    cat,
+    flows,
+    isUncategorized: isUncat,
+    collapsedCategories,
+    createCard,
+    onToggleCollapse,
+    onRenameCategory,
+    onDeleteCategory,
+    onDropFlow,
+    dragState,
+  };
+}
+
+/**
+ * Build the config object for createFlowCard.
+ * @param {{ runningMap: object, expandedCards: Set, drag: object, termManager: object, onRenderList: Function, onRun: Function, onToggle: Function, onRefresh: Function, onOpenModal: Function, onDeleteFlow: Function }} deps
+ * @param {object} flow
+ * @param {string} catId
+ * @returns {HTMLElement}
+ */
+export function buildFlowCard(deps, flow, catId) {
+  return createFlowCard({
+    runningMap: deps.runningMap,
+    expandedCards: deps.expandedCards,
+    drag: deps.drag,
+    termManager: deps.termManager,
+    onRenderList: deps.onRenderList,
+    onShowLog: (f, run) => deps.termManager.showRunLog(f, run),
+    onRun: deps.onRun,
+    onToggle: deps.onToggle,
+    onRefresh: deps.onRefresh,
+    onOpenModal: deps.onOpenModal,
+    onDeleteFlow: deps.onDeleteFlow,
+  }, flow, catId);
+}
+
+/**
+ * Render the full flow list (categories + uncategorized).
+ * @param {{ listEl: HTMLElement, flows: Array, catData: object, termManager: object, runningMap: object, buildParams: (cat: object, flows: Array, isUncat?: boolean) => object, createCard: (flow: object, catId: string) => HTMLElement }} ctx
+ */
+export function renderFlowList(ctx) {
+  const { listEl, flows, catData, termManager, runningMap, buildParams, createCard } = ctx;
+  if (!listEl) return;
+
+  termManager.cleanupStaleLiveTerminals(runningMap);
+  termManager.disposeAllLogTerminals();
+
+  listEl.replaceChildren();
+
+  const hasCats = catData.categories.length > 0;
+  const uncatFlows = getUncategorizedFlows(flows, catData.order);
+
+  if (flows.length === 0 && !hasCats) {
+    listEl.appendChild(_el('div', 'flow-empty', EMPTY_LIST_MESSAGE));
+    return;
+  }
+
+  for (const cat of catData.categories) {
+    const catFlows = getFlowsForCategory(flows, catData.order, cat.id);
+    listEl.appendChild(createCategoryGroup(buildParams(cat, catFlows)));
+  }
+
+  if (uncatFlows.length === 0 && !hasCats) return;
+  if (hasCats) {
+    listEl.appendChild(createCategoryGroup(
+      buildParams({ id: UNCATEGORIZED, name: 'Sans catégorie' }, uncatFlows, true)
+    ));
+  } else {
+    for (const flow of uncatFlows) {
+      listEl.appendChild(createCard(flow, UNCATEGORIZED));
+    }
+  }
+}
+
+/**
+ * Handle the "open modal" flow: prompt user, persist, and refresh.
+ * @param {{ existing: object|null, catData: object, moveFlowToCategory: Function, persistCategories: Function, refresh: Function }} ctx
+ * @param {Function} getOpenFlowModal - returns the openFlowModal component
+ * @param {object} flowApi - the flow API service
+ */
+export async function handleOpenModal(ctx, getOpenFlowModal, flowApi) {
+  const { existing, catData, moveFlowToCategory, persistCategories, refresh } = ctx;
+  const openFlowModal = getOpenFlowModal();
+  const flow = await openFlowModal(existing, catData.categories);
+  if (!flow) return;
+
+  const catId = flow._category;
+  delete flow._category;
+
+  await flowApi.save(flow);
+
+  if (catId) {
+    moveFlowToCategory(flow.id, catId);
+  } else if (!existing) {
+    if (!catData.order[UNCATEGORIZED]) catData.order[UNCATEGORIZED] = [];
+    const allOrdered = new Set(Object.values(catData.order).flat());
+    if (!allOrdered.has(flow.id)) {
+      catData.order[UNCATEGORIZED].push(flow.id);
+      await persistCategories();
+    }
+  }
+
+  refresh();
+}
+
+/**
+ * Delete a flow: dispose terminal, remove from order, persist, delete, refresh.
+ * @param {{ termManager: object, catDataOrder: object, persistCategories: Function, refresh: Function }} deps
+ * @param {string} flowId
+ * @param {object} flowApi
+ */
+export async function deleteFlow(deps, flowId, flowApi) {
+  deps.termManager.disposeLiveTerminal(flowId);
+  removeFlowFromOrder(deps.catDataOrder, flowId);
+  await deps.persistCategories();
+  await flowApi.deleteFlow(flowId);
+  deps.refresh();
+}

--- a/src/utils/flow-view-rendering.js
+++ b/src/utils/flow-view-rendering.js
@@ -10,7 +10,7 @@ import {
   getFlowsForCategory, getUncategorizedFlows,
   removeFlowFromOrder,
   createCategoryGroup, createFlowCard,
-  _el, renderButtonBar,
+  _el, buildDomainButtonBar,
 } from './flow-view-subsystem.js';
 
 /**
@@ -26,8 +26,7 @@ export function renderFlowViewShell(container, handlers) {
   header.appendChild(_el('h2', 'flow-title', 'Flows'));
 
   const headerHandlers = { addCategory: handlers.onAddCategory, addFlow: handlers.onAddFlow };
-  const configs = HEADER_BUTTONS.map(({ label, action }) => ({ label, cls: 'flow-add-btn', action }));
-  const headerRight = renderButtonBar({ containerClass: 'flow-header-right', configs, handlers: headerHandlers });
+  const headerRight = buildDomainButtonBar('flow-add-btn', 'flow-header-right', HEADER_BUTTONS, headerHandlers);
   headerRight.style.display = 'flex';
   headerRight.style.gap = '8px';
 

--- a/src/utils/skills-view-actions.js
+++ b/src/utils/skills-view-actions.js
@@ -1,0 +1,132 @@
+/**
+ * SkillsView action handlers — extracted from SkillsView component.
+ *
+ * Each function receives the component state and API dependencies as
+ * parameters, keeping the component class thin.
+ */
+
+import { showPromptDialog, showConfirmDialog } from './dom-dialogs.js';
+import { updateDirtyBadge } from './skills-view-renderer.js';
+
+/**
+ * Open the root skills folder in the OS file manager.
+ */
+export async function openRoot(rootPath, shellApi) {
+  if (!rootPath) return;
+  await shellApi.openPath(rootPath);
+}
+
+/**
+ * Configure the skills root path.
+ * @param {object} sv - SkillsView instance (state is mutated)
+ * @param {object} deps - { dialogApi, skillsApi }
+ */
+export async function configurePath(sv, deps) {
+  const picked = await deps.dialogApi.openFolder();
+  if (!picked) return;
+  const res = await deps.skillsApi.setRoot(picked);
+  if (res && res.success) {
+    sv.rootPath = res.root;
+    sv.selectedId = null;
+    sv.editorDirty = false;
+    await sv.refresh();
+  }
+}
+
+/**
+ * Import a skill from a folder.
+ * @param {object} sv - SkillsView instance
+ * @param {object} deps - { dialogApi, skillsApi }
+ */
+export async function importSkill(sv, deps) {
+  const picked = await deps.dialogApi.openFolder();
+  if (!picked) return;
+  const res = await deps.skillsApi.importSkill(picked);
+  if (res && res.success) {
+    sv.selectedId = res.id;
+    await sv.refresh();
+  } else {
+    await showConfirmDialog(
+      `Import impossible : ${res?.error || 'erreur inconnue'}. Le dossier doit contenir un fichier SKILL.md.`,
+      { confirmLabel: 'OK', cancelLabel: 'Fermer' },
+    );
+  }
+}
+
+/**
+ * Create a new skill via prompts.
+ * @param {object} sv - SkillsView instance
+ * @param {object} skillsApi
+ */
+export async function createSkill(sv, skillsApi) {
+  const id = await showPromptDialog({
+    title: 'Nouveau skill',
+    placeholder: 'identifiant-du-skill',
+    confirmLabel: 'Créer',
+    cancelLabel: 'Annuler',
+  });
+  if (!id) return;
+  const description = await showPromptDialog({
+    title: 'Description',
+    placeholder: 'Quand activer ce skill ?',
+    confirmLabel: 'Créer',
+    cancelLabel: 'Annuler',
+  });
+  const res = await skillsApi.create({ id, description: description || '' });
+  if (res && res.success) {
+    sv.selectedId = res.id;
+    await sv.refresh();
+  }
+}
+
+/**
+ * Delete a skill after confirmation.
+ * @param {object} sv - SkillsView instance
+ * @param {string} id - skill id
+ * @param {object} skillsApi
+ */
+export async function deleteSkill(sv, id, skillsApi) {
+  const ok = await showConfirmDialog(
+    `Supprimer le skill "${id}" ? Cette action est irréversible.`,
+    { confirmLabel: 'Supprimer', cancelLabel: 'Annuler' },
+  );
+  if (!ok) return;
+  await skillsApi.deleteSkill(id);
+  if (sv.selectedId === id) sv.selectedId = null;
+  await sv.refresh();
+}
+
+/**
+ * Select a skill (with dirty-check).
+ * @param {object} sv - SkillsView instance
+ * @param {string} id - skill id
+ */
+export async function selectSkill(sv, id) {
+  if (sv.editorDirty) {
+    const ok = await showConfirmDialog(
+      'Modifications non enregistrées. Abandonner les changements en cours ?',
+      { confirmLabel: 'Abandonner', cancelLabel: 'Rester' },
+    );
+    if (!ok) return;
+  }
+  sv.selectedId = id;
+  sv.editorDirty = false;
+  sv._renderList();
+  await sv._renderEditor();
+}
+
+/**
+ * Save the active skill.
+ * @param {object} sv - SkillsView instance
+ * @param {object} skillsApi
+ */
+export async function save(sv, skillsApi) {
+  const skill = sv.skills.find((s) => s.id === sv.selectedId);
+  if (!skill) return;
+  const res = await skillsApi.write(skill.path, sv.editorValue);
+  if (res && res.success) {
+    sv.editorDirty = false;
+    updateDirtyBadge(sv._dirtyBadgeEl, false);
+    await sv.refresh();
+  }
+}

--- a/src/utils/tab-manager-sidebar.js
+++ b/src/utils/tab-manager-sidebar.js
@@ -1,0 +1,91 @@
+/**
+ * TabManager sidebar and workspace helpers — extracted from TabManager class.
+ *
+ * These functions build the deps objects and call into sidebar-manager and
+ * workspace-ops on behalf of the TabManager.  State is passed in via the
+ * `tm` (TabManager instance) parameter.
+ */
+
+import {
+  renderActivityBar as doRenderActivityBar,
+  detachSidebarView, changeSidebarMode as doChangeSidebarMode,
+  disposeSideView as doDisposeSideView, disposeAllSideViews as doDisposeAllSideViews,
+} from './sidebar-manager.js';
+import {
+  renderWorkspace as doRenderWorkspace, reattachLayout,
+  capturePanelWidths, disposeAllTabs as doDisposeAllTabs,
+} from './workspace-ops.js';
+import { getComponent } from './tab-manager-init.js';
+import { buildViewStore } from './tab-facade.js';
+
+export function renderActivityBar(tm) {
+  doRenderActivityBar({
+    sidebarMode: tm.sidebarMode,
+    setSidebarMode: (mode) => tm.setSidebarMode(mode),
+    onOpenSettings: tm.onOpenSettings,
+  });
+}
+
+export function setSidebarMode(tm, mode) {
+  if (mode === tm.sidebarMode) return;
+
+  doChangeSidebarMode({
+    getActiveTab: () => tm._activeTab(),
+    capturePanelWidths,
+    viewStore: buildViewStore(tm),
+    workspaceContainer: tm.workspaceContainer,
+    reattachLayout,
+    renderWorkspace: (tab) => tm.renderWorkspace(tab),
+    tabManager: tm,
+    resolveComponent: getComponent,
+  }, tm.sidebarMode, mode);
+  tm.sidebarMode = mode;
+
+  tm.renderActivityBar();
+}
+
+export async function renderWorkspace(tm, tab, api) {
+  return doRenderWorkspace({
+    workspaceContainer: tm.workspaceContainer,
+    getActiveTabId: () => tm.activeTabId,
+    getActiveTab: () => tm._activeTab(),
+    scheduleAutoSave: () => tm.configManager.scheduleAutoSave(),
+  }, tab, api, {
+    FileTree: getComponent('FileTree'),
+    FileViewer: getComponent('FileViewer'),
+    TerminalPanel: getComponent('TerminalPanel'),
+    WebviewManager: getComponent('WebviewManager'),
+    GitChangesView: getComponent('GitChangesView'),
+  });
+}
+
+export function buildSwitchToDeps(tm) {
+  return {
+    tabs: tm.tabs,
+    getActiveTabId: () => tm.activeTabId,
+    setActiveTabId: (newId) => { tm.activeTabId = newId; },
+    getSidebarMode: () => tm.sidebarMode,
+    setSidebarMode: (mode) => { tm.sidebarMode = mode; },
+    workspaceContainer: tm.workspaceContainer,
+    renderTabBar: () => tm.renderTabBar(),
+    renderActivityBar: () => tm.renderActivityBar(),
+    renderWorkspace: (tab) => tm.renderWorkspace(tab),
+    detachSidebarView: (mode) => detachSidebarView({
+      getActiveTab: () => tm._activeTab(),
+      capturePanelWidths,
+      viewStore: buildViewStore(tm),
+    }, mode),
+  };
+}
+
+export function disposeSideView(tm, mode) {
+  doDisposeSideView(buildViewStore(tm), mode);
+}
+
+export function disposeAllSideViews(tm) {
+  doDisposeAllSideViews(buildViewStore(tm));
+}
+
+export function disposeAllTabs(tm) {
+  doDisposeAllTabs({ tabs: tm.tabs, setActiveTabId: (id) => { tm.activeTabId = id; } });
+}

--- a/src/utils/tab-manager-tab-ops.js
+++ b/src/utils/tab-manager-tab-ops.js
@@ -1,0 +1,87 @@
+/**
+ * TabManager tab operations helpers — extracted from TabManager class.
+ *
+ * Builds the deps objects for renderTabBar, createTab, closeTab, and
+ * color-filter operations.
+ */
+
+import {
+  renderTabBar as doRenderTabBar,
+  createTab as doCreateTab,
+  closeTab as doCloseTab,
+  reorderEntries,
+  inlineRenameTab as doInlineRenameTab,
+} from './tab-facade.js';
+
+/**
+ * Build the deps and call doRenderTabBar.
+ * @param {object} tm - TabManager instance
+ * @returns {Map} tab element map
+ */
+export function renderTabBar(tm) {
+  return doRenderTabBar({
+    tabBar: tm.tabBar,
+    tabs: tm.tabs,
+    activeTabId: tm.activeTabId,
+    activeColorFilter: tm.activeColorFilter,
+    excludedColors: tm.excludedColors,
+    switchTo: (id) => tm.switchTo(id),
+    closeTab: (id) => tm.closeTab(id),
+    renameTab: (id, nameEl) => tm.renameTab(id, nameEl),
+    setTabColorGroup: (id, cg) => tm.setTabColorGroup(id, cg),
+    toggleNoShortcut: (id) => tm.toggleNoShortcut(id),
+    setColorFilter: (id) => tm.setColorFilter(id),
+    toggleExcludeColor: (id) => tm.toggleExcludeColor(id),
+    clearColorFilters: () => { tm.activeColorFilter = null; tm.excludedColors.clear(); },
+    createTab: () => tm.createTab(),
+    reorderTab: (fromId, toId, before) => tm.reorderTab(fromId, toId, before),
+    isTabVisible: (tab) => tm._isTabVisible(tab),
+    renderTabBar: () => tm.renderTabBar(),
+  });
+}
+
+/**
+ * Build the deps and call doCreateTab.
+ */
+export function createTab(tm, switchTo, name, cwd) {
+  return doCreateTab({
+    tabs: tm.tabs,
+    defaultCwd: tm.defaultCwd,
+    activeColorFilter: tm.activeColorFilter,
+    renderTabBar: () => tm.renderTabBar(),
+    configManager: tm.configManager,
+  }, switchTo, name, cwd);
+}
+
+/**
+ * Build the deps and call doCloseTab.
+ */
+export function closeTab(tm, createTabFn, switchToFn, id) {
+  return doCloseTab({
+    tabs: tm.tabs,
+    activeTabId: tm.activeTabId,
+    renderTabBar: () => tm.renderTabBar(),
+    configManager: tm.configManager,
+  }, createTabFn, switchToFn, id);
+}
+
+/**
+ * Reorder tabs in the map.
+ */
+export function reorderTab(tm, fromId, toId, before) {
+  if (fromId === toId) return;
+  tm.tabs = new Map(reorderEntries(Array.from(tm.tabs.entries()), fromId, toId, before));
+  tm.renderTabBar();
+  tm.configManager.scheduleAutoSave();
+}
+
+/**
+ * Inline rename a tab.
+ */
+export function renameTab(tm, id) {
+  const tab = tm.tabs.get(id);
+  return (nameEl) => doInlineRenameTab(tab, nameEl,
+    () => { tm.renderTabBar(); tm.configManager.scheduleAutoSave(); },
+    () => tm.renderTabBar(),
+  );
+}

--- a/tests/utils/di-injection-workspace.test.js
+++ b/tests/utils/di-injection-workspace.test.js
@@ -113,15 +113,25 @@ describe('DI: workspace-layout renderWorkspace signature', () => {
 
 describe('DI: tab-manager caller passes explicit deps to renderWorkspace', () => {
   it('renderWorkspace call in tab-manager passes explicit deps object and this._api', () => {
-    const src = fs.readFileSync(
-      path.resolve(__dirname, '../../src/components/tab-manager.js'),
+    // The deps-building for renderWorkspace was extracted from tab-manager.js
+    // into tab-manager-sidebar.js.  The DI pattern is preserved there:
+    // doRenderWorkspace({ workspaceContainer: ... }, tab, api, { ... })
+    const sidebarSrc = fs.readFileSync(
+      path.resolve(__dirname, '../../src/utils/tab-manager-sidebar.js'),
       'utf-8',
     );
 
-    // Verify the caller passes an explicit deps object (not `this`)
-    expect(src).toContain('doRenderWorkspace({');
-    expect(src).toContain('this._api');
-    // Should NOT pass `this` as first argument
-    expect(src).not.toMatch(/doRenderWorkspace\(this,/);
+    // Verify the extracted module passes an explicit deps object (not `this`)
+    expect(sidebarSrc).toContain('doRenderWorkspace({');
+    // Should NOT pass `this` or `tm` as first argument
+    expect(sidebarSrc).not.toMatch(/doRenderWorkspace\(tm,/);
+    expect(sidebarSrc).not.toMatch(/doRenderWorkspace\(this,/);
+
+    // Verify tab-manager.js delegates to the sidebar module and passes this._api
+    const tmSrc = fs.readFileSync(
+      path.resolve(__dirname, '../../src/components/tab-manager.js'),
+      'utf-8',
+    );
+    expect(tmSrc).toContain('this._api');
   });
 });


### PR DESCRIPTION
## Summary

- Extracts rendering, actions, and DOM-building logic from the 5 largest UI components into dedicated helper modules
- **FlowView** (252 -> 141 lines): new `flow-view-rendering.js` (shell DOM, list rendering, card building, modal/delete logic)
- **TabManager** (294 -> 147 lines): new `tab-manager-sidebar.js` (sidebar/workspace deps) and `tab-manager-tab-ops.js` (tab bar/create/close/reorder deps)
- **FileViewer** (290 -> 127 lines): new `file-viewer-editor.js` (shell DOM, editor rendering, status bar, mode switching, tabs)
- **FileTree** (246 -> 99 lines): new `file-tree-dir-ops.js` (expand/collapse, dir entry callbacks, section management)
- **SkillsView** (192 -> 102 lines): new `skills-view-actions.js` (all user actions: create, delete, import, configure, select, save)
- All extractions are mechanical: same logic relocated into pure functions receiving explicit deps
- Updated DI injection test to check new file location for renderWorkspace deps pattern

## Test plan

- [x] `node build.js` passes
- [x] `npx vitest run` -- all 397 tests pass
- [x] Each component is under 150 lines
- [x] No business logic changes -- purely structural refactoring

Closes #397

Generated with [Claude Code](https://claude.com/claude-code)