### PR TITLE
refactor: remove 9 unused exports (issue #423)

### DIFF
--- a/main/date-utils.js
+++ b/main/date-utils.js
@@ -2,12 +2,11 @@
  * Date/time utilities for the main process.
  * Pure functions — no side effects.
  *
- * Generic formatting (formatDateTime) lives in shared/date-utils.js
- * and is re-exported here for backward compatibility.
+ * Generic formatting (formatDateTime) lives in shared/date-utils.js.
  * Domain-specific helpers (extractDateString, generateDateRange) stay here.
  */
 
-const { formatDateTime, DATE_LOCALE } = require('../shared/date-utils');
+const { DATE_LOCALE } = require('../shared/date-utils');
 const DAY_LABEL_FORMAT = { day: '2-digit', month: '2-digit' };
 
 /**
@@ -36,4 +35,4 @@ function generateDateRange(days = 30) {
   });
 }
 
-module.exports = { extractDateString, generateDateRange, formatDateTime };
+module.exports = { extractDateString, generateDateRange };

--- a/main/ipc-helpers.js
+++ b/main/ipc-helpers.js
@@ -43,24 +43,6 @@ function buildTablesFromSchema(schema) {
 const { forward: FORWARD_TABLE, spread: SPREAD_TABLE } = buildTablesFromSchema(API_SCHEMA);
 
 /**
- * Return the list of all declaratively registered IPC channel names.
- * Returns all declaratively registered IPC channel names.
- *
- * @param {Set<string>} [skip] - Channels to exclude (custom handlers managed separately)
- * @returns {string[]}
- */
-function getRegisteredChannels(skip = new Set()) {
-  const channels = [];
-  for (const [channel] of FORWARD_TABLE) {
-    if (!skip.has(channel)) channels.push(channel);
-  }
-  for (const [channel] of SPREAD_TABLE) {
-    if (!skip.has(channel)) channels.push(channel);
-  }
-  return channels;
-}
-
-/**
  * @internal
  * Generic handler registration — loops over entries and registers an
  * `ipc.handle` for each one, using `buildCallback` to create the handler.
@@ -125,7 +107,7 @@ function registerManagerHandlers(ipc, targets, skip = new Set()) {
   );
 }
 
-module.exports = { safeSend, registerManagerHandlers, getRegisteredChannels };
+module.exports = { safeSend, registerManagerHandlers };
 
 /** @internal — exposed for unit tests only; not part of the public API. */
 module.exports._internals = { buildTablesFromSchema, registerForward, registerSpread };

--- a/src/utils/file-tree-dir-ops.js
+++ b/src/utils/file-tree-dir-ops.js
@@ -17,7 +17,7 @@ import { rebuildSectionDOM } from './file-tree-section-dom.js';
 /**
  * Expand a directory in the tree.
  */
-export async function expandDir(dirPath, childContainer, chevron, depth, expandedDirs, renderDirFn) {
+async function expandDir(dirPath, childContainer, chevron, depth, expandedDirs, renderDirFn) {
   expandedDirs.add(dirPath);
   chevron.textContent = CHEVRON_EXPANDED;
   chevron.classList.add('expanded');
@@ -27,7 +27,7 @@ export async function expandDir(dirPath, childContainer, chevron, depth, expande
 /**
  * Collapse a directory in the tree.
  */
-export function collapseDir(dirPath, childContainer, chevron, expandedDirs) {
+function collapseDir(dirPath, childContainer, chevron, expandedDirs) {
   expandedDirs.delete(dirPath);
   childContainer.replaceChildren();
   chevron.textContent = CHEVRON_COLLAPSED;
@@ -39,7 +39,7 @@ export function collapseDir(dirPath, childContainer, chevron, expandedDirs) {
  * @param {object} ft - FileTree instance
  * @param {Set<string>} expandedDirs
  */
-export function getDirEntryCallbacks(ft, expandedDirs) {
+function getDirEntryCallbacks(ft, expandedDirs) {
   return {
     setupDropZone: (el, targetDir) => ft._setupDropZone(el, targetDir),
     expandDir: (dirPath, childContainer, chevron, depth, eDirs) =>
@@ -59,14 +59,14 @@ export function getDirEntryCallbacks(ft, expandedDirs) {
 /**
  * Render a single directory entry.
  */
-export async function renderDirEntryWrap(ft, entry, parentEl, depth, expandedDirs) {
+async function renderDirEntryWrap(ft, entry, parentEl, depth, expandedDirs) {
   await renderDirEntry(entry, parentEl, depth, expandedDirs, getDirEntryCallbacks(ft, expandedDirs));
 }
 
 /**
  * Render a single file entry.
  */
-export function renderFileEntryWrap(ft, entry, parentEl, depth) {
+function renderFileEntryWrap(ft, entry, parentEl, depth) {
   const activeRowRef = {
     get current() { return ft._activeRow; },
     set current(v) { ft._activeRow = v; },
@@ -128,7 +128,7 @@ export function removeTerminal(ft, termId, fsUnwatch) {
 /**
  * Remove a terminal from its section, and cleanup if section is empty.
  */
-export function removeTermFromSection(ft, termId, cwd, fsUnwatch) {
+function removeTermFromSection(ft, termId, cwd, fsUnwatch) {
   const section = ft.sections.get(cwd);
   if (!section) return;
 

--- a/src/utils/skills-view-renderer.js
+++ b/src/utils/skills-view-renderer.js
@@ -147,7 +147,7 @@ export function renderEditorEmpty(editorEl) {
  * @param {boolean} isDirty
  * @returns {HTMLElement}
  */
-export function createDirtyBadge(isDirty) {
+function createDirtyBadge(isDirty) {
   return _el('div', {
     className: `skills-editor-dirty ${isDirty ? 'is-dirty' : ''}`,
     textContent: isDirty ? 'Modifié' : 'Enregistré',

--- a/tests/main/date-utils.test.js
+++ b/tests/main/date-utils.test.js
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
-const { extractDateString, generateDateRange, formatDateTime } = require('../../main/date-utils');
+const { extractDateString, generateDateRange } = require('../../main/date-utils');
+const { formatDateTime } = require('../../shared/date-utils');
 
 describe('date-utils', () => {
   describe('extractDateString', () => {


### PR DESCRIPTION
## Summary

- **`src/utils/file-tree-dir-ops.js`**: removed `export` keyword from 6 functions (`expandDir`, `collapseDir`, `getDirEntryCallbacks`, `renderDirEntryWrap`, `renderFileEntryWrap`, `removeTermFromSection`) — they are only used locally within the module
- **`src/utils/skills-view-renderer.js`**: removed `export` from `createDirtyBadge` — only called internally by `renderEditorContent`
- **`main/ipc-helpers.js`**: removed `getRegisteredChannels` from `module.exports` and deleted the function entirely (no local or external usage found)
- **`main/date-utils.js`**: removed `formatDateTime` re-export — consumers already import it directly from `shared/date-utils.js`. Updated the test file accordingly.

No business logic changed. Build and all 402 tests pass.

Closes #423

## Test plan

- [x] `npm run build` passes
- [x] `npm test` passes (25 test files, 402 tests)
- [ ] Verify no runtime regression in the Electron app

🤖 Generated with [Claude Code](https://claude.com/claude-code)