### PR TITLE
refactor: replace JSDoc {*} wildcards with precise types in aggregation-utils

### DIFF
--- a/shared/aggregation-utils.js
+++ b/shared/aggregation-utils.js
@@ -50,8 +50,8 @@ function groupAndAggregate(items, keyFn, aggFn) {
  * Each element may be a plain string or an object with a `.key` property.
  *
  * @param {Array<string|{key: string}>} keys
- * @param {*} [defaultValue=0]
- * @returns {Record<string, *>}
+ * @param {number} [defaultValue=0]
+ * @returns {Record<string, number>}
  */
 function initializeCounters(keys, defaultValue = 0) {
   return Object.fromEntries(keys.map(k => [typeof k === 'string' ? k : k.key, defaultValue]));
@@ -89,8 +89,8 @@ function sumByKeys(obj, keys) {
  *
  * @param {Record<string, unknown>} source
  * @param {Array<{key: string, apiField: string}>} fieldMap
- * @param {*} [defaultValue=0]
- * @returns {Record<string, unknown>}
+ * @param {number} [defaultValue=0]
+ * @returns {Record<string, number>}
  */
 function mapFields(source, fieldMap, defaultValue = 0) {
   return Object.fromEntries(fieldMap.map(f => [f.key, source[f.apiField] || defaultValue]));


### PR DESCRIPTION
## Summary

- Replace `{*}` wildcard JSDoc types with `{number}` in `initializeCounters` and `mapFields` (`shared/aggregation-utils.js`)
- All call sites use numeric default value (`0`), so `{number}` is the correct concrete type
- Fixes regression pattern from #327/#367

## Changes

- **Line 53**: `@param {*} [defaultValue=0]` -> `@param {number} [defaultValue=0]` (initializeCounters)
- **Line 54**: `@returns {Record<string, *>}` -> `@returns {Record<string, number>}` (initializeCounters)
- **Line 92**: `@param {*} [defaultValue=0]` -> `@param {number} [defaultValue=0]` (mapFields)
- **Line 93**: `@returns {Record<string, unknown>}` -> `@returns {Record<string, number>}` (mapFields)

No logic changes -- only JSDoc comment annotations.

Closes #424

## Test plan

- [x] `npm run build` passes
- [x] `npm test` passes (25 test files, 402 tests)
- [x] Verified all call sites use numeric defaults -- `{number}` is correct over `@template`

🤖 Generated with [Claude Code](https://claude.com/claude-code)