### PR TITLE
refactor: extract createPtyBoundTerminal to deduplicate terminal creation

### DIFF
--- a/src/components/board-view.js
+++ b/src/components/board-view.js
@@ -1,7 +1,8 @@
 import {
   onTerminalCreated, onTerminalRemoved, onTerminalExited,
   _el, renderButtonBar, renderList,
-  _safeFit, createTerminal, disposeTerminal, disposeTerminalMap, setupTerminalAddons,
+  _safeFit, disposeTerminal, disposeTerminalMap, setupTerminalAddons,
+  createPtyBoundTerminal,
 } from '../utils/terminal-subsystem.js';
 import { registerComponent } from '../utils/component-registry.js';
 import { RendererPollingTimer } from '../utils/polling.js';
@@ -142,8 +143,24 @@ export class BoardView extends ComponentBase {
     return _el('div', { className: 'board-card-header' }, nameGroup, headerBtns);
   }
 
-  _createBoardTerminal(termContainer, termId) {
-    const { term, fitAddon } = createTerminal(termContainer, BOARD_TERMINAL_OPTS);
+  addCard(termId, info) {
+    const termContainer = _el('div', { className: 'board-card-terminal' });
+    const card = _el('div', { className: 'board-card board-card-running' });
+
+    card.appendChild(this._buildCardHeader(termId, info, card));
+    card.appendChild(termContainer);
+
+    const cardData = { element: card, term: null, fitAddon: null, unsubData: null, resizeObs: null, info, status: 'running', dataBytes: DATA_VOLUME_THRESHOLD };
+
+    const { term, fitAddon, resizeObs, unsubData } = createPtyBoundTerminal(termContainer, {
+      readonly: false,
+      termOpts: BOARD_TERMINAL_OPTS,
+      fitDelay: FIT_SETTLE_DELAY_MS,
+      onPtyData: (writeFn) => ptyApi.onData(termId, (data) => {
+        writeFn(data);
+        cardData.dataBytes += data.length;
+      }),
+    });
 
     setupTerminalAddons(term, {
       openExternal: (url) => shellApi.openExternal(url),
@@ -153,33 +170,10 @@ export class BoardView extends ComponentBase {
     });
     term.onData((data) => ptyApi.write(termId, data));
 
-    return { term, fitAddon };
-  }
-
-  addCard(termId, info) {
-    const termContainer = _el('div', { className: 'board-card-terminal' });
-    const card = _el('div', { className: 'board-card board-card-running' });
-
-    card.appendChild(this._buildCardHeader(termId, info, card));
-    card.appendChild(termContainer);
-
-    const { term, fitAddon } = this._createBoardTerminal(termContainer, termId);
-    const fitOnly = () => _safeFit(fitAddon);
-
-    const cardData = { element: card, term, fitAddon, unsubData: null, resizeObs: null, info, status: 'running', dataBytes: DATA_VOLUME_THRESHOLD };
-
-    cardData.unsubData = ptyApi.onData(termId, (data) => {
-      term.write(data);
-      cardData.dataBytes += data.length;
-    });
+    Object.assign(cardData, { term, fitAddon, resizeObs, unsubData });
 
     this.boardEl.insertBefore(card, this.emptyEl);
-
-    cardData.resizeObs = new ResizeObserver(fitOnly);
-    cardData.resizeObs.observe(termContainer);
     this.cards.set(termId, cardData);
-
-    setTimeout(fitOnly, FIT_SETTLE_DELAY_MS);
   }
 
   removeCard(termId) {

--- a/src/components/flow-card-terminal.js
+++ b/src/components/flow-card-terminal.js
@@ -5,7 +5,7 @@
 import { _el } from '../utils/flow-dom.js';
 import { createModalOverlay } from '../utils/dom-dialogs.js';
 import { onKeyAction } from '../utils/event-helpers.js';
-import { _safeFit, createReadonlyTerminal, disposeTerminal, disposeTerminalMap } from '../utils/terminal-factory.js';
+import { _safeFit, createReadonlyTerminal, createPtyBoundTerminal, disposeTerminal, disposeTerminalMap } from '../utils/terminal-factory.js';
 import {
   FIT_DELAY_MS, LOG_SCROLLBACK, LIVE_SCROLLBACK,
   STATUS_LABELS, NO_LOG_MESSAGE, NO_LOG_MODAL_MESSAGE,
@@ -65,15 +65,13 @@ export class FlowCardTerminalManager {
 
     const containerEl = _el('div', 'flow-card-terminal');
 
-    this._createAndRegister(
-      this._liveTerminals, flowId, containerEl,
-      { scrollback: LIVE_SCROLLBACK, cursorStyle: 'bar' },
-      (rec) => {
-        const unsubData = ptyApi.onData(ptyId, (data) => { rec.term.write(data); });
-        rec.unsubData = unsubData;
-        rec.ptyId = ptyId;
-      },
-    );
+    const record = createPtyBoundTerminal(containerEl, {
+      termOpts: { scrollback: LIVE_SCROLLBACK, cursorStyle: 'bar' },
+      fitDelay: FIT_DELAY_MS,
+      onPtyData: (writeFn) => ptyApi.onData(ptyId, writeFn),
+    });
+
+    this._liveTerminals.set(flowId, { ...record, containerEl, ptyId });
 
     return containerEl;
   }

--- a/src/utils/terminal-factory.js
+++ b/src/utils/terminal-factory.js
@@ -90,3 +90,39 @@ export function setupTerminalAddons(term, { openExternal, getCwd, homedir, openP
   }));
   term.registerLinkProvider(new FilePathLinkProvider(term, getCwd, { homedir, openPath }));
 }
+
+/**
+ * Create a terminal bound to a PTY data stream.
+ *
+ * Encapsulates the repeated pattern shared by BoardView cards and
+ * FlowCardTerminalManager live terminals:
+ *   1. Create a terminal (readonly by default) with auto-resize.
+ *   2. Subscribe to a PTY data feed so output is written to the terminal.
+ *   3. Return all handles needed for cleanup.
+ *
+ * @param {HTMLElement} container - DOM element the terminal opens into.
+ * @param {object} options
+ * @param {(cb: (data: string) => void) => (() => void)} options.onPtyData
+ *   Subscribe to PTY output — receives a callback that writes to the
+ *   terminal; must return an unsubscribe function.
+ * @param {object}  [options.termOpts]  Extra terminal options forwarded to
+ *   createReadonlyTerminal / createTerminal.
+ * @param {boolean} [options.readonly=true]  When true (default) the terminal
+ *   is created via createReadonlyTerminal; otherwise via createTerminal with
+ *   autoResize enabled.
+ * @param {number}  [options.fitDelay=0]  Delay (ms) before the first fit()
+ *   call — forwarded to the underlying createTerminal / createReadonlyTerminal.
+ * @returns {{ term: Terminal, fitAddon: FitAddon, resizeObs: ResizeObserver|null, unsubData: (() => void)|null }}
+ */
+export function createPtyBoundTerminal(container, { onPtyData, termOpts = {}, readonly = true, fitDelay = 0 } = {}) {
+  const create = readonly ? createReadonlyTerminal : createTerminal;
+  const { term, fitAddon, resizeObs } = create(container, {
+    autoResize: true,
+    fitDelay,
+    ...termOpts,
+  });
+
+  const unsubData = onPtyData ? onPtyData((data) => term.write(data)) : null;
+
+  return { term, fitAddon, resizeObs, unsubData };
+}

--- a/src/utils/terminal-subsystem.js
+++ b/src/utils/terminal-subsystem.js
@@ -46,5 +46,5 @@ export { _el, renderButtonBar, renderList } from './terminal-dom.js';
 // ── terminal-factory (board-view) ───────────────────────────────────
 export {
   _safeFit, createTerminal, disposeTerminal, disposeTerminalMap,
-  setupTerminalAddons,
+  setupTerminalAddons, createPtyBoundTerminal,
 } from './terminal-factory.js';


### PR DESCRIPTION
## Summary

- Extracted a new `createPtyBoundTerminal(container, options)` factory function in `src/utils/terminal-factory.js` that encapsulates the repeated pattern of creating a terminal with auto-resize, subscribing to a PTY data feed, and returning cleanup handles.
- Refactored `BoardView.addCard()` in `board-view.js` to use `createPtyBoundTerminal` instead of the removed `_createBoardTerminal` method + manual ResizeObserver + manual PTY subscription.
- Refactored `FlowCardTerminalManager.createLiveTerminal()` in `flow-card-terminal.js` to use `createPtyBoundTerminal` instead of `_createAndRegister` with a setup callback.
- Re-exported `createPtyBoundTerminal` from `terminal-subsystem.js` facade.

Closes #426

## Test plan

- [x] `npm run build` passes
- [x] `npm test` passes (402/402 tests)
- [ ] Manual: verify board cards still display live agent output and accept keyboard input
- [ ] Manual: verify flow card live terminals still stream PTY output

🤖 Generated with [Claude Code](https://claude.com/claude-code)