### PR TITLE
refactor: extract gitFlowStep helper to deduplicate error handling

### DIFF
--- a/src/utils/git-flow-helpers.js
+++ b/src/utils/git-flow-helpers.js
@@ -1,0 +1,29 @@
+/**
+ * Shared helpers for git-related flows (open-PR, worktree, etc.).
+ *
+ * Deduplicates the common "call an API → check result?.ok → showErrorAlert"
+ * pattern that was previously copy-pasted across flow modules.
+ */
+
+import { showErrorAlert } from './dom-dialogs.js';
+
+/**
+ * Execute a git-flow API call and surface a user-visible error alert when the
+ * call fails (i.e. `result?.ok` is falsy).
+ *
+ * Returns the API result on success, or `null` on failure (after the alert has
+ * been shown).  Callers can simply check `if (!result) return;`.
+ *
+ * @param {() => Promise<{ ok: boolean, error?: string }>} apiCall
+ * @param {string} errorPrefix  Human-readable prefix shown before the error
+ *   detail (e.g. `"Push failed: "`).
+ * @returns {Promise<{ ok: boolean, error?: string } | null>}
+ */
+export async function gitFlowStep(apiCall, errorPrefix) {
+  const result = await apiCall();
+  if (!result?.ok) {
+    await showErrorAlert(errorPrefix, result?.error);
+    return null;
+  }
+  return result;
+}

--- a/src/utils/open-pr-flow.js
+++ b/src/utils/open-pr-flow.js
@@ -8,6 +8,7 @@
 
 import { showConfirmDialog, showErrorAlert } from './dom-dialogs.js';
 import { _el } from './git-dom.js';
+import { gitFlowStep } from './git-flow-helpers.js';
 
 /**
  * Parse a remote URL (HTTPS or SSH) into { host, owner, repo }.
@@ -163,11 +164,8 @@ export async function openPrFlow({ cwd, baseBranch = null, api }) {
   );
   if (!ok) return;
 
-  const push = await api.pushBranch({ cwd, branch });
-  if (!push?.ok) {
-    await showErrorAlert('Push failed: ', push?.error);
-    return;
-  }
+  const push = await gitFlowStep(() => api.pushBranch({ cwd, branch }), 'Push failed: ');
+  if (!push) return;
 
   await api.openExternal(url);
 }

--- a/src/utils/worktree-flow.js
+++ b/src/utils/worktree-flow.js
@@ -8,8 +8,9 @@
  */
 
 import { showWorktreeDialog } from './worktree-dialog.js';
-import { showConfirmDialog, showErrorAlert } from './dom-dialogs.js';
+import { showConfirmDialog } from './dom-dialogs.js';
 import { _el } from './git-dom.js';
+import { gitFlowStep } from './git-flow-helpers.js';
 
 /**
  * Branches to hide from the "existing branch" picker: those already checked
@@ -63,18 +64,17 @@ export async function createWorktreeFlow({ repoCwd, api, createTab }) {
   });
   if (!choice) return;
 
-  const result = await api.worktreeAdd({
-    cwd: repoCwd,
-    branch: choice.branch,
-    targetPath: choice.targetPath,
-    createBranch: choice.createBranch,
-    baseBranch: choice.baseBranch,
-  });
-
-  if (!result?.ok) {
-    await showErrorAlert('Worktree creation failed: ', result?.error);
-    return;
-  }
+  const result = await gitFlowStep(
+    () => api.worktreeAdd({
+      cwd: repoCwd,
+      branch: choice.branch,
+      targetPath: choice.targetPath,
+      createBranch: choice.createBranch,
+      baseBranch: choice.baseBranch,
+    }),
+    'Worktree creation failed: ',
+  );
+  if (!result) return;
 
   const tab = createTab(choice.branch, choice.targetPath);
   if (tab) {
@@ -123,14 +123,13 @@ export async function maybeRemoveWorktree(worktree, tabName, api) {
       { confirmLabel: 'Force remove', cancelLabel: 'Cancel' },
     );
     if (!retryForce) return;
-    result = await api.worktreeRemove({
-      cwd: worktree.mainRepoCwd,
-      worktreePath: worktree.worktreePath,
-      force: true,
-    });
-  }
-
-  if (!result?.ok) {
-    await showErrorAlert('Could not remove worktree: ', result?.error);
+    await gitFlowStep(
+      () => api.worktreeRemove({
+        cwd: worktree.mainRepoCwd,
+        worktreePath: worktree.worktreePath,
+        force: true,
+      }),
+      'Could not remove worktree: ',
+    );
   }
 }


### PR DESCRIPTION
## Summary

- Extracted a `gitFlowStep(apiCall, errorPrefix)` helper into `src/utils/git-flow-helpers.js` that encapsulates the recurring `if (!result?.ok) { showErrorAlert(...); return; }` pattern
- Refactored `open-pr-flow.js` to use `gitFlowStep` for the push step
- Refactored `worktree-flow.js` to use `gitFlowStep` for worktree-add and force-remove steps
- Removed unused `showErrorAlert` import from `worktree-flow.js`

Closes #427

## Test plan

- [x] `npm run build` passes
- [x] `npm test` passes (403/403 tests)
- [ ] Manual: verify open-PR flow shows same error messages on push failure
- [ ] Manual: verify worktree creation flow shows same error on add failure
- [ ] Manual: verify worktree force-remove shows same error on failure

Generated with [Claude Code](https://claude.com/claude-code)