### PR TITLE
refactor: deduplicate sanitization and button bar patterns

### DIFF
--- a/main/skills-manager.js
+++ b/main/skills-manager.js
@@ -7,6 +7,7 @@ const { readJson, writeJson, ensureDirOnce } = require('./fs-utils');
 const { trySafe } = require('./logger');
 const { pathExists } = require('./fs-manager-helpers');
 const { JsonStore } = require('./json-store');
+const { sanitizeSegment } = require('../shared/string-utils');
 
 const store = new JsonStore(BASE_DIR, 'skills-manager');
 const log = store.log;
@@ -92,7 +93,7 @@ async function write({ filePath, content }) {
 }
 
 async function create({ id, description }) {
-  const safeId = String(id || '').trim().replace(/[^a-zA-Z0-9._-]/g, '-');
+  const safeId = sanitizeSegment(String(id || '').trim());
   if (!safeId) return { success: false, error: 'Invalid id' };
   const root = await _loadRoot();
   const dir = path.join(root, safeId);


### PR DESCRIPTION
## Summary

- Replace the last inline sanitization regex in `skills-manager.js` with the shared `sanitizeSegment` helper from `shared/string-utils.js`
- The button bar deduplication (`buildDomainButtonBar`) and `sanitizeName` extraction were already completed by PR #421; this PR addresses the remaining residual inline pattern

## Context

Issue #415 reported residual duplications for sanitization and button bar patterns (partial regression of #338). Most of the work was already done by #421. This PR cleans up the last inline `replace(/[^a-zA-Z0-9._-]/g, '-')` in `main/skills-manager.js` line 95.

## Changes

- `main/skills-manager.js`: Import `sanitizeSegment` from `shared/string-utils` and use it instead of the inline regex

## Test plan

- [x] `npm run build` passes
- [x] `npm test` passes (402/402 tests)
- [x] Behavior preserved: `sanitizeSegment` applies the same character allowlist (`[a-zA-Z0-9._-]`) with minor improvement (coalesces consecutive replacements, trims boundary hyphens)

Closes #415

🤖 Generated with [Claude Code](https://claude.com/claude-code)