### PR TITLE
refactor: reduce UI-service coupling via domain facades

### DIFF
--- a/src/components/board-view.js
+++ b/src/components/board-view.js
@@ -14,7 +14,7 @@ import {
   resolveCardStatus, findTabForTerminal, getTabNameForTerminal, computeFocusIndex,
   formatCardLabel,
 } from '../utils/board-helpers.js';
-import { ptyApi, shellApi, fsApi } from '../utils/terminal-services.js';
+import { terminalFacade } from '../utils/terminal-services.js';
 
 export class BoardView extends ComponentBase {
   constructor(container, tabManager) {
@@ -47,7 +47,7 @@ export class BoardView extends ComponentBase {
     if (this.disposed) return;
 
     try {
-      const agents = await ptyApi.checkAgents();
+      const agents = await terminalFacade.ptyCheckAgents();
 
       for (const [termId] of this.cards) {
         if (!agents[termId]) this.removeCard(termId);
@@ -156,19 +156,19 @@ export class BoardView extends ComponentBase {
       readonly: false,
       termOpts: BOARD_TERMINAL_OPTS,
       fitDelay: FIT_SETTLE_DELAY_MS,
-      onPtyData: (writeFn) => ptyApi.onData(termId, (data) => {
+      onPtyData: (writeFn) => terminalFacade.ptyOnData(termId, (data) => {
         writeFn(data);
         cardData.dataBytes += data.length;
       }),
     });
 
     setupTerminalAddons(term, {
-      openExternal: (url) => shellApi.openExternal(url),
+      openExternal: (url) => terminalFacade.openExternal(url),
       getCwd: () => null,
-      homedir: fsApi.homedir,
-      openPath: shellApi.openPath,
+      homedir: terminalFacade.homedir,
+      openPath: terminalFacade.openPath,
     });
-    term.onData((data) => ptyApi.write(termId, data));
+    term.onData((data) => terminalFacade.ptyWrite(termId, data));
 
     Object.assign(cardData, { term, fitAddon, resizeObs, unsubData });
 

--- a/src/components/file-tree.js
+++ b/src/components/file-tree.js
@@ -14,7 +14,7 @@ import {
   removeTerminal as doRemoveTerminal,
   refreshSection as doRefreshSection,
 } from '../utils/file-tree-dir-ops.js';
-import { fsApi, shellApi, clipboardApi } from '../utils/file-tree-services.js';
+import { fileTreeFacade } from '../utils/file-tree-services.js';
 
 export class FileTree extends ComponentBase {
   constructor(container) {
@@ -34,12 +34,12 @@ export class FileTree extends ComponentBase {
 
   _initApi() {
     this._contextMenuApi = {
-      clipboardWrite: clipboardApi.write, fsCopy: fsApi.copy,
-      showInFolder: shellApi.showInFolder, fsTrash: fsApi.trash,
+      clipboardWrite: fileTreeFacade.clipboardWrite, fsCopy: fileTreeFacade.copy,
+      showInFolder: fileTreeFacade.showInFolder, fsTrash: fileTreeFacade.trash,
     };
     this._dropApi = {
-      copyTo: fsApi.copyTo, rename: fsApi.rename,
-      mkdir: fsApi.mkdir, writefile: fsApi.writefile,
+      copyTo: fileTreeFacade.copyTo, rename: fileTreeFacade.rename,
+      mkdir: fileTreeFacade.mkdir, writefile: fileTreeFacade.writefile,
     };
   }
 
@@ -54,14 +54,14 @@ export class FileTree extends ComponentBase {
   }
 
   listenForChanges() {
-    this._track(listenForChanges(this.debounceTimers, (id) => this.refreshSection(id), { onChanged: fsApi.onChanged }));
+    this._track(listenForChanges(this.debounceTimers, (id) => this.refreshSection(id), { onChanged: fileTreeFacade.onChanged }));
   }
 
   async setTerminalRoot(termId, dirPath) {
-    await doSetTerminalRoot(this, termId, dirPath, fsApi.watch, (c) => this.refreshSection(c), fsApi.unwatch);
+    await doSetTerminalRoot(this, termId, dirPath, fileTreeFacade.watch, (c) => this.refreshSection(c), fileTreeFacade.unwatch);
   }
 
-  removeTerminal(termId) { doRemoveTerminal(this, termId, fsApi.unwatch); }
+  removeTerminal(termId) { doRemoveTerminal(this, termId, fileTreeFacade.unwatch); }
 
   async refreshSection(watchIdOrCwd) {
     await doRefreshSection(this, watchIdOrCwd, (dp, pe, d, ed) => this.renderDir(dp, pe, d, ed));
@@ -83,12 +83,12 @@ export class FileTree extends ComponentBase {
   }
 
   async renderDir(dirPath, parentEl, depth, expandedDirs) {
-    await doRenderDir(this, dirPath, parentEl, depth, expandedDirs, fsApi.readdir);
+    await doRenderDir(this, dirPath, parentEl, depth, expandedDirs, fileTreeFacade.readdir);
   }
 
   dispose() {
     super.dispose();
-    const unwatchApi = { unwatch: fsApi.unwatch };
+    const unwatchApi = { unwatch: fileTreeFacade.unwatch };
     for (const [, section] of this.sections) stopWatch(section.watchId, unwatchApi);
     this.sections.clear();
     this.termCwds.clear();

--- a/src/components/skills-view.js
+++ b/src/components/skills-view.js
@@ -8,7 +8,7 @@ import {
   openRoot, configurePath, importSkill, createSkill,
   deleteSkill, selectSkill, save,
 } from '../utils/skills-view-actions.js';
-import { skillsApi, shellApi, dialogApi } from '../utils/skills-services.js';
+import { skillsFacade } from '../utils/skills-services.js';
 
 export class SkillsView extends ComponentBase {
   constructor(container) {
@@ -26,8 +26,8 @@ export class SkillsView extends ComponentBase {
 
   async refresh() {
     if (this.disposed) return;
-    this.skills = await skillsApi.list();
-    if (!this.rootPath) this.rootPath = await skillsApi.getRoot();
+    this.skills = await skillsFacade.list();
+    if (!this.rootPath) this.rootPath = await skillsFacade.getRoot();
     if (this.selectedId && !this.skills.find((s) => s.id === this.selectedId)) {
       this.selectedId = null;
     }
@@ -70,7 +70,7 @@ export class SkillsView extends ComponentBase {
     if (!this.selectedId) { renderEditorEmpty(this.editorEl); return; }
     const skill = this.skills.find((s) => s.id === this.selectedId);
     if (!skill) return;
-    const content = await skillsApi.read(skill.path);
+    const content = await skillsFacade.read(skill.path);
     this.editorValue = content ?? '';
     this.editorDirty = false;
     const { dirtyBadgeEl } = renderEditorContent(this.editorEl, skill, this.editorValue, {
@@ -85,14 +85,14 @@ export class SkillsView extends ComponentBase {
     if (!this.editorDirty) { this.editorDirty = true; updateDirtyBadge(this._dirtyBadgeEl, true); }
   }
 
-  // --- Actions (delegated) ---
-  async _openRoot() { await openRoot(this.rootPath, shellApi); }
-  async _configurePath() { await configurePath(this, { dialogApi, skillsApi }); }
-  async _importSkill() { await importSkill(this, { dialogApi, skillsApi }); }
-  async _createSkill() { await createSkill(this, skillsApi); }
-  async _deleteSkill(id) { await deleteSkill(this, id, skillsApi); }
+  // --- Actions (delegated via unified facade) ---
+  async _openRoot() { await openRoot(this.rootPath, skillsFacade); }
+  async _configurePath() { await configurePath(this, { dialogApi: skillsFacade, skillsApi: skillsFacade }); }
+  async _importSkill() { await importSkill(this, { dialogApi: skillsFacade, skillsApi: skillsFacade }); }
+  async _createSkill() { await createSkill(this, skillsFacade); }
+  async _deleteSkill(id) { await deleteSkill(this, id, skillsFacade); }
   async _selectSkill(id) { await selectSkill(this, id); }
-  async _save() { await save(this, skillsApi); }
+  async _save() { await save(this, skillsFacade); }
 
   dispose() { super.dispose(); this.el.remove(); }
 }

--- a/src/components/tab-manager.js
+++ b/src/components/tab-manager.js
@@ -31,7 +31,7 @@ import {
   reorderTab as doReorderTab,
   renameTab as doRenameTab,
 } from '../utils/tab-manager-tab-ops.js';
-import { gitApi, fsApi, configApi } from '../utils/tab-services.js';
+import { tabFacade } from '../utils/tab-services.js';
 
 export class TabManager {
   constructor(tabBar, workspaceContainer) {
@@ -55,7 +55,7 @@ export class TabManager {
     this.excludedColors = new Set();
   }
 
-  _initApi() { this._api = { gitBranch: gitApi.branch }; }
+  _initApi() { this._api = { gitBranch: tabFacade.gitBranch }; }
   _prApi() { return buildPrApi(); }
   _worktreeApi() { return buildWorktreeApi(); }
   _viewStore() { return buildViewStore(this); }
@@ -68,7 +68,7 @@ export class TabManager {
       restoreConfig: (config) => this.restoreConfig(config),
       createTab: (name) => this.createTab(name),
       setDefaultCwd: (cwd) => { this.defaultCwd = cwd; },
-      api: { homedir: fsApi.homedir, getDefault: configApi.getDefault, loadDefault: configApi.loadDefault },
+      api: { homedir: tabFacade.homedir, getDefault: tabFacade.getDefault, loadDefault: tabFacade.loadDefault },
     });
     this._busListeners = setupBusListeners({
       tabs: this.tabs,
@@ -76,7 +76,7 @@ export class TabManager {
       configManager: this.configManager,
       createTab: (name, cwd) => this.createTab(name, cwd),
       renderTabBar: () => this.renderTabBar(),
-      api: { gitBranch: gitApi.branch, worktree: this._worktreeApi(), pr: this._prApi() },
+      api: { gitBranch: tabFacade.gitBranch, worktree: this._worktreeApi(), pr: this._prApi() },
     });
   }
 

--- a/src/components/terminal-panel.js
+++ b/src/components/terminal-panel.js
@@ -15,7 +15,7 @@ import {
   splitTerminal,
   focusDirection as focusDirectionHelper,
 } from '../utils/terminal-subsystem.js';
-import { shellApi, fsApi, ptyApi } from '../utils/terminal-services.js';
+import { terminalFacade } from '../utils/terminal-services.js';
 
 export class TerminalPanel {
   constructor(container, cwd) {
@@ -36,16 +36,16 @@ export class TerminalPanel {
   _initApi() {
     // Injected API methods forwarded to TerminalInstance
     this._terminalApi = {
-      openExternal: shellApi.openExternal,
-      homedir: fsApi.homedir,
-      openPath: shellApi.openPath,
-      ptyWrite: ptyApi.write,
-      ptyOnData: ptyApi.onData,
-      ptyOnExit: ptyApi.onExit,
-      ptyCreate: ptyApi.create,
-      ptyGetCwd: ptyApi.getCwd,
-      ptyResize: ptyApi.resize,
-      ptyKill: ptyApi.kill,
+      openExternal: terminalFacade.openExternal,
+      homedir: terminalFacade.homedir,
+      openPath: terminalFacade.openPath,
+      ptyWrite: terminalFacade.ptyWrite,
+      ptyOnData: terminalFacade.ptyOnData,
+      ptyOnExit: terminalFacade.ptyOnExit,
+      ptyCreate: terminalFacade.ptyCreate,
+      ptyGetCwd: terminalFacade.ptyGetCwd,
+      ptyResize: terminalFacade.ptyResize,
+      ptyKill: terminalFacade.ptyKill,
     };
   }
 

--- a/src/utils/file-tree-services.js
+++ b/src/utils/file-tree-services.js
@@ -1,8 +1,33 @@
 /**
- * Facade re-exporting fs-api, shell-api and clipboard-api services
+ * Domain facade for fs-api, shell-api and clipboard-api services
  * used by the FileTree component.
- * Reduces direct coupling between UI components and multiple service modules.
+ *
+ * Exposes a single flat interface so the component never imports more than
+ * one service module.  The previous named re-exports are kept for
+ * backward-compatibility but components should prefer `fileTreeFacade`.
  */
-export { default as fsApi } from '../services/fs-api.js';
-export { default as shellApi } from '../services/shell-api.js';
-export { default as clipboardApi } from '../services/clipboard-api.js';
+import fsApi from '../services/fs-api.js';
+import shellApi from '../services/shell-api.js';
+import clipboardApi from '../services/clipboard-api.js';
+
+// ── backward-compat re-exports ──────────────────────────────────────
+export { fsApi, shellApi, clipboardApi };
+
+// ── unified facade ──────────────────────────────────────────────────
+export const fileTreeFacade = {
+  // fs
+  copy:       (...a) => fsApi.copy(...a),
+  copyTo:     (...a) => fsApi.copyTo(...a),
+  rename:     (...a) => fsApi.rename(...a),
+  mkdir:      (...a) => fsApi.mkdir(...a),
+  writefile:  (...a) => fsApi.writefile(...a),
+  readdir:    (...a) => fsApi.readdir(...a),
+  watch:      (...a) => fsApi.watch(...a),
+  unwatch:    (...a) => fsApi.unwatch(...a),
+  onChanged:  (...a) => fsApi.onChanged(...a),
+  trash:      (...a) => fsApi.trash(...a),
+  // shell
+  showInFolder: (...a) => shellApi.showInFolder(...a),
+  // clipboard
+  clipboardWrite: (...a) => clipboardApi.write(...a),
+};

--- a/src/utils/skills-services.js
+++ b/src/utils/skills-services.js
@@ -1,8 +1,31 @@
 /**
- * Facade re-exporting skills-api, shell-api and dialog-api services
+ * Domain facade for skills-api, shell-api and dialog-api services
  * used by the SkillsView component.
- * Reduces direct coupling between UI components and multiple service modules.
+ *
+ * Exposes a single flat interface so the component never imports more than
+ * one service module.  The previous named re-exports are kept for
+ * backward-compatibility but components should prefer `skillsFacade`.
  */
-export { default as skillsApi } from '../services/skills-api.js';
-export { default as shellApi } from '../services/shell-api.js';
-export { default as dialogApi } from '../services/dialog-api.js';
+import skillsApi from '../services/skills-api.js';
+import shellApi from '../services/shell-api.js';
+import dialogApi from '../services/dialog-api.js';
+
+// ── backward-compat re-exports ──────────────────────────────────────
+export { skillsApi, shellApi, dialogApi };
+
+// ── unified facade ──────────────────────────────────────────────────
+export const skillsFacade = {
+  // skills
+  list:         (...a) => skillsApi.list(...a),
+  getRoot:      (...a) => skillsApi.getRoot(...a),
+  read:         (...a) => skillsApi.read(...a),
+  write:        (...a) => skillsApi.write(...a),
+  importSkill:  (...a) => skillsApi.importSkill(...a),
+  create:       (...a) => skillsApi.create(...a),
+  deleteSkill:  (...a) => skillsApi.deleteSkill(...a),
+  setRoot:      (...a) => skillsApi.setRoot(...a),
+  // shell
+  openPath:     (...a) => shellApi.openPath(...a),
+  // dialog
+  openFolder:   (...a) => dialogApi.openFolder(...a),
+};

--- a/src/utils/tab-services.js
+++ b/src/utils/tab-services.js
@@ -1,8 +1,25 @@
 /**
- * Facade re-exporting git-api, fs-api and config-api services
+ * Domain facade for git-api, fs-api and config-api services
  * used by the TabManager component.
- * Reduces direct coupling between UI components and multiple service modules.
+ *
+ * Exposes a single flat interface so the component never imports more than
+ * one service module.  The previous named re-exports are kept for
+ * backward-compatibility but components should prefer `tabFacade`.
  */
-export { default as gitApi } from '../services/git-api.js';
-export { default as fsApi } from '../services/fs-api.js';
-export { default as configApi } from '../services/config-api.js';
+import gitApi from '../services/git-api.js';
+import fsApi from '../services/fs-api.js';
+import configApi from '../services/config-api.js';
+
+// ── backward-compat re-exports ──────────────────────────────────────
+export { gitApi, fsApi, configApi };
+
+// ── unified facade ──────────────────────────────────────────────────
+export const tabFacade = {
+  // git
+  gitBranch:    (...a) => gitApi.branch(...a),
+  // fs
+  homedir:      (...a) => fsApi.homedir(...a),
+  // config
+  getDefault:   (...a) => configApi.getDefault(...a),
+  loadDefault:  (...a) => configApi.loadDefault(...a),
+};

--- a/src/utils/terminal-services.js
+++ b/src/utils/terminal-services.js
@@ -1,8 +1,32 @@
 /**
- * Facade re-exporting terminal-api, shell-api and fs-api services
+ * Domain facade for terminal-api, shell-api and fs-api services
  * used by TerminalPanel and BoardView components.
- * Reduces direct coupling between UI components and multiple service modules.
+ *
+ * Exposes a single flat interface so components never import more than
+ * one service module.  The previous named re-exports are kept for
+ * backward-compatibility but components should prefer `terminalFacade`.
  */
-export { default as ptyApi } from '../services/terminal-api.js';
-export { default as shellApi } from '../services/shell-api.js';
-export { default as fsApi } from '../services/fs-api.js';
+import ptyApi from '../services/terminal-api.js';
+import shellApi from '../services/shell-api.js';
+import fsApi from '../services/fs-api.js';
+
+// ── backward-compat re-exports ──────────────────────────────────────
+export { ptyApi, shellApi, fsApi };
+
+// ── unified facade ──────────────────────────────────────────────────
+export const terminalFacade = {
+  // shell
+  openExternal: (...a) => shellApi.openExternal(...a),
+  openPath:     (...a) => shellApi.openPath(...a),
+  // fs
+  homedir:      (...a) => fsApi.homedir(...a),
+  // pty
+  ptyWrite:     (...a) => ptyApi.write(...a),
+  ptyOnData:    (...a) => ptyApi.onData(...a),
+  ptyOnExit:    (...a) => ptyApi.onExit(...a),
+  ptyCreate:    (...a) => ptyApi.create(...a),
+  ptyGetCwd:    (...a) => ptyApi.getCwd(...a),
+  ptyResize:    (...a) => ptyApi.resize(...a),
+  ptyKill:      (...a) => ptyApi.kill(...a),
+  ptyCheckAgents: (...a) => ptyApi.checkAgents(...a),
+};


### PR DESCRIPTION
## Summary

- Enhanced 4 existing `*-services.js` facade modules (`terminal-services`, `file-tree-services`, `skills-services`, `tab-services`) with unified facade objects (`terminalFacade`, `fileTreeFacade`, `skillsFacade`, `tabFacade`) that flatten multi-service APIs into a single interface per domain
- Updated 5 components (`terminal-panel.js`, `board-view.js`, `file-tree.js`, `skills-view.js`, `tab-manager.js`) to import a single facade instead of 3+ individual service API namespaces
- Backward-compatible named re-exports preserved for any other consumers

Closes #416

## Test plan

- [x] `npm run build` passes
- [x] `npm test` passes (25 test files, 402 tests)
- [ ] Manual smoke test: terminal panel split/resize/drag-drop
- [ ] Manual smoke test: board view agent cards
- [ ] Manual smoke test: file tree operations (rename, new, copy, drag-drop)
- [ ] Manual smoke test: skills CRUD and import
- [ ] Manual smoke test: tab creation, switching, color groups

Generated with [Claude Code](https://claude.com/claude-code)