### PR TITLE
refactor: deduplicate select factory in flow-modal-helpers

### DIFF
--- a/src/utils/flow-modal-helpers.js
+++ b/src/utils/flow-modal-helpers.js
@@ -1,22 +1,8 @@
 import { _el } from './flow-dom.js';
 import { _vis as _visGeneric } from './dom.js';
+import { buildSelect } from './form-helpers.js';
 import { SCHEDULE_TYPE_CONFIG } from './flow-schedule-helpers.js';
 import { AGENT_OPTIONS } from '../../shared/agent-registry.js';
-
-/**
- * Create a <select> element from an options map.
- * @param {{ options: Record<string, string>, value?: string, className?: string, onChange?: (e: Event) => void }} opts
- * @returns {HTMLSelectElement}
- */
-function createSelect({ options, value, className, onChange } = {}) {
-  const select = _el('select', { className: className || '' });
-  for (const [val, label] of Object.entries(options)) {
-    select.appendChild(_el('option', { value: val, textContent: label }));
-  }
-  if (value !== undefined) select.value = value;
-  if (onChange) select.addEventListener('change', onChange);
-  return select;
-}
 
 // --- Constants ---
 
@@ -38,10 +24,11 @@ export function _vis(el, show) {
 
 /**
  * Create a <select> for flow modals.
- * Thin wrapper around the centralized `createSelect` factory.
+ * Thin wrapper around the centralized `buildSelect` factory from form-helpers.
  */
 export function _createSelect(options, value) {
-  return createSelect({ options, value, className: 'flow-modal-select' });
+  const items = Object.entries(options).map(([v, label]) => ({ value: v, label }));
+  return buildSelect(items, { className: 'flow-modal-select', selected: String(value) });
 }
 
 export function _createChip(icon, content, extra = {}) {


### PR DESCRIPTION
## Summary
- Replace the private `createSelect` function in `flow-modal-helpers.js` with the centralized `buildSelect` factory from `form-helpers.js`, eliminating duplicated `<select>` construction logic
- The `_createSelect` wrapper now converts the `Record<string, string>` options map to the array format expected by `buildSelect`, preserving the same public API
- Visibility toggling (`_vis`) and drop indicator (`_getFlowCards`) were already properly deduplicated in prior refactors — no changes needed

Closes #406

## Test plan
- [x] `npm run build` passes
- [x] `npm test` — all 402 tests pass
- [ ] Manual: verify flow modal selects (agent, schedule, category) render correctly
- [ ] Manual: verify worktree dialog selects still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)