### PR TITLE
refactor: extract persistedSetting helper and bindTabOps factory

### DIFF
--- a/src/utils/app-theme.js
+++ b/src/utils/app-theme.js
@@ -1,11 +1,13 @@
-const STORAGE_KEY = 'pikagent-app-theme';
+import { persistedSetting } from './persisted-setting.js';
+
+const appThemeSetting = persistedSetting('pikagent-app-theme', 'dark');
 
 export function getAppTheme() {
-  return localStorage.getItem(STORAGE_KEY) || 'dark';
+  return appThemeSetting.get();
 }
 
 export function setAppTheme(theme) {
-  localStorage.setItem(STORAGE_KEY, theme);
+  appThemeSetting.set(theme);
   applyAppTheme(theme);
 }
 

--- a/src/utils/persisted-setting.js
+++ b/src/utils/persisted-setting.js
@@ -1,0 +1,39 @@
+/**
+ * Tiny factory for localStorage-backed string settings.
+ *
+ * Centralizes the repeated pattern of:
+ *   - reading a key with a fallback default
+ *   - writing a key while swallowing access / quota errors
+ *
+ * Values are stored as raw strings to preserve compatibility with existing
+ * keys (e.g. 'pikagent-app-theme' has always held bare strings like
+ * 'dark' / 'light', not JSON). Callers that need structured data should
+ * serialize themselves before calling `set` and parse the result of `get`.
+ *
+ * Errors from `localStorage` (e.g. SecurityError in private mode, quota
+ * exceeded) are caught so callers never have to wrap the call site.
+ *
+ * @param {string} key          The localStorage key to read/write.
+ * @param {string} defaultValue Value returned when the key is missing or
+ *                              localStorage throws.
+ * @returns {{ get: () => string, set: (value: string) => void }}
+ */
+export function persistedSetting(key, defaultValue) {
+  return {
+    get() {
+      try {
+        const raw = localStorage.getItem(key);
+        return raw == null ? defaultValue : raw;
+      } catch {
+        return defaultValue;
+      }
+    },
+    set(value) {
+      try {
+        localStorage.setItem(key, value);
+      } catch {
+        // ignore quota / access errors — setting is best-effort.
+      }
+    },
+  };
+}

--- a/src/utils/tab-manager-tab-ops.js
+++ b/src/utils/tab-manager-tab-ops.js
@@ -14,55 +14,86 @@ import {
 } from './tab-facade.js';
 
 /**
+ * Bind the tab-ops trio to a TabManager instance.
+ *
+ * Centralizes the shared callback wiring (switchTo, renderTabBar,
+ * configManager bridges) so each op no longer duplicates the boilerplate.
+ *
+ * Primitive deps that may be reassigned on `tm` between calls
+ * (activeTabId, activeColorFilter, defaultCwd, tabs Map) are still read
+ * fresh at op-invocation time — deps objects are built per-call. Only
+ * the bound closures over `tm` are shared. This preserves the exact
+ * pre-refactor semantics where `renderTabBar(tm)` re-reads tm state.
+ *
+ * Public standalone exports (`renderTabBar`, `createTab`, `closeTab`)
+ * delegate here so existing call sites keep working unchanged.
+ *
+ * @param {object} tm - TabManager instance
+ */
+export function bindTabOps(tm) {
+  // Stable closures over `tm`, captured once.
+  const renderTabBar = () => tm.renderTabBar();
+  const switchTo = (id) => tm.switchTo(id);
+  const closeTabBridge = (id) => tm.closeTab(id);
+  const renameTabBridge = (id, nameEl) => tm.renameTab(id, nameEl);
+
+  return {
+    renderTabBar: () => doRenderTabBar({
+      tabBar: tm.tabBar,
+      tabs: tm.tabs,
+      activeTabId: tm.activeTabId,
+      activeColorFilter: tm.activeColorFilter,
+      excludedColors: tm.excludedColors,
+      switchTo,
+      closeTab: closeTabBridge,
+      renameTab: renameTabBridge,
+      setTabColorGroup: (id, cg) => tm.setTabColorGroup(id, cg),
+      toggleNoShortcut: (id) => tm.toggleNoShortcut(id),
+      setColorFilter: (id) => tm.setColorFilter(id),
+      toggleExcludeColor: (id) => tm.toggleExcludeColor(id),
+      clearColorFilters: () => { tm.activeColorFilter = null; tm.excludedColors.clear(); },
+      createTab: () => tm.createTab(),
+      reorderTab: (fromId, toId, before) => tm.reorderTab(fromId, toId, before),
+      isTabVisible: (tab) => tm._isTabVisible(tab),
+      renderTabBar,
+    }),
+    createTab: (switchToFn, name, cwd) => doCreateTab({
+      tabs: tm.tabs,
+      defaultCwd: tm.defaultCwd,
+      activeColorFilter: tm.activeColorFilter,
+      renderTabBar,
+      configManager: tm.configManager,
+    }, switchToFn, name, cwd),
+    closeTab: (createTabFn, switchToFn, id) => doCloseTab({
+      tabs: tm.tabs,
+      activeTabId: tm.activeTabId,
+      renderTabBar,
+      configManager: tm.configManager,
+    }, createTabFn, switchToFn, id),
+  };
+}
+
+/**
  * Build the deps and call doRenderTabBar.
  * @param {object} tm - TabManager instance
  * @returns {Map} tab element map
  */
 export function renderTabBar(tm) {
-  return doRenderTabBar({
-    tabBar: tm.tabBar,
-    tabs: tm.tabs,
-    activeTabId: tm.activeTabId,
-    activeColorFilter: tm.activeColorFilter,
-    excludedColors: tm.excludedColors,
-    switchTo: (id) => tm.switchTo(id),
-    closeTab: (id) => tm.closeTab(id),
-    renameTab: (id, nameEl) => tm.renameTab(id, nameEl),
-    setTabColorGroup: (id, cg) => tm.setTabColorGroup(id, cg),
-    toggleNoShortcut: (id) => tm.toggleNoShortcut(id),
-    setColorFilter: (id) => tm.setColorFilter(id),
-    toggleExcludeColor: (id) => tm.toggleExcludeColor(id),
-    clearColorFilters: () => { tm.activeColorFilter = null; tm.excludedColors.clear(); },
-    createTab: () => tm.createTab(),
-    reorderTab: (fromId, toId, before) => tm.reorderTab(fromId, toId, before),
-    isTabVisible: (tab) => tm._isTabVisible(tab),
-    renderTabBar: () => tm.renderTabBar(),
-  });
+  return bindTabOps(tm).renderTabBar();
 }
 
 /**
  * Build the deps and call doCreateTab.
  */
 export function createTab(tm, switchTo, name, cwd) {
-  return doCreateTab({
-    tabs: tm.tabs,
-    defaultCwd: tm.defaultCwd,
-    activeColorFilter: tm.activeColorFilter,
-    renderTabBar: () => tm.renderTabBar(),
-    configManager: tm.configManager,
-  }, switchTo, name, cwd);
+  return bindTabOps(tm).createTab(switchTo, name, cwd);
 }
 
 /**
  * Build the deps and call doCloseTab.
  */
 export function closeTab(tm, createTabFn, switchToFn, id) {
-  return doCloseTab({
-    tabs: tm.tabs,
-    activeTabId: tm.activeTabId,
-    renderTabBar: () => tm.renderTabBar(),
-    configManager: tm.configManager,
-  }, createTabFn, switchToFn, id);
+  return bindTabOps(tm).closeTab(createTabFn, switchToFn, id);
 }
 
 /**

--- a/src/utils/terminal-themes.js
+++ b/src/utils/terminal-themes.js
@@ -1,3 +1,5 @@
+import { persistedSetting } from './persisted-setting.js';
+
 const ANSI = ['black', 'red', 'green', 'yellow', 'blue', 'magenta', 'cyan', 'white'];
 
 function _buildTheme(chrome, ansi, bright) {
@@ -75,28 +77,30 @@ export const TERMINAL_THEMES = Object.fromEntries(
 
 const LIGHT_THEMES = new Set(THEME_DEFS.filter((d) => d.light).map((d) => d.name));
 
-const STORAGE = { theme: 'pikagent-terminal-theme', prev: 'pikagent-terminal-theme-prev' };
 const DEFAULT_LIGHT = 'Pikagent Light';
 const DEFAULT_DARK = 'Pikagent';
 
+const themeSetting = persistedSetting('pikagent-terminal-theme', DEFAULT_DARK);
+const prevThemeSetting = persistedSetting('pikagent-terminal-theme-prev', DEFAULT_DARK);
+
 export function getTerminalTheme() {
-  const name = localStorage.getItem(STORAGE.theme) || DEFAULT_DARK;
+  const name = themeSetting.get();
   return TERMINAL_THEMES[name] || TERMINAL_THEMES[DEFAULT_DARK];
 }
 
 export function getTerminalThemeName() {
-  return localStorage.getItem(STORAGE.theme) || DEFAULT_DARK;
+  return themeSetting.get();
 }
 
 export function setTerminalTheme(name) {
-  localStorage.setItem(STORAGE.theme, name);
+  themeSetting.set(name);
 }
 
 export function switchTerminalForMode(mode) {
   const current = getTerminalThemeName();
   const wantLight = mode === 'light';
   if (wantLight === LIGHT_THEMES.has(current)) return false;
-  if (wantLight) localStorage.setItem(STORAGE.prev, current);
-  setTerminalTheme(wantLight ? DEFAULT_LIGHT : (localStorage.getItem(STORAGE.prev) || DEFAULT_DARK));
+  if (wantLight) prevThemeSetting.set(current);
+  setTerminalTheme(wantLight ? DEFAULT_LIGHT : prevThemeSetting.get());
   return true;
 }


### PR DESCRIPTION
## Refactoring

Two residual duplication patterns deduped:

### 1. localStorage theme persistence
New \`src/utils/persisted-setting.js\` exporting a small factory:

\`\`\`js
persistedSetting(key, defaultValue) → { get, set }
\`\`\`

Try/catch around \`getItem\`/\`setItem\` to absorb \`SecurityError\` (private browsing) and \`QuotaExceededError\`. Raw strings (no JSON serialization) to preserve compatibility with existing user values like \`'dark'\`.

\`app-theme.js\` and \`terminal-themes.js\` now both delegate to this helper. **Public API unchanged**, **storage keys unchanged**, **defaults unchanged**.

### 2. Tab ops factory wrappers
\`tab-manager-tab-ops.js\` had \`renderTabBar\`, \`createTab\`, \`closeTab\` each rebuilding the same set of dependency closures from \`TabManager\`. Introduced a local \`bindTabOps(tm)\` helper that captures the shared closures once and returns the three ops. **Standalone exports preserved** as thin delegates (no caller needs to change).

Importantly, \`tm.activeTabId\`, \`tm.tabs\`, \`tm.activeColorFilter\` and \`tm.defaultCwd\` are still **re-read inside each op** at call time, so side-effect order and state freshness are byte-equivalent to before.

Closes #438

## Fichier(s) modifié(s)

- \`src/utils/persisted-setting.js\` (new)
- \`src/utils/app-theme.js\`
- \`src/utils/terminal-themes.js\`
- \`src/utils/tab-manager-tab-ops.js\`

## Vérifications

- [x] Build OK (\`node build.js\`)
- [x] Tests OK (\`vitest run\` — 404/404)

---

📂 Path local : \`/Users/claude/flux/review/pikagent/\`
🤖 PR créée automatiquement par l'Agent Refactor