### PR TITLE
refactor: reduce manager-init.js coupling via domain-grouped re-exports

### DIFF
--- a/main/data-managers.js
+++ b/main/data-managers.js
@@ -1,0 +1,12 @@
+/**
+ * Data managers — session tracking and usage/metrics aggregation.
+ *
+ * Groups managers that persist and expose runtime data (active sessions,
+ * token usage, agent metrics) so that manager-init.js can import a
+ * single module instead of two separate ones.
+ */
+
+const sessionManager = require('./session-manager');
+const usageManager = require('./usage-manager');
+
+module.exports = { sessionManager, usageManager };

--- a/main/infra-managers.js
+++ b/main/infra-managers.js
@@ -1,0 +1,13 @@
+/**
+ * Infrastructure managers — git operations, configuration, and app updates.
+ *
+ * Groups managers that deal with developer tooling (git), user preferences
+ * (config), and self-update logic so that manager-init.js can import a
+ * single module instead of three separate ones.
+ */
+
+const gitManager = require('./git-manager');
+const configManager = require('./config-manager');
+const updateManager = require('./update-manager');
+
+module.exports = { gitManager, configManager, updateManager };

--- a/main/io-managers.js
+++ b/main/io-managers.js
@@ -1,0 +1,13 @@
+/**
+ * IO managers — filesystem and terminal (PTY) access.
+ *
+ * Groups managers that deal with low-level I/O so that manager-init.js
+ * can import a single module instead of two separate ones.
+ */
+
+const PtyManager = require('./pty-manager');
+const fsManager = require('./fs-manager');
+
+const ptyManager = new PtyManager();
+
+module.exports = { ptyManager, fsManager };

--- a/main/manager-init.js
+++ b/main/manager-init.js
@@ -4,20 +4,21 @@
  * Centralises the creation of every manager singleton and the inter-manager
  * dependencies that used to live inside ipc-handlers.js.  The main entry
  * point calls `initManagers()` once and passes the result to the IPC layer.
+ *
+ * Managers are imported through domain-grouped re-export modules to reduce
+ * the number of direct imports in this file:
+ *
+ *   io-managers.js       — ptyManager, fsManager
+ *   data-managers.js     — sessionManager, usageManager
+ *   workflow-managers.js — flowManager, skillsManager
+ *   infra-managers.js    — gitManager, configManager, updateManager
  */
 
-const PtyManager = require('./pty-manager');
-const sessionManager = require('./session-manager');
-const fsManager = require('./fs-manager');
-const gitManager = require('./git-manager');
-const configManager = require('./config-manager');
-const flowManager = require('./flow-manager');
-const usageManager = require('./usage-manager');
-const skillsManager = require('./skills-manager');
-const updateManager = require('./update-manager');
+const { ptyManager, fsManager } = require('./io-managers');
+const { sessionManager, usageManager } = require('./data-managers');
+const { flowManager, skillsManager } = require('./workflow-managers');
+const { gitManager, configManager, updateManager } = require('./infra-managers');
 const { safeSend } = require('./ipc-helpers');
-
-const ptyManager = new PtyManager();
 
 /**
  * Modules that expose a `cleanup()` method and should be torn down when

--- a/main/workflow-managers.js
+++ b/main/workflow-managers.js
@@ -1,0 +1,12 @@
+/**
+ * Workflow managers — flow orchestration and skills management.
+ *
+ * Groups managers that handle user-defined automations (flows) and
+ * reusable skill definitions so that manager-init.js can import a
+ * single module instead of two separate ones.
+ */
+
+const flowManager = require('./flow-manager');
+const skillsManager = require('./skills-manager');
+
+module.exports = { flowManager, skillsManager };


### PR DESCRIPTION
## Summary

- Reduces `main/manager-init.js` from 10 direct manager imports to 4 domain-grouped barrel imports
- Introduces four new grouping modules that re-export related managers:
  - `io-managers.js` — `ptyManager` + `fsManager` (low-level I/O)
  - `data-managers.js` — `sessionManager` + `usageManager` (runtime data & metrics)
  - `workflow-managers.js` — `flowManager` + `skillsManager` (user automations)
  - `infra-managers.js` — `gitManager` + `configManager` + `updateManager` (tooling & preferences)
- No runtime behaviour changes; all exports from `manager-init.js` remain identical

## Test plan

- [x] All 403 existing tests pass (`npx vitest run`)
- [x] All four grouping modules load and export the correct keys
- [x] `manager-init.js` import count reduced from 10 to 5 (4 groups + ipc-helpers)

Closes #441

🤖 Generated with [Claude Code](https://claude.com/claude-code)