### PR TITLE
refactor: create per-component UI-service facades

### DIFF
--- a/src/components/board-view.js
+++ b/src/components/board-view.js
@@ -14,7 +14,7 @@ import {
   resolveCardStatus, findTabForTerminal, getTabNameForTerminal, computeFocusIndex,
   formatCardLabel,
 } from '../utils/board-helpers.js';
-import { terminalFacade } from '../utils/terminal-services.js';
+import { boardApi } from '../utils/board-facade.js';
 
 export class BoardView extends ComponentBase {
   constructor(container, tabManager) {
@@ -47,7 +47,7 @@ export class BoardView extends ComponentBase {
     if (this.disposed) return;
 
     try {
-      const agents = await terminalFacade.ptyCheckAgents();
+      const agents = await boardApi.ptyCheckAgents();
 
       for (const [termId] of this.cards) {
         if (!agents[termId]) this.removeCard(termId);
@@ -156,19 +156,19 @@ export class BoardView extends ComponentBase {
       readonly: false,
       termOpts: BOARD_TERMINAL_OPTS,
       fitDelay: FIT_SETTLE_DELAY_MS,
-      onPtyData: (writeFn) => terminalFacade.ptyOnData(termId, (data) => {
+      onPtyData: (writeFn) => boardApi.ptyOnData(termId, (data) => {
         writeFn(data);
         cardData.dataBytes += data.length;
       }),
     });
 
     setupTerminalAddons(term, {
-      openExternal: (url) => terminalFacade.openExternal(url),
+      openExternal: (url) => boardApi.openExternal(url),
       getCwd: () => null,
-      homedir: terminalFacade.homedir,
-      openPath: terminalFacade.openPath,
+      homedir: boardApi.homedir,
+      openPath: boardApi.openPath,
     });
-    term.onData((data) => terminalFacade.ptyWrite(termId, data));
+    term.onData((data) => boardApi.ptyWrite(termId, data));
 
     Object.assign(cardData, { term, fitAddon, resizeObs, unsubData });
 

--- a/src/components/file-tree.js
+++ b/src/components/file-tree.js
@@ -14,7 +14,7 @@ import {
   removeTerminal as doRemoveTerminal,
   refreshSection as doRefreshSection,
 } from '../utils/file-tree-dir-ops.js';
-import { fileTreeFacade } from '../utils/file-tree-services.js';
+import { fileTreeApi } from '../utils/file-tree-facade.js';
 
 export class FileTree extends ComponentBase {
   constructor(container) {
@@ -34,12 +34,12 @@ export class FileTree extends ComponentBase {
 
   _initApi() {
     this._contextMenuApi = {
-      clipboardWrite: fileTreeFacade.clipboardWrite, fsCopy: fileTreeFacade.copy,
-      showInFolder: fileTreeFacade.showInFolder, fsTrash: fileTreeFacade.trash,
+      clipboardWrite: fileTreeApi.clipboardWrite, fsCopy: fileTreeApi.copy,
+      showInFolder: fileTreeApi.showInFolder, fsTrash: fileTreeApi.trash,
     };
     this._dropApi = {
-      copyTo: fileTreeFacade.copyTo, rename: fileTreeFacade.rename,
-      mkdir: fileTreeFacade.mkdir, writefile: fileTreeFacade.writefile,
+      copyTo: fileTreeApi.copyTo, rename: fileTreeApi.rename,
+      mkdir: fileTreeApi.mkdir, writefile: fileTreeApi.writefile,
     };
   }
 
@@ -54,14 +54,14 @@ export class FileTree extends ComponentBase {
   }
 
   listenForChanges() {
-    this._track(listenForChanges(this.debounceTimers, (id) => this.refreshSection(id), { onChanged: fileTreeFacade.onChanged }));
+    this._track(listenForChanges(this.debounceTimers, (id) => this.refreshSection(id), { onChanged: fileTreeApi.onChanged }));
   }
 
   async setTerminalRoot(termId, dirPath) {
-    await doSetTerminalRoot(this, termId, dirPath, fileTreeFacade.watch, (c) => this.refreshSection(c), fileTreeFacade.unwatch);
+    await doSetTerminalRoot(this, termId, dirPath, fileTreeApi.watch, (c) => this.refreshSection(c), fileTreeApi.unwatch);
   }
 
-  removeTerminal(termId) { doRemoveTerminal(this, termId, fileTreeFacade.unwatch); }
+  removeTerminal(termId) { doRemoveTerminal(this, termId, fileTreeApi.unwatch); }
 
   async refreshSection(watchIdOrCwd) {
     await doRefreshSection(this, watchIdOrCwd, (dp, pe, d, ed) => this.renderDir(dp, pe, d, ed));
@@ -83,12 +83,12 @@ export class FileTree extends ComponentBase {
   }
 
   async renderDir(dirPath, parentEl, depth, expandedDirs) {
-    await doRenderDir(this, dirPath, parentEl, depth, expandedDirs, fileTreeFacade.readdir);
+    await doRenderDir(this, dirPath, parentEl, depth, expandedDirs, fileTreeApi.readdir);
   }
 
   dispose() {
     super.dispose();
-    const unwatchApi = { unwatch: fileTreeFacade.unwatch };
+    const unwatchApi = { unwatch: fileTreeApi.unwatch };
     for (const [, section] of this.sections) stopWatch(section.watchId, unwatchApi);
     this.sections.clear();
     this.termCwds.clear();

--- a/src/components/skills-view.js
+++ b/src/components/skills-view.js
@@ -8,7 +8,7 @@ import {
   openRoot, configurePath, importSkill, createSkill,
   deleteSkill, selectSkill, save,
 } from '../utils/skills-view-actions.js';
-import { skillsFacade } from '../utils/skills-services.js';
+import { skillsViewApi } from '../utils/skills-facade.js';
 
 export class SkillsView extends ComponentBase {
   constructor(container) {
@@ -26,8 +26,8 @@ export class SkillsView extends ComponentBase {
 
   async refresh() {
     if (this.disposed) return;
-    this.skills = await skillsFacade.list();
-    if (!this.rootPath) this.rootPath = await skillsFacade.getRoot();
+    this.skills = await skillsViewApi.list();
+    if (!this.rootPath) this.rootPath = await skillsViewApi.getRoot();
     if (this.selectedId && !this.skills.find((s) => s.id === this.selectedId)) {
       this.selectedId = null;
     }
@@ -70,7 +70,7 @@ export class SkillsView extends ComponentBase {
     if (!this.selectedId) { renderEditorEmpty(this.editorEl); return; }
     const skill = this.skills.find((s) => s.id === this.selectedId);
     if (!skill) return;
-    const content = await skillsFacade.read(skill.path);
+    const content = await skillsViewApi.read(skill.path);
     this.editorValue = content ?? '';
     this.editorDirty = false;
     const { dirtyBadgeEl } = renderEditorContent(this.editorEl, skill, this.editorValue, {
@@ -86,13 +86,13 @@ export class SkillsView extends ComponentBase {
   }
 
   // --- Actions (delegated via unified facade) ---
-  async _openRoot() { await openRoot(this.rootPath, skillsFacade); }
-  async _configurePath() { await configurePath(this, { dialogApi: skillsFacade, skillsApi: skillsFacade }); }
-  async _importSkill() { await importSkill(this, { dialogApi: skillsFacade, skillsApi: skillsFacade }); }
-  async _createSkill() { await createSkill(this, skillsFacade); }
-  async _deleteSkill(id) { await deleteSkill(this, id, skillsFacade); }
+  async _openRoot() { await openRoot(this.rootPath, skillsViewApi); }
+  async _configurePath() { await configurePath(this, { dialogApi: skillsViewApi, skillsApi: skillsViewApi }); }
+  async _importSkill() { await importSkill(this, { dialogApi: skillsViewApi, skillsApi: skillsViewApi }); }
+  async _createSkill() { await createSkill(this, skillsViewApi); }
+  async _deleteSkill(id) { await deleteSkill(this, id, skillsViewApi); }
   async _selectSkill(id) { await selectSkill(this, id); }
-  async _save() { await save(this, skillsFacade); }
+  async _save() { await save(this, skillsViewApi); }
 
   dispose() { super.dispose(); this.el.remove(); }
 }

--- a/src/components/tab-manager.js
+++ b/src/components/tab-manager.js
@@ -31,7 +31,7 @@ import {
   reorderTab as doReorderTab,
   renameTab as doRenameTab,
 } from '../utils/tab-manager-tab-ops.js';
-import { tabFacade } from '../utils/tab-services.js';
+import { tabManagerApi } from '../utils/tab-manager-facade.js';
 
 export class TabManager {
   constructor(tabBar, workspaceContainer) {
@@ -55,7 +55,7 @@ export class TabManager {
     this.excludedColors = new Set();
   }
 
-  _initApi() { this._api = { gitBranch: tabFacade.gitBranch }; }
+  _initApi() { this._api = { gitBranch: tabManagerApi.gitBranch }; }
   _prApi() { return buildPrApi(); }
   _worktreeApi() { return buildWorktreeApi(); }
   _viewStore() { return buildViewStore(this); }
@@ -68,7 +68,7 @@ export class TabManager {
       restoreConfig: (config) => this.restoreConfig(config),
       createTab: (name) => this.createTab(name),
       setDefaultCwd: (cwd) => { this.defaultCwd = cwd; },
-      api: { homedir: tabFacade.homedir, getDefault: tabFacade.getDefault, loadDefault: tabFacade.loadDefault },
+      api: { homedir: tabManagerApi.homedir, getDefault: tabManagerApi.getDefault, loadDefault: tabManagerApi.loadDefault },
     });
     this._busListeners = setupBusListeners({
       tabs: this.tabs,
@@ -76,7 +76,7 @@ export class TabManager {
       configManager: this.configManager,
       createTab: (name, cwd) => this.createTab(name, cwd),
       renderTabBar: () => this.renderTabBar(),
-      api: { gitBranch: tabFacade.gitBranch, worktree: this._worktreeApi(), pr: this._prApi() },
+      api: { gitBranch: tabManagerApi.gitBranch, worktree: this._worktreeApi(), pr: this._prApi() },
     });
   }
 

--- a/src/components/terminal-panel.js
+++ b/src/components/terminal-panel.js
@@ -15,7 +15,7 @@ import {
   splitTerminal,
   focusDirection as focusDirectionHelper,
 } from '../utils/terminal-subsystem.js';
-import { terminalFacade } from '../utils/terminal-services.js';
+import { terminalPanelApi } from '../utils/terminal-panel-facade.js';
 
 export class TerminalPanel {
   constructor(container, cwd) {
@@ -36,16 +36,16 @@ export class TerminalPanel {
   _initApi() {
     // Injected API methods forwarded to TerminalInstance
     this._terminalApi = {
-      openExternal: terminalFacade.openExternal,
-      homedir: terminalFacade.homedir,
-      openPath: terminalFacade.openPath,
-      ptyWrite: terminalFacade.ptyWrite,
-      ptyOnData: terminalFacade.ptyOnData,
-      ptyOnExit: terminalFacade.ptyOnExit,
-      ptyCreate: terminalFacade.ptyCreate,
-      ptyGetCwd: terminalFacade.ptyGetCwd,
-      ptyResize: terminalFacade.ptyResize,
-      ptyKill: terminalFacade.ptyKill,
+      openExternal: terminalPanelApi.openExternal,
+      homedir: terminalPanelApi.homedir,
+      openPath: terminalPanelApi.openPath,
+      ptyWrite: terminalPanelApi.ptyWrite,
+      ptyOnData: terminalPanelApi.ptyOnData,
+      ptyOnExit: terminalPanelApi.ptyOnExit,
+      ptyCreate: terminalPanelApi.ptyCreate,
+      ptyGetCwd: terminalPanelApi.ptyGetCwd,
+      ptyResize: terminalPanelApi.ptyResize,
+      ptyKill: terminalPanelApi.ptyKill,
     };
   }
 

--- a/src/utils/board-facade.js
+++ b/src/utils/board-facade.js
@@ -1,0 +1,22 @@
+/**
+ * Domain facade for terminal-api, shell-api and fs-api services
+ * used by the BoardView component.
+ *
+ * Exposes a single flat object so the component imports exactly one
+ * module instead of three separate service modules.
+ */
+import ptyApi from '../services/terminal-api.js';
+import shellApi from '../services/shell-api.js';
+import fsApi from '../services/fs-api.js';
+
+export const boardApi = {
+  // pty (terminal-api)
+  ptyCheckAgents: (...a) => ptyApi.checkAgents(...a),
+  ptyOnData:      (...a) => ptyApi.onData(...a),
+  ptyWrite:       (...a) => ptyApi.write(...a),
+  // shell
+  openExternal:   (...a) => shellApi.openExternal(...a),
+  openPath:       (...a) => shellApi.openPath(...a),
+  // fs
+  homedir:        (...a) => fsApi.homedir(...a),
+};

--- a/src/utils/file-tree-facade.js
+++ b/src/utils/file-tree-facade.js
@@ -1,0 +1,28 @@
+/**
+ * Domain facade for fs-api, shell-api and clipboard-api services
+ * used by the FileTree component.
+ *
+ * Exposes a single flat object so the component imports exactly one
+ * module instead of three separate service modules.
+ */
+import fsApi from '../services/fs-api.js';
+import shellApi from '../services/shell-api.js';
+import clipboardApi from '../services/clipboard-api.js';
+
+export const fileTreeApi = {
+  // fs
+  copy:           (...a) => fsApi.copy(...a),
+  copyTo:         (...a) => fsApi.copyTo(...a),
+  rename:         (...a) => fsApi.rename(...a),
+  mkdir:          (...a) => fsApi.mkdir(...a),
+  writefile:      (...a) => fsApi.writefile(...a),
+  readdir:        (...a) => fsApi.readdir(...a),
+  watch:          (...a) => fsApi.watch(...a),
+  unwatch:        (...a) => fsApi.unwatch(...a),
+  onChanged:      (...a) => fsApi.onChanged(...a),
+  trash:          (...a) => fsApi.trash(...a),
+  // shell
+  showInFolder:   (...a) => shellApi.showInFolder(...a),
+  // clipboard
+  clipboardWrite: (...a) => clipboardApi.write(...a),
+};

--- a/src/utils/skills-facade.js
+++ b/src/utils/skills-facade.js
@@ -1,0 +1,26 @@
+/**
+ * Domain facade for skills-api, shell-api and dialog-api services
+ * used by the SkillsView component.
+ *
+ * Exposes a single flat object so the component imports exactly one
+ * module instead of three separate service modules.
+ */
+import skillsApiSvc from '../services/skills-api.js';
+import shellApi from '../services/shell-api.js';
+import dialogApi from '../services/dialog-api.js';
+
+export const skillsViewApi = {
+  // skills
+  list:         (...a) => skillsApiSvc.list(...a),
+  getRoot:      (...a) => skillsApiSvc.getRoot(...a),
+  read:         (...a) => skillsApiSvc.read(...a),
+  write:        (...a) => skillsApiSvc.write(...a),
+  importSkill:  (...a) => skillsApiSvc.importSkill(...a),
+  create:       (...a) => skillsApiSvc.create(...a),
+  deleteSkill:  (...a) => skillsApiSvc.deleteSkill(...a),
+  setRoot:      (...a) => skillsApiSvc.setRoot(...a),
+  // shell
+  openPath:     (...a) => shellApi.openPath(...a),
+  // dialog
+  openFolder:   (...a) => dialogApi.openFolder(...a),
+};

--- a/src/utils/tab-manager-facade.js
+++ b/src/utils/tab-manager-facade.js
@@ -1,0 +1,20 @@
+/**
+ * Domain facade for git-api, fs-api and config-api services
+ * used by the TabManager component.
+ *
+ * Exposes a single flat object so the component imports exactly one
+ * module instead of three separate service modules.
+ */
+import gitApi from '../services/git-api.js';
+import fsApi from '../services/fs-api.js';
+import configApi from '../services/config-api.js';
+
+export const tabManagerApi = {
+  // git
+  gitBranch:  (...a) => gitApi.branch(...a),
+  // fs
+  homedir:    (...a) => fsApi.homedir(...a),
+  // config
+  getDefault:  (...a) => configApi.getDefault(...a),
+  loadDefault: (...a) => configApi.loadDefault(...a),
+};

--- a/src/utils/terminal-panel-facade.js
+++ b/src/utils/terminal-panel-facade.js
@@ -1,0 +1,26 @@
+/**
+ * Domain facade for terminal-api, shell-api and fs-api services
+ * used by the TerminalPanel component.
+ *
+ * Exposes a single flat object so the component imports exactly one
+ * module instead of three separate service modules.
+ */
+import ptyApi from '../services/terminal-api.js';
+import shellApi from '../services/shell-api.js';
+import fsApi from '../services/fs-api.js';
+
+export const terminalPanelApi = {
+  // shell
+  openExternal: (...a) => shellApi.openExternal(...a),
+  openPath:     (...a) => shellApi.openPath(...a),
+  // fs
+  homedir:      (...a) => fsApi.homedir(...a),
+  // pty (terminal-api)
+  ptyWrite:     (...a) => ptyApi.write(...a),
+  ptyOnData:    (...a) => ptyApi.onData(...a),
+  ptyOnExit:    (...a) => ptyApi.onExit(...a),
+  ptyCreate:    (...a) => ptyApi.create(...a),
+  ptyGetCwd:    (...a) => ptyApi.getCwd(...a),
+  ptyResize:    (...a) => ptyApi.resize(...a),
+  ptyKill:      (...a) => ptyApi.kill(...a),
+};


### PR DESCRIPTION
## Summary

- Create 5 dedicated facade modules in `src/utils/` — one per UI component — to aggregate their service API dependencies
- Each component now imports exactly **1 facade** instead of 3 direct service imports, eliminating the UI→service coupling reported in #416
- New facades: `board-facade.js`, `file-tree-facade.js`, `terminal-panel-facade.js`, `skills-facade.js`, `tab-manager-facade.js`
- No logic changes; all existing behavior is preserved through delegation

## Facades created

| Facade | Component | Services grouped |
|--------|-----------|-----------------|
| `board-facade.js` | `board-view.js` | `terminal-api` + `shell-api` + `fs-api` |
| `file-tree-facade.js` | `file-tree.js` | `fs-api` + `shell-api` + `clipboard-api` |
| `terminal-panel-facade.js` | `terminal-panel.js` | `terminal-api` + `shell-api` + `fs-api` |
| `skills-facade.js` | `skills-view.js` | `skills-api` + `shell-api` + `dialog-api` |
| `tab-manager-facade.js` | `tab-manager.js` | `git-api` + `fs-api` + `config-api` |

## Test plan

- [x] All 25 test files pass (408 tests)
- [x] Build succeeds (`npm run build`)
- [ ] Manual: terminal panel (resize, PTY write/read)
- [ ] Manual: board view (agent scan, card add/remove)
- [ ] Manual: file tree (navigation, CRUD, clipboard)
- [ ] Manual: skills view (list, import, delete, save)
- [ ] Manual: tab manager (create/close tabs, workspace restore)

Closes #416

🤖 Generated with [Claude Code](https://claude.com/claude-code)