### PR TITLE
refactor: remove unused trackMouseDrag export

### DIFF
--- a/src/utils/drag-helpers.js
+++ b/src/utils/drag-helpers.js
@@ -66,19 +66,6 @@ export function trackMouse(cursor, onMove, onDone, { bodyClass = 'resizing' } = 
 }
 
 /**
- * Named-params variant of trackMouse for callers that prefer destructuring.
- *
- * Adds mousemove and mouseup listeners on document, applies cursor and
- * userSelect on document.body, and cleans everything up automatically on
- * mouseup.
- *
- * @param {{ cursor?: string, onMove: (e: MouseEvent) => void, onUp?: () => void, bodyClass?: string }} opts
- */
-export function trackMouseDrag({ cursor = 'default', onMove, onUp = () => {}, bodyClass = 'resizing' } = {}) {
-  return trackMouse(cursor, onMove, onUp, { bodyClass });
-}
-
-/**
  * Add an event listener to a target and return a cleanup function that
  * removes it.  Calling the cleanup is idempotent.
  *


### PR DESCRIPTION
## Refactoring

Suppression de l'export mort `trackMouseDrag` dans `src/utils/drag-helpers.js`. Cette fonction était un wrapper à paramètres nommés autour de `trackMouse` qu'aucun consommateur n'utilisait — tous les call sites passent directement par `trackMouse(...)`.

Vérification : `grep -rn trackMouseDrag main shared src tests` ne retournait qu'une seule occurrence (la définition).

Closes #457

## Fichier(s) modifié(s)

- `src/utils/drag-helpers.js` (suppression L68-L79 : doc JSDoc + export)

## Vérifications

- [x] Build OK (`npm run build`)
- [x] Tests OK (25 fichiers, 403 tests)

---

📂 Path local : \`/Users/claude/flux/review/pikagent/\`
🤖 PR créée automatiquement par l'Agent Refactor