### PR TITLE
refactor: tighten loose JSDoc Map/Array/Function types in 8 files

### DIFF
--- a/main/flow-executor.js
+++ b/main/flow-executor.js
@@ -6,6 +6,8 @@
  *
  * Logging helpers live in flow-executor-log.js; run-recording
  * helpers live in flow-executor-run.js.
+ *
+ * @typedef {Map<string, { ptyId: string, proc: object, timeout: ReturnType<typeof setTimeout> }>} RunningFlows
  */
 
 const os = require('os');
@@ -25,7 +27,7 @@ const { recordRun } = require('./flow-executor-run');
  * and notifies the renderer.
  *
  * @param {{ getPtyManager: Function, sendToWindow: Function }} deps
- * @param {Map} runningFlows
+ * @param {RunningFlows} runningFlows
  * @param {string} flowId
  * @param {string} ptyId
  * @param {number} exitCode
@@ -43,7 +45,7 @@ function cleanupFlowProcess(deps, runningFlows, flowId, ptyId, exitCode) {
  * Wires up PTY data/exit listeners for a running flow process.
  *
  * @param {{ sendToWindow: Function, getPtyManager: Function, getFlow: Function, saveFlow: Function, log: object }} deps
- * @param {Map} runningFlows
+ * @param {RunningFlows} runningFlows
  * @param {object} proc
  * @param {object} flow
  * @param {string} ptyId
@@ -71,7 +73,7 @@ function setupPtyListeners(deps, runningFlows, proc, flow, ptyId, runTimestamp) 
  * Executes a single flow inside a new PTY process.
  *
  * @param {{ getPtyManager: Function, sendToWindow: Function, log: object, getFlow: Function, saveFlow: Function }} deps
- * @param {Map} runningFlows
+ * @param {RunningFlows} runningFlows
  * @param {object} flow
  */
 function execute(deps, runningFlows, flow) {
@@ -120,7 +122,7 @@ function execute(deps, runningFlows, flow) {
  * Kills all running flow processes and clears the map.
  *
  * @param {{ getPtyManager: Function }} deps
- * @param {Map} runningFlows
+ * @param {RunningFlows} runningFlows
  */
 function stopAll(deps, runningFlows) {
   const ptyManager = deps.getPtyManager();
@@ -134,7 +136,7 @@ function stopAll(deps, runningFlows) {
 /**
  * Returns a plain object mapping flow IDs to their PTY IDs.
  *
- * @param {Map} runningFlows
+ * @param {RunningFlows} runningFlows
  * @returns {Record<string, string>}
  */
 function getRunning(runningFlows) {

--- a/main/parse-utils.js
+++ b/main/parse-utils.js
@@ -2,7 +2,7 @@
  * Split raw text into lines, filter empty, optionally map.
  * @param {string} raw
  * @param {((line: string) => *)?} [mapFn]
- * @returns {Array}
+ * @returns {Array<string|*>}
  */
 function splitLines(raw, mapFn) {
   if (!raw) return [];

--- a/src/components/flow-card-terminal.js
+++ b/src/components/flow-card-terminal.js
@@ -40,7 +40,7 @@ export class FlowCardTerminalManager {
   /**
    * Create a readonly terminal, register it in the given map, and run an
    * optional setup callback.  Returns the terminal record.
-   * @param {Map} map - target map (_liveTerminals or _logTerminals)
+   * @param {Map<string, object>} map - target map (_liveTerminals or _logTerminals)
    * @param {string} flowId
    * @param {HTMLElement} containerEl
    * @param {object} opts - extra terminal options (scrollback, cursorStyle, …)

--- a/src/utils/file-tree-watcher.js
+++ b/src/utils/file-tree-watcher.js
@@ -6,7 +6,7 @@ import { DEBOUNCE_DELAY, WATCH_PREFIX } from './file-tree-helpers.js';
 
 /**
  * Set up a debounced fs.onChanged listener.
- * @param {Map} debounceTimers - shared timer map
+ * @param {Map<string, ReturnType<typeof setTimeout>>} debounceTimers - shared timer map
  * @param {(watchIdOrCwd: string) => Promise<void>} refreshSection - callback to refresh
  * @param {{ onChanged: (cb: (event: { id: string }) => void) => (() => void) }} fsApi - injected fs API
  * @returns {() => void} unsubscribe function

--- a/src/utils/file-viewer-files.js
+++ b/src/utils/file-viewer-files.js
@@ -9,7 +9,7 @@ import { pinnedFiles } from './editor-helpers.js';
  * Open a file and add it to the open-files map.
  * If already open, returns false (caller should just activate the tab).
  *
- * @param {Map} openFiles
+ * @param {Map<string, { name: string, content: string, savedContent: string, lang: string, error: string|null, viewMode: string }>} openFiles
  * @param {string} filePath
  * @param {string} fileName
  * @param {{ readfile: (path: string) => Promise<{ content?: string, error?: string }> }} fsApi - injected fs API

--- a/src/utils/flow-view-rendering.js
+++ b/src/utils/flow-view-rendering.js
@@ -122,7 +122,7 @@ export function renderFlowList(ctx) {
 /**
  * Handle the "open modal" flow: prompt user, persist, and refresh.
  * @param {{ existing: object|null, catData: object, moveFlowToCategory: Function, persistCategories: Function, refresh: Function }} ctx
- * @param {Function} getOpenFlowModal - returns the openFlowModal component
+ * @param {() => Function} getOpenFlowModal - returns the openFlowModal component
  * @param {object} flowApi - the flow API service
  */
 export async function handleOpenModal(ctx, getOpenFlowModal, flowApi) {

--- a/src/utils/tab-manager-tab-ops.js
+++ b/src/utils/tab-manager-tab-ops.js
@@ -76,7 +76,7 @@ export function bindTabOps(tm) {
 /**
  * Build the deps and call doRenderTabBar.
  * @param {object} tm - TabManager instance
- * @returns {Map} tab element map
+ * @returns {Map<string, HTMLElement>} tab element map
  */
 export function renderTabBar(tm) {
   return bindTabOps(tm).renderTabBar();

--- a/src/utils/usage-view-helpers.js
+++ b/src/utils/usage-view-helpers.js
@@ -81,12 +81,12 @@ export function createSection(title) {
  * Factory that builds the common { cards, chart, tables } shape shared by
  * run-based tabs (agents and flows).
  *
- * @param {object}   m               The metrics slice (metrics.agent or metrics.flow).
- * @param {object}   options
- * @param {Array}    options.cards    Four card descriptors (label/value/cls/sub).
- * @param {string}   options.chartTitle  Title displayed above the chart.
- * @param {Array}    options.tables   One or more table descriptors.
- * @returns {{ cards: Array, chart: object, tables: Array }}
+ * @param {object} m The metrics slice (metrics.agent or metrics.flow).
+ * @param {object} options
+ * @param {Array<{ label: string, value: string|number, cls: string, sub?: string }>} options.cards Four card descriptors.
+ * @param {string} options.chartTitle Title displayed above the chart.
+ * @param {Array<object>} options.tables One or more table descriptors.
+ * @returns {{ cards: Array<object>, chart: object, tables: Array<object> }}
  */
 function _createRunBasedTabConfig(m, { cards, chartTitle, tables }) {
   return {


### PR DESCRIPTION
## Refactoring

Resserre 13 occurrences de types JSDoc lâches (\`{Map}\`, \`{Array}\`, \`{Function}\` sans paramètres de type) réparties sur 8 fichiers. Modifications purement documentaires — aucun changement runtime.

Choix de typage :
- Pour \`flow-executor.js\` (5 occurrences répétées), introduction d'un \`@typedef RunningFlows\` réutilisable.
- Pour \`Map\` simples, types clé/valeur explicites (\`Map<string, object>\`, \`Map<string, HTMLElement>\`, etc.).
- Pour \`Array\` à structure connue, \`Array<{...}>\` avec champs.
- Pour \`Function\` retournant un composant, signature explicite \`() => Function\`.

Closes #456

## Fichier(s) modifié(s)

- \`main/flow-executor.js\` — 5x \`{Map}\` → \`{RunningFlows}\` + typedef
- \`main/parse-utils.js\` — \`@returns {Array}\` → \`Array<string|*>\`
- \`src/components/flow-card-terminal.js\` — \`{Map}\` → \`Map<string, object>\`
- \`src/utils/file-tree-watcher.js\` — \`{Map}\` → \`Map<string, ReturnType<typeof setTimeout>>\`
- \`src/utils/file-viewer-files.js\` — \`{Map}\` → \`Map<string, {...}>\` détaillé
- \`src/utils/flow-view-rendering.js\` — \`{Function}\` → \`() => Function\`
- \`src/utils/tab-manager-tab-ops.js\` — \`@returns {Map}\` → \`Map<string, HTMLElement>\`
- \`src/utils/usage-view-helpers.js\` — 2x \`{Array}\` → \`Array<{...}>\`

## Vérifications

- [x] Build OK (\`npm run build\`)
- [x] Tests OK (25 fichiers, 403 tests)

---

📂 Path local : \`/Users/claude/flux/review/pikagent/\`
🤖 PR créée automatiquement par l'Agent Refactor