### PR TITLE
refactor: remove unused exports DATE_LOCALE and buildMetrics

### DIFF
--- a/shared/aggregation-utils.js
+++ b/shared/aggregation-utils.js
@@ -231,6 +231,5 @@ module.exports = {
   initializeCounters,
   computeRate,
   computeNumericStats,
-  buildMetrics,
   createDomainMetricsBuilder,
 };

--- a/shared/date-utils.js
+++ b/shared/date-utils.js
@@ -53,4 +53,4 @@ function generateDateRange(days = 30) {
   });
 }
 
-module.exports = { DATE_LOCALE, formatDateTime, extractDateString, generateDateRange };
+module.exports = { formatDateTime, extractDateString, generateDateRange };


### PR DESCRIPTION
## Refactoring

Suppression de 2 exports inutilisés dans shared/ :
- `DATE_LOCALE` dans `shared/date-utils.js` — utilisé en interne uniquement
- `buildMetrics` dans `shared/aggregation-utils.js` — utilisé en interne par `createDomainMetricsBuilder` uniquement

Closes #464

## Fichier(s) modifié(s)

- `shared/date-utils.js`
- `shared/aggregation-utils.js`

## Vérifications

- [x] Build OK
- [x] Tests OK

---

📂 Path local : `/Users/rekta/projet/coding/refactor-pikagent`
🤖 PR créée automatiquement par l'Agent Refactor