### PR TITLE
refactor: rename UI config-manager to config-settings-panel

### DIFF
--- a/src/components/config-settings-panel.js
+++ b/src/components/config-settings-panel.js
@@ -10,7 +10,7 @@ import {
 import { registerComponent } from '../utils/component-registry.js';
 import configApi from '../services/config-api.js';
 
-export class ConfigManager {
+export class ConfigSettingsPanel {
   constructor(tabManager) {
     this.tabManager = tabManager;
     this.currentConfigName = null;
@@ -127,4 +127,4 @@ export class ConfigManager {
   }
 }
 
-registerComponent('ConfigManager', ConfigManager);
+registerComponent('ConfigSettingsPanel', ConfigSettingsPanel);

--- a/src/components/tab-manager.js
+++ b/src/components/tab-manager.js
@@ -45,7 +45,7 @@ export class TabManager {
   _initState() {
     this.tabs = new Map();
     this.activeTabId = this.defaultCwd = this.onOpenSettings = null;
-    this.configManager = new (getComponent('ConfigManager'))(this);
+    this.configManager = new (getComponent('ConfigSettingsPanel'))(this);
     this.boardView = this._boardContainerEl = null;
     this.flowView = this._flowContainerEl = null;
     this.usageView = this._usageContainerEl = null;


### PR DESCRIPTION
## Refactoring

Renommage de la classe `ConfigManager` en `ConfigSettingsPanel` dans `src/components/config-settings-panel.js` pour lever l'ambiguïté avec `main/config-manager.js` (backend CRUD).

Le fichier avait déjà été renommé dans #445. Ce PR complète le travail en renommant la classe exportée et la clé du registre de composants.

Closes #442

## Fichier(s) modifié(s)

- `src/components/config-settings-panel.js` — classe `ConfigManager` → `ConfigSettingsPanel`, `registerComponent` mis à jour
- `src/components/tab-manager.js` — `getComponent('ConfigManager')` → `getComponent('ConfigSettingsPanel')`

## Vérifications

- [x] Build OK (`npm run build`)
- [x] Tests OK (403 tests, 25 suites)

---

PR créée automatiquement par l'Agent Refactor