### PR TITLE
refactor: extract gitFlowStep helper for error handling

### DIFF
--- a/tests/utils/git-flow-helpers.test.js
+++ b/tests/utils/git-flow-helpers.test.js
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('../../src/utils/dom-dialogs.js', () => ({
+  showErrorAlert: vi.fn(),
+}));
+
+import { gitFlowStep } from '../../src/utils/git-flow-helpers.js';
+import { showErrorAlert } from '../../src/utils/dom-dialogs.js';
+
+describe('gitFlowStep', () => {
+  it('returns the result when apiCall succeeds', async () => {
+    const apiCall = vi.fn().mockResolvedValue({ ok: true, data: 42 });
+    const result = await gitFlowStep(apiCall, 'Test failed: ');
+    expect(result).toEqual({ ok: true, data: 42 });
+    expect(apiCall).toHaveBeenCalledOnce();
+    expect(showErrorAlert).not.toHaveBeenCalled();
+  });
+
+  it('returns null and shows error alert when result.ok is false', async () => {
+    const apiCall = vi.fn().mockResolvedValue({ ok: false, error: 'branch conflict' });
+    const result = await gitFlowStep(apiCall, 'Push failed: ');
+    expect(result).toBeNull();
+    expect(showErrorAlert).toHaveBeenCalledWith('Push failed: ', 'branch conflict');
+  });
+
+  it('returns null and shows error alert when result is null', async () => {
+    const apiCall = vi.fn().mockResolvedValue(null);
+    const result = await gitFlowStep(apiCall, 'Unexpected: ');
+    expect(result).toBeNull();
+    expect(showErrorAlert).toHaveBeenCalledWith('Unexpected: ', undefined);
+  });
+
+  it('returns null and shows error alert when result is undefined', async () => {
+    const apiCall = vi.fn().mockResolvedValue(undefined);
+    const result = await gitFlowStep(apiCall, 'No result: ');
+    expect(result).toBeNull();
+    expect(showErrorAlert).toHaveBeenCalledWith('No result: ', undefined);
+  });
+
+  it('returns null when result.ok is falsy (e.g. 0)', async () => {
+    const apiCall = vi.fn().mockResolvedValue({ ok: 0, error: 'zero' });
+    const result = await gitFlowStep(apiCall, 'Zero: ');
+    expect(result).toBeNull();
+    expect(showErrorAlert).toHaveBeenCalledWith('Zero: ', 'zero');
+  });
+
+  it('propagates errors thrown by apiCall', async () => {
+    const apiCall = vi.fn().mockRejectedValue(new Error('network down'));
+    await expect(gitFlowStep(apiCall, 'Crash: ')).rejects.toThrow('network down');
+  });
+});


### PR DESCRIPTION
## Refactoring

Extraction d'un helper gitFlowStep pour dédupliquer le pattern d'error handling dans open-pr-flow.js et worktree-flow.js.

Le helper `gitFlowStep` (dans `src/utils/git-flow-helpers.js`) et son usage dans les deux flow files existent déjà sur `dev` (via PR #432). Cette PR ajoute les tests unitaires manquants pour valider le comportement du helper.

Closes #427

## Fichier(s) modifié(s)

- `src/utils/git-flow-helpers.js` (existant - helper gitFlowStep)
- `src/utils/open-pr-flow.js` (existant - utilise gitFlowStep)
- `src/utils/worktree-flow.js` (existant - utilise gitFlowStep)
- **Nouveau**: `tests/utils/git-flow-helpers.test.js` (6 tests unitaires)

## Tests ajoutés

- Retourne le résultat quand l'appel API réussit (`ok: true`)
- Retourne `null` et affiche une alerte quand `result.ok` est `false`
- Gère `null` et `undefined` comme résultats
- Gère les valeurs falsy pour `ok` (e.g. `0`)
- Propage les erreurs lancées par l'appel API

## Vérifications

- [x] Build OK
- [x] Tests OK (26 fichiers, 409 tests)

---

📂 Path local : `/Users/rekta/projet/coding/refactor-pikagent`
🤖 PR créée automatiquement par l'Agent Refactor