### PR TITLE
refactor: use buildDomainButtonBar and consolidate sanitization

### DIFF
--- a/main/config-helpers.js
+++ b/main/config-helpers.js
@@ -4,7 +4,6 @@
  */
 
 const { buildTimestampedRecord } = require('./record-helpers');
-const { sanitizeName } = require('../shared/string-utils');
 
 const DEFAULT_META = { defaultConfig: null };
 
@@ -23,4 +22,4 @@ function formatConfigList(configs, defaultConfigName) {
     }));
 }
 
-module.exports = { DEFAULT_META, sanitizeName, buildConfigRecord, formatConfigList };
+module.exports = { DEFAULT_META, buildConfigRecord, formatConfigList };

--- a/main/config-manager.js
+++ b/main/config-manager.js
@@ -1,6 +1,7 @@
 const { CONFIG_DIR, META_FILE } = require('./paths');
 const { readJson, writeJson } = require('./fs-utils');
-const { DEFAULT_META, sanitizeName, buildConfigRecord, formatConfigList } = require('./config-helpers');
+const { DEFAULT_META, buildConfigRecord, formatConfigList } = require('./config-helpers');
+const { sanitizeName } = require('../shared/string-utils');
 const { Cache, cachedAsync } = require('./cache');
 const { trySafe } = require('./logger');
 const { JsonStore } = require('./json-store');

--- a/tests/main/config-helpers.test.js
+++ b/tests/main/config-helpers.test.js
@@ -1,22 +1,7 @@
 import { describe, it, expect } from 'vitest';
-const { DEFAULT_META, sanitizeName, buildConfigRecord, formatConfigList } = require('../../main/config-helpers');
+const { DEFAULT_META, buildConfigRecord, formatConfigList } = require('../../main/config-helpers');
 
 describe('config-helpers', () => {
-  describe('sanitizeName', () => {
-    it('keeps alphanumeric, dash, underscore and space', () => {
-      expect(sanitizeName('my-config_1 test')).toBe('my-config_1 test');
-    });
-
-    it('replaces special characters with underscore', () => {
-      expect(sanitizeName('foo/bar:baz!')).toBe('foo_bar_baz_');
-    });
-
-    it('truncates to 64 characters', () => {
-      const long = 'a'.repeat(100);
-      expect(sanitizeName(long)).toHaveLength(64);
-    });
-  });
-
   describe('buildConfigRecord', () => {
     it('creates a new record with createdAt = now', () => {
       const record = buildConfigRecord('test', { tabs: [1] }, null, '2025-01-01');

--- a/tests/shared/string-utils.test.js
+++ b/tests/shared/string-utils.test.js
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+const { sanitizeName, sanitizeSegment } = require('../../shared/string-utils');
+
+describe('string-utils', () => {
+  describe('sanitizeName', () => {
+    it('keeps alphanumeric, dash, underscore and space', () => {
+      expect(sanitizeName('my-config_1 test')).toBe('my-config_1 test');
+    });
+
+    it('replaces special characters with underscore', () => {
+      expect(sanitizeName('foo/bar:baz!')).toBe('foo_bar_baz_');
+    });
+
+    it('truncates to 64 characters', () => {
+      const long = 'a'.repeat(100);
+      expect(sanitizeName(long)).toHaveLength(64);
+    });
+  });
+
+  describe('sanitizeSegment', () => {
+    it('replaces non-alphanum/dot/dash/underscore with hyphens', () => {
+      expect(sanitizeSegment('feat/my branch')).toBe('feat-my-branch');
+    });
+
+    it('trims leading and trailing hyphens', () => {
+      expect(sanitizeSegment('--hello--')).toBe('hello');
+    });
+
+    it('preserves dots, underscores and dashes', () => {
+      expect(sanitizeSegment('v1.0_rc-1')).toBe('v1.0_rc-1');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Remove `sanitizeName` re-export from `config-helpers.js` — consumers now import directly from `shared/string-utils.js`
- Update `config-manager.js` to import `sanitizeName` from `shared/string-utils` instead of via `config-helpers`
- Move `sanitizeName` tests from `config-helpers.test.js` to new `tests/shared/string-utils.test.js` (with added `sanitizeSegment` coverage)
- The button bar dedup (`buildDomainButtonBar`) was already applied in a prior PR; this completes the consolidation

Closes #415

## Test plan

- [x] `npm run build` passes
- [x] `npm test` — 27 test files, 411 tests pass
- [ ] Manual: verify flow card and category buttons render correctly
- [ ] Manual: verify config save/load still sanitizes names
- [ ] Manual: verify worktree dialog path sanitization

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>