### PR TITLE
refactor: reduce manager-init.js coupling via domain grouping

### DIFF
--- a/main/manager-init.js
+++ b/main/manager-init.js
@@ -5,15 +5,15 @@
  * dependencies that used to live inside ipc-handlers.js.  The main entry
  * point calls `initManagers()` once and passes the result to the IPC layer.
  *
- * Managers are lazy-loaded via getter properties so that each domain module
- * is only `require()`-d when first accessed (i.e. inside `initManagers()`),
- * rather than at module-load time.  This reduces coupling and speeds up
- * initial require of this file.
+ * Managers are organized into 4 domain groups (sourced from `managers.js`):
+ *   IO        — ptyManager, fsManager
+ *   Data      — sessionManager, usageManager
+ *   Workflow  — flowManager, skillsManager
+ *   Infra     — gitManager, configManager, updateManager
  *
- * All managers are sourced from the consolidated barrel:
- *   managers.js — ptyManager, fsManager, sessionManager, usageManager,
- *                 flowManager, skillsManager, gitManager, configManager,
- *                 updateManager
+ * Each domain group is lazy-loaded via a getter property so that modules
+ * are only `require()`-d when first accessed (inside `initManagers()`),
+ * rather than at module-load time.
  */
 
 /**
@@ -39,62 +39,31 @@ function lazyProp(obj, name, factory) {
   });
 }
 
-/**
- * Resolve a manager from the consolidated barrel module.
- *
- * @param {string} name  Manager export name, e.g. 'ptyManager'.
- * @returns {any}
- */
-function resolveManager(name) {
-  return require('./managers')[name];
-}
-
-/**
- * Lazy accessor object — each property loads its manager on first access,
- * then caches the result by replacing itself with a plain data property.
- */
-const managers = {};
-
-const ALL_MANAGER_NAMES = [
-  'ptyManager',
-  'fsManager',
-  'sessionManager',
-  'usageManager',
-  'flowManager',
-  'skillsManager',
-  'gitManager',
-  'configManager',
-  'updateManager',
-];
-
-for (const name of ALL_MANAGER_NAMES) {
-  lazyProp(managers, name, () => resolveManager(name));
-}
-
 const { safeSend } = require('./ipc-helpers');
 
 /**
- * Names of managers that expose a `cleanup()` method and should be torn
- * down when the application closes.  Resolved lazily via `managers[name]`
- * so the modules are not loaded until cleanup time (which is after
- * `initManagers()` has already accessed them).
- *
- * Guarded at definition time: every entry must correspond to a known manager.
+ * Domain-grouped lazy accessor — each domain group loads its managers on
+ * first access, then caches the result.  Individual managers are accessed
+ * as `domains.io.ptyManager`, `domains.data.sessionManager`, etc.
  */
-const LIFECYCLE_NAMES = [
-  'sessionManager',
-  'ptyManager',
-  'fsManager',
-  'flowManager',
-  'usageManager',
-];
+const domains = {};
 
-// Guard: verify every lifecycle name maps to a known manager property.
-for (const name of LIFECYCLE_NAMES) {
-  if (!ALL_MANAGER_NAMES.includes(name)) {
-    throw new Error(`LIFECYCLE_NAMES contains unknown manager: "${name}"`);
-  }
-}
+lazyProp(domains, 'io',       () => require('./managers').io);
+lazyProp(domains, 'data',     () => require('./managers').data);
+lazyProp(domains, 'workflow', () => require('./managers').workflow);
+lazyProp(domains, 'infra',    () => require('./managers').infra);
+
+/**
+ * Names of managers (by domain) that expose a `cleanup()` method and
+ * should be torn down when the application closes.
+ */
+const LIFECYCLE_CLEANUP = [
+  { domain: 'data',     name: 'sessionManager' },
+  { domain: 'io',       name: 'ptyManager'     },
+  { domain: 'io',       name: 'fsManager'      },
+  { domain: 'workflow', name: 'flowManager'    },
+  { domain: 'data',     name: 'usageManager'   },
+];
 
 /**
  * Wire inter-manager dependencies and start runtime services.
@@ -103,12 +72,14 @@ for (const name of LIFECYCLE_NAMES) {
  * @returns {{ targets: Record<string, object>, cleanup: () => void }}
  */
 function initManagers(getWindow) {
+  const { io, data, workflow, infra } = domains;
+
   // -- Lifecycle: start managers that need runtime context --
   // Access order matters: updateManager first, then flow, session, usage.
-  managers.updateManager.init();
-  managers.flowManager.start(getWindow, managers.ptyManager);
-  managers.sessionManager.start(managers.ptyManager);
-  managers.usageManager.init(managers.sessionManager);
+  infra.updateManager.init();
+  workflow.flowManager.start(getWindow, io.ptyManager);
+  data.sessionManager.start(io.ptyManager);
+  data.usageManager.init(data.sessionManager);
 
   // -- Build target map consumed by IPC dispatching --
   const { shell, clipboard } = require('electron');
@@ -117,33 +88,33 @@ function initManagers(getWindow) {
   // getVersion, performUpdate); the IPC schema uses shorter aliases
   // (check, version, run) and `run` needs a per-call progress callback.
   const updateTarget = {
-    check:    () => managers.updateManager.checkForUpdates(),
-    version:  () => managers.updateManager.getVersion(),
-    relaunch: () => managers.updateManager.relaunch(),
-    run:      () => managers.updateManager.performUpdate((p) => safeSend(getWindow, 'update:progress', p)),
+    check:    () => infra.updateManager.checkForUpdates(),
+    version:  () => infra.updateManager.getVersion(),
+    relaunch: () => infra.updateManager.relaunch(),
+    run:      () => infra.updateManager.performUpdate((p) => safeSend(getWindow, 'update:progress', p)),
   };
 
   const targets = {
-    pty:       managers.ptyManager,
-    fs:        managers.fsManager,
-    git:       managers.gitManager,
-    config:    managers.configManager,
-    flow:      managers.flowManager,
-    usage:     managers.usageManager,
-    skills:    managers.skillsManager,
+    pty:       io.ptyManager,
+    fs:        io.fsManager,
+    git:       infra.gitManager,
+    config:    infra.configManager,
+    flow:      workflow.flowManager,
+    usage:     data.usageManager,
+    skills:    workflow.skillsManager,
     update:    updateTarget,
     shell,
     clipboard,
   };
 
   function cleanup() {
-    for (const name of LIFECYCLE_NAMES) {
-      const mod = managers[name];
+    for (const { domain, name } of LIFECYCLE_CLEANUP) {
+      const mod = domains[domain][name];
       if (typeof mod.cleanup === 'function') mod.cleanup();
     }
   }
 
-  return { targets, cleanup, ptyManager: managers.ptyManager, sessionManager: managers.sessionManager };
+  return { targets, cleanup, ptyManager: io.ptyManager, sessionManager: data.sessionManager };
 }
 
 module.exports = { initManagers };

--- a/main/managers.js
+++ b/main/managers.js
@@ -4,7 +4,7 @@
  * Replaces the individual barrel files (data-managers.js, infra-managers.js,
  * io-managers.js, workflow-managers.js).
  *
- * Groups:
+ * Domain groups (also exported as named collections for domain-aware consumers):
  *   IO        — ptyManager, fsManager
  *   Data      — sessionManager, usageManager
  *   Workflow  — flowManager, skillsManager
@@ -17,27 +17,40 @@ const fsManager = require('./fs-manager');
 
 const ptyManager = new PtyManager();
 
+const io = { ptyManager, fsManager };
+
 // ── Data managers ───────────────────────────────────────────────────
 const sessionManager = require('./session-manager');
 const usageManager = require('./usage-manager');
 
+const data = { sessionManager, usageManager };
+
 // ── Workflow managers ───────────────────────────────────────────────
 const flowManager = require('./flow-manager');
 const skillsManager = require('./skills-manager');
+
+const workflow = { flowManager, skillsManager };
 
 // ── Infra managers ──────────────────────────────────────────────────
 const gitManager = require('./git-manager');
 const configManager = require('./config-manager');
 const updateManager = require('./update-manager');
 
-module.exports = {
-  ptyManager,
-  fsManager,
-  sessionManager,
-  usageManager,
-  flowManager,
-  skillsManager,
-  gitManager,
-  configManager,
-  updateManager,
-};
+const infra = { gitManager, configManager, updateManager };
+
+// Domain groups — for consumers that want to import by domain
+module.exports.io = io;
+module.exports.data = data;
+module.exports.workflow = workflow;
+module.exports.infra = infra;
+
+// Flat exports — backward-compatible individual access
+module.exports.ptyManager = ptyManager;
+module.exports.fsManager = fsManager;
+module.exports.sessionManager = sessionManager;
+module.exports.usageManager = usageManager;
+module.exports.flowManager = flowManager;
+module.exports.skillsManager = skillsManager;
+module.exports.gitManager = gitManager;
+module.exports.configManager = configManager;
+module.exports.updateManager = updateManager;


### PR DESCRIPTION
## Summary

- Replace the flat 10-manager lazy accessor in `manager-init.js` with 4 domain-grouped lazy properties (`io`, `data`, `workflow`, `infra`), reducing the coupling surface from 10 individual names to 4 domain groups
- Add domain group exports (`io`, `data`, `workflow`, `infra`) to `managers.js` alongside backward-compatible flat exports
- Restructure `LIFECYCLE_CLEANUP` to use `{domain, name}` pairs instead of bare string names, making domain ownership explicit

## Changes

| File | Change |
|---|---|
| `main/managers.js` | Add domain group objects (`io`, `data`, `workflow`, `infra`) and export them alongside flat backward-compatible exports |
| `main/manager-init.js` | Replace `ALL_MANAGER_NAMES` flat list + `resolveManager()` with 4 domain-grouped lazy accessors; use `domains.io.ptyManager` style access throughout |

## Test plan

- [x] `npm run build` passes
- [x] `npm test` passes (408/408 tests)
- [ ] Manual: verify application startup (all managers initialize correctly)
- [ ] Manual: verify each domain works (terminals, git, flows, skills, configs, updates, usage tracking)

Closes #441

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>