### PR TITLE
refactor: remove unused bindTabOps export (closes #474)

### DIFF
--- a/src/utils/tab-manager-tab-ops.js
+++ b/src/utils/tab-manager-tab-ops.js
@@ -30,7 +30,7 @@ import {
  *
  * @param {object} tm - TabManager instance
  */
-export function bindTabOps(tm) {
+function bindTabOps(tm) {
   // Stable closures over `tm`, captured once.
   const renderTabBar = () => tm.renderTabBar();
   const switchTo = (id) => tm.switchTo(id);


### PR DESCRIPTION
## Refactoring

Suppression de l'export mort `bindTabOps` dans `tab-manager-tab-ops.js` — convertie en fonction locale car uniquement utilisée en interne par `renderTabBar`, `createTab` et `closeTab` du même fichier.

Les alias camelCase dans `fs-manager.js` et `git-manager.js` mentionnés dans l'issue avaient déjà été nettoyés dans des refactors antérieurs. L'export `importFrom` dans `skills-manager.js` est utilisé via IPC (`import: importFrom`).

Closes #474

## Fichier(s) modifié(s)

- `src/utils/tab-manager-tab-ops.js` — `export function bindTabOps` → `function bindTabOps`

## Vérifications

- [x] Build OK
- [x] Tests OK (408/408)

---

📂 Path local : `/Users/rekta/projet/coding/refactor-pikagent`
🤖 PR créée automatiquement par l'Agent Refactor