### PR TITLE
refactor: factor _agentTabConfig/_flowTabConfig into shared factory (closes #425)

### DIFF
--- a/src/utils/usage-view-helpers.js
+++ b/src/utils/usage-view-helpers.js
@@ -78,19 +78,45 @@ export function createSection(title) {
 // --- Tab configurations ---
 
 /**
+ * Build the success-rate card (3rd card in run-based tabs).
+ * @param {{ rate: { rate: number } }} m
+ */
+function _rateCard(m) {
+  return { label: 'Taux succès', value: `${m.rate.rate}%`, cls: rateCls(m.rate.rate) };
+}
+
+/**
+ * Build the average-duration card (4th card in run-based tabs).
+ * Includes min/max sub-text when duration samples exist.
+ * @param {{ duration: { avg: number, min: number, max: number, count: number } }} m
+ */
+function _durationCard(m) {
+  return {
+    label: 'Durée moy.',
+    value: formatDuration(m.duration.avg),
+    cls: 'usage-stat-value-blue',
+    sub: m.duration.count > 0 ? `min: ${formatDuration(m.duration.min)} · max: ${formatDuration(m.duration.max)}` : '',
+  };
+}
+
+/**
  * Factory that builds the common { cards, chart, tables } shape shared by
  * run-based tabs (agents and flows).
  *
- * @param {object}   m               The metrics slice (metrics.agent or metrics.flow).
+ * The 3rd and 4th cards (success rate + avg duration) follow an identical
+ * pattern across tabs and are derived from `m` automatically. Callers only
+ * supply the two domain-specific leading cards.
+ *
+ * @param {object}   m                  The metrics slice (metrics.agent or metrics.flow).
  * @param {object}   options
- * @param {Array}    options.cards    Four card descriptors (label/value/cls/sub).
+ * @param {Array}    options.leadingCards Two card descriptors (total + active).
  * @param {string}   options.chartTitle  Title displayed above the chart.
- * @param {Array}    options.tables   One or more table descriptors.
+ * @param {Array}    options.tables     One or more table descriptors.
  * @returns {{ cards: Array, chart: object, tables: Array }}
  */
-function _createRunBasedTabConfig(m, { cards, chartTitle, tables }) {
+function _createRunBasedTabConfig(m, { leadingCards, chartTitle, tables }) {
   return {
-    cards,
+    cards: [...leadingCards, _rateCard(m), _durationCard(m)],
     chart: { title: chartTitle, data: m.perDay, segments: RUN_CHART_SEGMENTS, tooltip: runTooltip },
     tables,
   };
@@ -105,11 +131,9 @@ function _agentTabConfig(metrics) {
   const m = metrics.agent;
   const maxFileCount = metrics.mostModifiedFiles[0]?.count || 1;
   return _createRunBasedTabConfig(m, {
-    cards: [
+    leadingCards: [
       { label: 'Sessions', value: m.totalSessions, cls: '' },
       { label: 'En cours', value: m.activeSessions, cls: m.activeSessions > 0 ? 'usage-stat-value-green' : '' },
-      { label: 'Taux succès', value: `${m.rate.rate}%`, cls: rateCls(m.rate.rate) },
-      { label: 'Durée moy.', value: formatDuration(m.duration.avg), cls: 'usage-stat-value-blue', sub: m.duration.count > 0 ? `min: ${formatDuration(m.duration.min)} · max: ${formatDuration(m.duration.max)}` : '' },
     ],
     chartTitle: 'Sessions par jour',
     tables: [
@@ -182,11 +206,9 @@ function _flowTabConfig(metrics) {
     return { empty: ['Aucun flow configuré', 'Créez des flows depuis la vue FLOW'] };
   }
   return _createRunBasedTabConfig(f, {
-    cards: [
+    leadingCards: [
       { label: 'Total Runs', value: f.rate.total, cls: '' },
       { label: 'Flows actifs', value: `${f.activeFlows}/${f.totalFlows}`, cls: '' },
-      { label: 'Taux succès', value: `${f.rate.rate}%`, cls: rateCls(f.rate.rate) },
-      { label: 'Durée moy.', value: formatDuration(f.duration.avg), cls: 'usage-stat-value-blue', sub: f.duration.count > 0 ? `min: ${formatDuration(f.duration.min)} · max: ${formatDuration(f.duration.max)}` : '' },
     ],
     chartTitle: 'Runs par jour',
     tables: [


### PR DESCRIPTION
## Résumé

Élimine la duplication structurelle restante entre `_agentTabConfig` et `_flowTabConfig` dans `src/utils/usage-view-helpers.js`.

Les cartes 3 et 4 (taux de succès + durée moyenne) suivaient exactement le même pattern dans les deux fonctions. Elles sont désormais construites par deux petits helpers (`_rateCard`, `_durationCard`) appelés depuis la factory partagée `_createRunBasedTabConfig`. Les appelants ne fournissent plus que les deux cartes de tête (`leadingCards`) spécifiques à leur domaine, plus le titre du chart et les tables.

Comportement strictement identique : aucune modification des valeurs, classes CSS ou labels.

## Fichier modifié

- `src/utils/usage-view-helpers.js`

## Vérifications

- `node build.js` : OK
- `npx vitest run` : 408 tests passent (26 fichiers)

Closes #425

📂 Path local : `/Users/claude/flux/review/pikagent`

🤖 PR créée automatiquement par l'Agent Refactor