### PR TITLE
refactor: rename internal manager fns to match IPC channel names (closes #474)

### DIFF
--- a/main/fs-manager.js
+++ b/main/fs-manager.js
@@ -11,17 +11,17 @@ const { MAX_FILE_SIZE, wrapSafe, doCopy, dirFirstCompare } = require('./fs-manag
 const watchers = new Map();
 
 function watchDir(id, dirPath, callback) {
-  unwatchDir(id);
+  unwatch(id);
   try {
     const watcher = fs.watch(dirPath, { recursive: true }, (eventType, filename) => {
       callback({ id, dirPath, eventType, filename });
     });
-    watcher.on('error', () => unwatchDir(id));
+    watcher.on('error', () => unwatch(id));
     watchers.set(id, watcher);
   } catch {}
 }
 
-function unwatchDir(id) {
+function unwatch(id) {
   const w = watchers.get(id);
   if (w) {
     w.close();
@@ -35,10 +35,10 @@ function unwatchAll() {
 }
 
 // ---------------------------------------------------------------------------
-// Public API
+// Public API — function names match IPC channel suffixes (fs:readdir → readdir)
 // ---------------------------------------------------------------------------
 
-async function readDirectory(dirPath) {
+async function readdir(dirPath) {
   try {
     const entries = await fsp.readdir(dirPath, { withFileTypes: true });
     return entries.sort(dirFirstCompare).map((e) => ({
@@ -51,40 +51,40 @@ async function readDirectory(dirPath) {
   }
 }
 
-const readFile = wrapSafe(async (filePath) => {
+const readfile = wrapSafe(async (filePath) => {
   const stat = await fsp.stat(filePath);
   if (stat.size > MAX_FILE_SIZE) return { error: 'File too large (>2MB)' };
   const content = await fsp.readFile(filePath, 'utf-8');
   return { content, size: stat.size };
 });
 
-const writeFile = wrapSafe(async (filePath, content) => {
+const writefile = wrapSafe(async (filePath, content) => {
   await fsp.writeFile(filePath, content, 'utf-8');
   return { success: true };
 });
 
-const makeDir = wrapSafe(async (dirPath) => {
+const mkdir = wrapSafe(async (dirPath) => {
   await fsp.mkdir(dirPath, { recursive: true });
   return { success: true };
 });
 
-const copyEntry = wrapSafe(async (srcPath) => {
+const copy = wrapSafe(async (srcPath) => {
   const destPath = await doCopy(srcPath, path.dirname(srcPath), true);
   return { success: true, destPath };
 });
 
-const copyFileTo = wrapSafe(async (srcPath, destDir) => {
+const copyTo = wrapSafe(async (srcPath, destDir) => {
   const destPath = await doCopy(srcPath, destDir, false);
   return { success: true, destPath };
 });
 
-const renameEntry = wrapSafe(async (oldPath, newName) => {
+const rename = wrapSafe(async (oldPath, newName) => {
   const newPath = path.join(path.dirname(oldPath), newName);
   await fsp.rename(oldPath, newPath);
   return { success: true, newPath };
 });
 
-function getHomedir() {
+function homedir() {
   return os.homedir();
 }
 
@@ -93,16 +93,7 @@ function cleanup() {
 }
 
 module.exports = {
-  // Method aliases matching channel suffixes (fs:readdir → readdir, etc.)
-  readdir: readDirectory,
-  readfile: readFile,
-  writefile: writeFile,
-  mkdir: makeDir,
-  copy: copyEntry,
-  copyTo: copyFileTo,
-  rename: renameEntry,
-  homedir: getHomedir,
-  unwatch: unwatchDir,
+  readdir, readfile, writefile, mkdir, copy, copyTo, rename, homedir, unwatch,
   // Used directly by ipc-handlers.js (custom fs:watch handler) and manager-init.js (cleanup)
   watchDir, cleanup,
 };

--- a/main/git-manager.js
+++ b/main/git-manager.js
@@ -28,11 +28,11 @@ async function runGit(cwd, args, { fallback = null, maxBuffer } = {}) {
 // Public API
 // ---------------------------------------------------------------------------
 
-async function getBranch(cwd) {
+async function branch(cwd) {
   return runGit(cwd, ['rev-parse', '--abbrev-ref', 'HEAD']);
 }
 
-async function getLocalChanges(cwd) {
+async function localChanges(cwd) {
   return trySafe(
     async () => {
       const [stagedRaw, unstagedRaw, untrackedRaw] = await Promise.all([
@@ -48,11 +48,11 @@ async function getLocalChanges(cwd) {
       };
     },
     { staged: [], unstaged: [], untracked: [] },
-    { log, label: 'getLocalChanges' },
+    { log, label: 'localChanges' },
   );
 }
 
-async function getFileDiff(cwd, filePath, isStaged) {
+async function fileDiff(cwd, filePath, isStaged) {
   const args = isStaged ? ['diff', '--cached', '--', filePath] : ['diff', '--', filePath];
   const result = await runGit(cwd, args, { fallback: '', maxBuffer: DIFF_MAX_BUFFER });
   return result;
@@ -62,7 +62,7 @@ async function getFileDiff(cwd, filePath, isStaged) {
 // Worktree / branch API
 // ---------------------------------------------------------------------------
 
-async function isGitRepo(cwd) {
+async function isRepo(cwd) {
   const out = await runGit(cwd, ['rev-parse', '--is-inside-work-tree']);
   return out === 'true';
 }
@@ -147,7 +147,7 @@ async function worktreeRemove(cwd, worktreePath, force) {
   return executeGitCommand(cwd, args, `worktree remove ${worktreePath}`);
 }
 
-async function getRemoteUrl(cwd) {
+async function remoteUrl(cwd) {
   return runGit(cwd, ['config', '--get', 'remote.origin.url']);
 }
 
@@ -212,16 +212,15 @@ async function ghPrCreate(cwd, baseBranch) {
 }
 
 module.exports = {
-  // Method aliases matching channel suffixes (git:branch → branch, etc.)
-  branch: getBranch,
-  localChanges: getLocalChanges,
-  fileDiff: getFileDiff,
-  isRepo: isGitRepo,
+  branch,
+  localChanges,
+  fileDiff,
+  isRepo,
   listBranches,
   worktreeList,
   worktreeAdd,
   worktreeRemove,
-  remoteUrl: getRemoteUrl,
+  remoteUrl,
   pushBranch,
   ghAvailable,
   ghPrCreate,

--- a/src/utils/tab-manager-tab-ops.js
+++ b/src/utils/tab-manager-tab-ops.js
@@ -30,7 +30,7 @@ import {
  *
  * @param {object} tm - TabManager instance
  */
-export function bindTabOps(tm) {
+function bindTabOps(tm) {
   // Stable closures over `tm`, captured once.
   const renderTabBar = () => tm.renderTabBar();
   const switchTo = (id) => tm.switchTo(id);


### PR DESCRIPTION
## Résumé

Élimine la couche d'aliasing camelCase → suffixe de canal IPC dans plusieurs managers en renommant directement les fonctions internes pour qu'elles portent le nom du canal IPC public. Réduit le bruit dans `module.exports` et supprime un export ESM réellement inutilisé dans `tab-manager-tab-ops.js`.

Closes #474

## Changements par fichier

### `main/fs-manager.js`
- `readDirectory` → `readdir`
- `readFile` → `readfile`
- `writeFile` → `writefile`
- `makeDir` → `mkdir`
- `copyEntry` → `copy`
- `copyFileTo` → `copyTo`
- `renameEntry` → `rename`
- `getHomedir` → `homedir`
- `unwatchDir` → `unwatch` (et mise à jour des call sites internes dans `watchDir`)
- `module.exports` utilise désormais la notation shorthand.

### `main/git-manager.js`
- `getBranch` → `branch`
- `getLocalChanges` → `localChanges`
- `getFileDiff` → `fileDiff`
- `isGitRepo` → `isRepo`
- `getRemoteUrl` → `remoteUrl`
- `module.exports` utilise désormais la notation shorthand.

### `main/skills-manager.js`
- Le commentaire sur les alias `delete:` / `import:` a été précisé : ils restent nécessaires car `delete` et `import` sont des mots réservés en JS, donc impossible de renommer les fonctions internes vers ces noms.

### `src/utils/tab-manager-tab-ops.js`
- `bindTabOps` n'est plus exporté (uniquement utilisé en interne par les trois wrappers du même fichier).

## Note sur l'issue

L'issue listait certains exports (`readDirectory`, `getBranch`, etc.) comme exportés en plus de leurs alias minuscules. En réalité ils n'étaient pas dans `module.exports` mais étaient juste les noms locaux des fonctions, utilisés comme valeurs dans des entrées d'alias (`readdir: readDirectory`). Le refactor implémenté suit l'esprit de l'issue (« retirer les alias, conserver les noms minuscules utilisés par les canaux IPC ») en renommant directement les fonctions internes vers leurs noms publics. Les noms `delete` et `import` ne peuvent pas être renommés (mots réservés) donc leurs alias sont conservés.

## Vérifications

- `node build.js` → Build complete.
- `npx vitest run` → 408 tests passed (26 fichiers).

📂 Path local : `/Users/claude/flux/review/pikagent`

🤖 PR créée par l'Agent Refactor