### PR TITLE
refactor: dedupe localStorage theme + tab-ops factory wrappers

### DIFF
--- a/src/components/shortcuts.js
+++ b/src/components/shortcuts.js
@@ -9,6 +9,9 @@ import {
   mergeBindings,
   buildBindingsList,
 } from '../utils/shortcut-helpers.js';
+import { persistedJsonSetting } from '../utils/persisted-setting.js';
+
+const bindingsStore = persistedJsonSetting(STORAGE_KEY, null);
 
 export class ShortcutManager {
   constructor(tabManager) {
@@ -30,19 +33,11 @@ export class ShortcutManager {
   }
 
   loadBindings() {
-    let saved = null;
-    try {
-      const raw = localStorage.getItem(STORAGE_KEY);
-      if (raw) saved = JSON.parse(raw);
-    } catch {}
-    this.bindings = mergeBindings(saved, DEFAULT_BINDINGS);
+    this.bindings = mergeBindings(bindingsStore.get(), DEFAULT_BINDINGS);
   }
 
   _saveBindings() {
-    localStorage.setItem(
-      STORAGE_KEY,
-      JSON.stringify(Object.fromEntries(buildActionKeysMap(this.bindings))),
-    );
+    bindingsStore.set(Object.fromEntries(buildActionKeysMap(this.bindings)));
   }
 
   getBindingsList() {
@@ -60,7 +55,7 @@ export class ShortcutManager {
   }
 
   resetToDefaults() {
-    localStorage.removeItem(STORAGE_KEY);
+    bindingsStore.remove();
     this.loadBindings();
   }
 

--- a/src/utils/persisted-setting.js
+++ b/src/utils/persisted-setting.js
@@ -1,39 +1,111 @@
 /**
- * Tiny factory for localStorage-backed string settings.
+ * Tiny factories for localStorage-backed settings.
  *
- * Centralizes the repeated pattern of:
+ * Centralize the repeated pattern of:
  *   - reading a key with a fallback default
  *   - writing a key while swallowing access / quota errors
+ *   - clearing a key the same way
+ *
+ * Errors from `localStorage` (e.g. SecurityError in private mode, quota
+ * exceeded) are caught so callers never have to wrap the call site.
+ */
+
+/**
+ * Internal helper: safe localStorage read.
+ * @param {string} key
+ * @returns {string | null} raw stored value or null if missing/inaccessible.
+ */
+function readRaw(key) {
+  try {
+    return localStorage.getItem(key);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Internal helper: safe localStorage write.
+ * @param {string} key
+ * @param {string} value
+ */
+function writeRaw(key, value) {
+  try {
+    localStorage.setItem(key, value);
+  } catch {
+    // ignore quota / access errors — setting is best-effort.
+  }
+}
+
+/**
+ * Internal helper: safe localStorage delete.
+ * @param {string} key
+ */
+function removeRaw(key) {
+  try {
+    localStorage.removeItem(key);
+  } catch {
+    // ignore access errors.
+  }
+}
+
+/**
+ * String-valued persisted setting.
  *
  * Values are stored as raw strings to preserve compatibility with existing
  * keys (e.g. 'pikagent-app-theme' has always held bare strings like
  * 'dark' / 'light', not JSON). Callers that need structured data should
- * serialize themselves before calling `set` and parse the result of `get`.
- *
- * Errors from `localStorage` (e.g. SecurityError in private mode, quota
- * exceeded) are caught so callers never have to wrap the call site.
+ * use {@link persistedJsonSetting} instead.
  *
  * @param {string} key          The localStorage key to read/write.
  * @param {string} defaultValue Value returned when the key is missing or
  *                              localStorage throws.
- * @returns {{ get: () => string, set: (value: string) => void }}
+ * @returns {{ get: () => string, set: (value: string) => void, remove: () => void }}
  */
 export function persistedSetting(key, defaultValue) {
   return {
     get() {
+      const raw = readRaw(key);
+      return raw == null ? defaultValue : raw;
+    },
+    set(value) {
+      writeRaw(key, value);
+    },
+    remove() {
+      removeRaw(key);
+    },
+  };
+}
+
+/**
+ * JSON-valued persisted setting.
+ *
+ * Stores any JSON-serializable value, parsing on read and stringifying on
+ * write. Returns `defaultValue` when the key is missing, the stored value
+ * fails to parse, or localStorage throws. The default is returned as-is
+ * (not cloned), so callers should avoid mutating it if they want it to
+ * remain a stable fallback.
+ *
+ * @template T
+ * @param {string} key          The localStorage key to read/write.
+ * @param {T}      defaultValue Value returned on miss / parse error.
+ * @returns {{ get: () => T, set: (value: T) => void, remove: () => void }}
+ */
+export function persistedJsonSetting(key, defaultValue) {
+  return {
+    get() {
+      const raw = readRaw(key);
+      if (raw == null) return defaultValue;
       try {
-        const raw = localStorage.getItem(key);
-        return raw == null ? defaultValue : raw;
+        return JSON.parse(raw);
       } catch {
         return defaultValue;
       }
     },
     set(value) {
-      try {
-        localStorage.setItem(key, value);
-      } catch {
-        // ignore quota / access errors — setting is best-effort.
-      }
+      writeRaw(key, JSON.stringify(value));
+    },
+    remove() {
+      removeRaw(key);
     },
   };
 }

--- a/src/utils/tab-manager-tab-ops.js
+++ b/src/utils/tab-manager-tab-ops.js
@@ -73,27 +73,41 @@ export function bindTabOps(tm) {
   };
 }
 
+// Cache the bound trio per TabManager instance: each `tm` keeps its own
+// closures over `switchTo`, `closeTab`, `renameTab`, so they are reused
+// across calls instead of being rebuilt on every wrapper invocation.
+const opsCache = new WeakMap();
+
+function ops(tm) {
+  let bound = opsCache.get(tm);
+  if (!bound) {
+    bound = bindTabOps(tm);
+    opsCache.set(tm, bound);
+  }
+  return bound;
+}
+
 /**
  * Build the deps and call doRenderTabBar.
  * @param {object} tm - TabManager instance
  * @returns {Map} tab element map
  */
 export function renderTabBar(tm) {
-  return bindTabOps(tm).renderTabBar();
+  return ops(tm).renderTabBar();
 }
 
 /**
  * Build the deps and call doCreateTab.
  */
 export function createTab(tm, switchTo, name, cwd) {
-  return bindTabOps(tm).createTab(switchTo, name, cwd);
+  return ops(tm).createTab(switchTo, name, cwd);
 }
 
 /**
  * Build the deps and call doCloseTab.
  */
 export function closeTab(tm, createTabFn, switchToFn, id) {
-  return bindTabOps(tm).closeTab(createTabFn, switchToFn, id);
+  return ops(tm).closeTab(createTabFn, switchToFn, id);
 }
 
 /**


### PR DESCRIPTION
## Résumé

Issue #438 — Duplications résiduelles.

1. **localStorage JSON pattern dans `shortcuts.js`** : la classe `ShortcutManager` ré-implémentait à la main le couple try/`JSON.parse` + `setItem`/`JSON.stringify` + `removeItem`, alors qu'`app-theme.js` et `terminal-themes.js` passent déjà par le helper `persistedSetting`. J'ajoute un `persistedJsonSetting` (variante JSON, avec `remove`) à côté du helper existant et je l'utilise dans `ShortcutManager` — plus aucun accès direct à `localStorage` hors du helper côté thèmes/keybindings.

2. **Factory wrappers dans `tab-manager-tab-ops.js`** : les exports standalone `renderTabBar` / `createTab` / `closeTab` appelaient chacun `bindTabOps(tm)` en pleine réémission de tout l'objet de deps à chaque invocation. Memoization via une `WeakMap` (clé = instance `tm`) : le trio est désormais construit une seule fois par TabManager et partagé entre les trois wrappers. Les primitives volatiles (`activeTabId`, `tabs`, etc.) restaient déjà re-lues à chaque opération via `bindTabOps`, donc la sémantique est préservée.

Closes #438.

## Fichiers modifiés

- `src/utils/persisted-setting.js` — ajout de `persistedJsonSetting` + `remove()` sur les deux factories.
- `src/components/shortcuts.js` — utilise `persistedJsonSetting`, suppression des `localStorage.*` directs.
- `src/utils/tab-manager-tab-ops.js` — `WeakMap` de cache pour `bindTabOps(tm)`, wrappers délèguent au binding cached.

## Vérifications

- `node build.js` : OK (`Build complete.`)
- `npx vitest run` : 408 / 408 passing (26 fichiers)

📂 Path local : /Users/claude/flux/review/pikagent

🤖 PR créée automatiquement par l'Agent Refactor