### PR TITLE
refactor: dedupe sanitization and button bar patterns (closes #415)

### DIFF
--- a/shared/string-utils.js
+++ b/shared/string-utils.js
@@ -5,6 +5,22 @@
  */
 
 /**
+ * Generic sanitizer: replaces characters outside `allowedChars` with `replacement`,
+ * then optionally post-processes the result. Centralises the
+ * "replace forbidden chars, then transform" pattern shared by sanitizeName
+ * and sanitizeSegment.
+ *
+ * @param {string} name
+ * @param {{ allowedChars: string, replacement: string, plus?: boolean, postProcess?: (s: string) => string }} opts
+ * @returns {string}
+ */
+function _sanitize(name, { allowedChars, replacement, plus = false, postProcess }) {
+  const pattern = new RegExp(`[^${allowedChars}]${plus ? '+' : ''}`, 'g');
+  const replaced = name.replace(pattern, replacement);
+  return postProcess ? postProcess(replaced) : replaced;
+}
+
+/**
  * Sanitize a name by replacing non-alphanumeric characters (except dash,
  * underscore, and space) with underscores, then truncating to 64 characters.
  * Used for config names and similar identifiers.
@@ -12,7 +28,11 @@
  * @returns {string}
  */
 function sanitizeName(name) {
-  return name.replace(/[^a-zA-Z0-9_\- ]/g, '_').substring(0, 64);
+  return _sanitize(name, {
+    allowedChars: 'a-zA-Z0-9_\\- ',
+    replacement: '_',
+    postProcess: (s) => s.substring(0, 64),
+  });
 }
 
 /**
@@ -24,7 +44,12 @@ function sanitizeName(name) {
  * @returns {string}
  */
 function sanitizeSegment(name) {
-  return name.replace(/[^a-zA-Z0-9._-]+/g, '-').replace(/^-+|-+$/g, '');
+  return _sanitize(name, {
+    allowedChars: 'a-zA-Z0-9._-',
+    replacement: '-',
+    plus: true,
+    postProcess: (s) => s.replace(/^-+|-+$/g, ''),
+  });
 }
 
 module.exports = { sanitizeName, sanitizeSegment };

--- a/src/components/board-view.js
+++ b/src/components/board-view.js
@@ -1,6 +1,6 @@
 import {
   onTerminalCreated, onTerminalRemoved, onTerminalExited,
-  _el, renderButtonBar, renderList,
+  _el, renderPrefixedButtonBar, renderList,
   _safeFit, disposeTerminal, disposeTerminalMap, setupTerminalAddons,
   createPtyBoundTerminal,
 } from '../utils/terminal-subsystem.js';
@@ -132,13 +132,12 @@ export class BoardView extends ComponentBase {
       },
     };
 
-    const configs = HEADER_BUTTONS.map(({ text, title, action }) => ({
-      text,
-      title,
-      cls: 'board-card-btn',
-      action,
-    }));
-    const headerBtns = renderButtonBar({ containerClass: 'board-card-btns', configs, handlers: actionHandlers });
+    const headerBtns = renderPrefixedButtonBar({
+      baseClass: 'board-card-btn',
+      containerClass: 'board-card-btns',
+      actions: HEADER_BUTTONS,
+      handlers: actionHandlers,
+    });
 
     return _el('div', { className: 'board-card-header' }, nameGroup, headerBtns);
   }

--- a/src/utils/dom-facades.js
+++ b/src/utils/dom-facades.js
@@ -15,7 +15,7 @@ export { _el, renderList } from './dom.js';
 // ── settings domain ─────────────────────────────────────────────────
 // settings-modal, settings-appearance, settings-configs,
 // settings-keybindings, settings-update, settings-section-builder
-export { createActionButton, renderButtonBar } from './dom.js';
+export { createActionButton, renderButtonBar, renderPrefixedButtonBar } from './dom.js';
 
 // ── git domain ──────────────────────────────────────────────────────
 // worktree-flow, worktree-dialog, open-pr-flow

--- a/src/utils/dom.js
+++ b/src/utils/dom.js
@@ -112,6 +112,28 @@ export function renderButtonBar({ containerClass, configs, handlers }) {
 }
 
 /**
+ * Render a button bar where every action's `cls` is prefixed with `baseClass`.
+ * Centralises the "prefix CSS class on every button + call renderButtonBar"
+ * pattern previously duplicated across domain renderers.
+ *
+ * @param {{ baseClass: string, containerClass: string,
+ *           actions: Array<{ text: string, title?: string, action: string, cls?: string }>,
+ *           handlers: Record<string, (e: MouseEvent) => void>,
+ *           stopPropagation?: boolean }} opts
+ * @returns {HTMLElement}
+ */
+export function renderPrefixedButtonBar({ baseClass, containerClass, actions, handlers, stopPropagation = false }) {
+  const configs = actions.map(({ text, title, action, cls }) => ({
+    text,
+    title,
+    cls: cls ? `${baseClass} ${cls}` : baseClass,
+    action,
+    stopPropagation,
+  }));
+  return renderButtonBar({ containerClass, configs, handlers });
+}
+
+/**
  * Clear a container and populate it by calling `renderItem` for each item.
  * @param {HTMLElement} container
  * @param {Array<unknown>} items

--- a/src/utils/flow-dom.js
+++ b/src/utils/flow-dom.js
@@ -7,12 +7,15 @@
  */
 export { _el, createActionButton, renderButtonBar } from './dom.js';
 
-import { renderButtonBar as _renderButtonBar } from './dom.js';
+import { renderPrefixedButtonBar } from './dom.js';
 
 /**
- * Build a domain-specific button bar from a list of action definitions.
- * Each action's `cls` is prefixed with `baseClass` and `stopPropagation` is set
- * to true — the two repetitive steps previously duplicated across renderers.
+ * Build a flow-domain button bar from a list of action definitions.
+ * Each action's `cls` is prefixed with `baseClass` and `stopPropagation` is
+ * forced to `true` — flow cards/categories sit inside clickable containers
+ * so their buttons must stop event bubbling.
+ *
+ * Thin wrapper around the generic `renderPrefixedButtonBar` helper.
  *
  * @param {string} baseClass   - CSS class prefix for each button (e.g. "flow-card-btn")
  * @param {string} containerClass - CSS class for the bar container
@@ -21,12 +24,11 @@ import { renderButtonBar as _renderButtonBar } from './dom.js';
  * @returns {HTMLElement}
  */
 export function buildDomainButtonBar(baseClass, containerClass, actions, handlers) {
-  const configs = actions.map(({ text, title, action, cls }) => ({
-    text,
-    title,
-    cls: cls ? `${baseClass} ${cls}` : baseClass,
-    action,
+  return renderPrefixedButtonBar({
+    baseClass,
+    containerClass,
+    actions,
+    handlers,
     stopPropagation: true,
-  }));
-  return _renderButtonBar({ containerClass, configs, handlers });
+  });
 }

--- a/src/utils/terminal-subsystem.js
+++ b/src/utils/terminal-subsystem.js
@@ -41,7 +41,7 @@ export {
 } from './terminal-events.js';
 
 // ── dom-facades (board-view) ────────────────────────────────────────
-export { _el, renderButtonBar, renderList } from './dom-facades.js';
+export { _el, renderButtonBar, renderPrefixedButtonBar, renderList } from './dom-facades.js';
 
 // ── terminal-factory (board-view) ───────────────────────────────────
 export {


### PR DESCRIPTION
## Résumé

Centralise deux patterns dupliqués résiduels identifiés dans #415 :

1. **Sanitization** : nouveau helper interne `_sanitize` dans `shared/string-utils.js` qui factorise le pattern commun à `sanitizeName` et `sanitizeSegment` (regex replace + post-traitement). L'API publique des deux fonctions est inchangée.
2. **Button bar prefixé** : nouvelle fonction `renderPrefixedButtonBar` dans `src/utils/dom.js` qui factorise le pattern "préfixer la classe CSS de chaque action puis appeler `renderButtonBar`". `buildDomainButtonBar` (flow domain) devient un thin wrapper qui force `stopPropagation: true`, et `board-view.js` réutilise désormais ce helper au lieu de réimplémenter le mapping inline.

Closes #415

## Fichiers modifiés

- `shared/string-utils.js`
- `src/utils/dom.js`
- `src/utils/dom-facades.js`
- `src/utils/flow-dom.js`
- `src/utils/terminal-subsystem.js`
- `src/components/board-view.js`

## Build / Tests

- `node build.js` : OK
- `npx vitest run` : 408 tests passent (26 files)

## Test plan

- [ ] Vérifier les boutons flow cards et catégories (stopPropagation comportement inchangé).
- [ ] Vérifier les boutons du board-view (navigate, hide).
- [ ] Vérifier la création de configs (sanitizeName) et le worktree dialog (sanitizeSegment).

📂 Path local : /Users/claude/flux/review/pikagent

Agent : refactor (Claude Opus 4.7 1M)