### PR TITLE
refactor: remove dead export trackMouseDrag

### DIFF
--- a/src/utils/drag-helpers.js
+++ b/src/utils/drag-helpers.js
@@ -66,19 +66,6 @@ export function trackMouse(cursor, onMove, onDone, { bodyClass = 'resizing' } = 
 }
 
 /**
- * Named-params variant of trackMouse for callers that prefer destructuring.
- *
- * Adds mousemove and mouseup listeners on document, applies cursor and
- * userSelect on document.body, and cleans everything up automatically on
- * mouseup.
- *
- * @param {{ cursor?: string, onMove: (e: MouseEvent) => void, onUp?: () => void, bodyClass?: string }} opts
- */
-export function trackMouseDrag({ cursor = 'default', onMove, onUp = () => {}, bodyClass = 'resizing' } = {}) {
-  return trackMouse(cursor, onMove, onUp, { bodyClass });
-}
-
-/**
  * Add an event listener to a target and return a cleanup function that
  * removes it.  Calling the cleanup is idempotent.
  *


### PR DESCRIPTION
## Refactoring

Suppression de l'export `trackMouseDrag` et de sa documentation JSDoc dans `drag-helpers.js`. Cette fonction n'est importée nulle part dans le projet — tous les call sites utilisent directement `trackMouse()`.

Closes #457

## Fichier(s) modifié(s)

- `src/utils/drag-helpers.js` — suppression lignes 68-79 (JSDoc + fonction)

## Vérifications

- [x] Build OK
- [x] Tests OK (408/408)

---

📂 Path local : `/Users/rekta/projet/coding/refactor-pikagent`
🤖 PR créée automatiquement par l'Agent Refactor