### PR TITLE
refactor: add precise generics to JSDoc types in 8 files

### DIFF
--- a/main/flow-executor.js
+++ b/main/flow-executor.js
@@ -25,7 +25,7 @@ const { recordRun } = require('./flow-executor-run');
  * and notifies the renderer.
  *
  * @param {{ getPtyManager: Function, sendToWindow: Function }} deps
- * @param {Map} runningFlows
+ * @param {Map<string, {ptyId: string, proc: object, timeout: ReturnType<typeof setTimeout>}>} runningFlows
  * @param {string} flowId
  * @param {string} ptyId
  * @param {number} exitCode
@@ -43,7 +43,7 @@ function cleanupFlowProcess(deps, runningFlows, flowId, ptyId, exitCode) {
  * Wires up PTY data/exit listeners for a running flow process.
  *
  * @param {{ sendToWindow: Function, getPtyManager: Function, getFlow: Function, saveFlow: Function, log: object }} deps
- * @param {Map} runningFlows
+ * @param {Map<string, {ptyId: string, proc: object, timeout: ReturnType<typeof setTimeout>}>} runningFlows
  * @param {object} proc
  * @param {object} flow
  * @param {string} ptyId
@@ -71,7 +71,7 @@ function setupPtyListeners(deps, runningFlows, proc, flow, ptyId, runTimestamp) 
  * Executes a single flow inside a new PTY process.
  *
  * @param {{ getPtyManager: Function, sendToWindow: Function, log: object, getFlow: Function, saveFlow: Function }} deps
- * @param {Map} runningFlows
+ * @param {Map<string, {ptyId: string, proc: object, timeout: ReturnType<typeof setTimeout>}>} runningFlows
  * @param {object} flow
  */
 function execute(deps, runningFlows, flow) {
@@ -120,7 +120,7 @@ function execute(deps, runningFlows, flow) {
  * Kills all running flow processes and clears the map.
  *
  * @param {{ getPtyManager: Function }} deps
- * @param {Map} runningFlows
+ * @param {Map<string, {ptyId: string, proc: object, timeout: ReturnType<typeof setTimeout>}>} runningFlows
  */
 function stopAll(deps, runningFlows) {
   const ptyManager = deps.getPtyManager();
@@ -134,7 +134,7 @@ function stopAll(deps, runningFlows) {
 /**
  * Returns a plain object mapping flow IDs to their PTY IDs.
  *
- * @param {Map} runningFlows
+ * @param {Map<string, {ptyId: string, proc: object, timeout: ReturnType<typeof setTimeout>}>} runningFlows
  * @returns {Record<string, string>}
  */
 function getRunning(runningFlows) {

--- a/main/parse-utils.js
+++ b/main/parse-utils.js
@@ -2,7 +2,7 @@
  * Split raw text into lines, filter empty, optionally map.
  * @param {string} raw
  * @param {((line: string) => *)?} [mapFn]
- * @returns {Array}
+ * @returns {Array<string>}
  */
 function splitLines(raw, mapFn) {
   if (!raw) return [];

--- a/main/parse-utils.js
+++ b/main/parse-utils.js
@@ -1,8 +1,9 @@
 /**
  * Split raw text into lines, filter empty, optionally map.
  * @param {string} raw
- * @param {((line: string) => *)?} [mapFn]
- * @returns {Array<string>}
+ * @template [T=string]
+ * @param {((line: string) => T)?} [mapFn]
+ * @returns {Array<T>}
  */
 function splitLines(raw, mapFn) {
   if (!raw) return [];

--- a/src/components/flow-card-terminal.js
+++ b/src/components/flow-card-terminal.js
@@ -32,7 +32,7 @@ export class FlowCardTerminalManager {
   /**
    * Create a readonly terminal, register it in the given map, and run an
    * optional setup callback.  Returns the terminal record.
-   * @param {Map} map - target map (_liveTerminals or _logTerminals)
+   * @param {Map<string, {term: object, fitAddon: object, containerEl: HTMLElement}>} map - target map (_liveTerminals or _logTerminals)
    * @param {string} flowId
    * @param {HTMLElement} containerEl
    * @param {object} opts - extra terminal options (scrollback, cursorStyle, …)

--- a/src/utils/file-tree-watcher.js
+++ b/src/utils/file-tree-watcher.js
@@ -6,7 +6,7 @@ import { DEBOUNCE_DELAY, WATCH_PREFIX } from './file-tree-helpers.js';
 
 /**
  * Set up a debounced fs.onChanged listener.
- * @param {Map} debounceTimers - shared timer map
+ * @param {Map<string, ReturnType<typeof setTimeout>>} debounceTimers - shared timer map
  * @param {(watchIdOrCwd: string) => Promise<void>} refreshSection - callback to refresh
  * @param {{ onChanged: (cb: (event: { id: string }) => void) => (() => void) }} fsApi - injected fs API
  * @returns {() => void} unsubscribe function

--- a/src/utils/file-viewer-files.js
+++ b/src/utils/file-viewer-files.js
@@ -9,7 +9,7 @@ import { pinnedFiles } from './editor-helpers.js';
  * Open a file and add it to the open-files map.
  * If already open, returns false (caller should just activate the tab).
  *
- * @param {Map} openFiles
+ * @param {Map<string, {name: string, content: string, savedContent: string, lang: string, error: string|null, viewMode: string}>} openFiles
  * @param {string} filePath
  * @param {string} fileName
  * @param {{ readfile: (path: string) => Promise<{ content?: string, error?: string }> }} fsApi - injected fs API

--- a/src/utils/flow-view-rendering.js
+++ b/src/utils/flow-view-rendering.js
@@ -122,7 +122,7 @@ export function renderFlowList(ctx) {
 /**
  * Handle the "open modal" flow: prompt user, persist, and refresh.
  * @param {{ existing: object|null, catData: object, moveFlowToCategory: Function, persistCategories: Function, refresh: Function }} ctx
- * @param {Function} getOpenFlowModal - returns the openFlowModal component
+ * @param {() => (existing: object|null, categories: Array<object>) => Promise<object|null>} getOpenFlowModal - returns the openFlowModal component
  * @param {object} flowApi - the flow API service
  */
 export async function handleOpenModal(ctx, getOpenFlowModal, flowApi) {

--- a/src/utils/tab-manager-tab-ops.js
+++ b/src/utils/tab-manager-tab-ops.js
@@ -76,7 +76,7 @@ export function bindTabOps(tm) {
 /**
  * Build the deps and call doRenderTabBar.
  * @param {object} tm - TabManager instance
- * @returns {Map} tab element map
+ * @returns {Map<string, HTMLElement>} tab element map
  */
 export function renderTabBar(tm) {
   return bindTabOps(tm).renderTabBar();

--- a/src/utils/usage-view-helpers.js
+++ b/src/utils/usage-view-helpers.js
@@ -83,9 +83,9 @@ export function createSection(title) {
  *
  * @param {object}   m               The metrics slice (metrics.agent or metrics.flow).
  * @param {object}   options
- * @param {Array}    options.cards    Four card descriptors (label/value/cls/sub).
+ * @param {Array<{label: string, value: string|number, cls: string, sub?: string}>} options.cards Four card descriptors (label/value/cls/sub).
  * @param {string}   options.chartTitle  Title displayed above the chart.
- * @param {Array}    options.tables   One or more table descriptors.
+ * @param {Array<{title: string, headers: string[], tableCls: string, data: Array<object>, renderRow: (item: object) => HTMLTableRowElement}>} options.tables One or more table descriptors.
  * @returns {{ cards: Array, chart: object, tables: Array }}
  */
 function _createRunBasedTabConfig(m, { cards, chartTitle, tables }) {


### PR DESCRIPTION
## Refactoring

Remplacement de 13 annotations JSDoc imprécises ({Map}, {Array}, {Function} sans generics) par des types précis basés sur l'usage réel dans le code.

Closes #456

## Fichier(s) modifié(s)

- `main/flow-executor.js` — 5x `{Map}` → `{Map<string, {ptyId, proc, timeout}>}`
- `main/parse-utils.js` — `{Array}` → `{Array<string>}`
- `src/components/flow-card-terminal.js` — `{Map}` → `{Map<string, {term, fitAddon, containerEl}>}`
- `src/utils/file-tree-watcher.js` — `{Map}` → `{Map<string, ReturnType<typeof setTimeout>>}`
- `src/utils/file-viewer-files.js` — `{Map}` → `{Map<string, {name, content, savedContent, lang, error, viewMode}>}`
- `src/utils/flow-view-rendering.js` — `{Function}` → signature callback précise
- `src/utils/tab-manager-tab-ops.js` — `{Map}` → `{Map<string, HTMLElement>}`
- `src/utils/usage-view-helpers.js` — 2x `{Array}` → types de cards et tables

## Vérifications

- [x] Build OK
- [x] Tests OK (408/408)

---

📂 Path local : `/Users/rekta/projet/coding/refactor-pikagent`
🤖 PR créée automatiquement par l'Agent Refactor