### PR TITLE
refactor: extract _runMetricCards to deduplicate agent/flow tab configs

### DIFF
--- a/src/utils/usage-view-helpers.js
+++ b/src/utils/usage-view-helpers.js
@@ -88,6 +88,17 @@ export function createSection(title) {
  * @param {Array}    options.tables   One or more table descriptors.
  * @returns {{ cards: Array, chart: object, tables: Array }}
  */
+/**
+ * Build the two run-metric cards shared by agents and flows tabs:
+ * success rate + average duration (with min/max sub-text).
+ */
+function _runMetricCards(m) {
+  return [
+    { label: 'Taux succès', value: `${m.rate.rate}%`, cls: rateCls(m.rate.rate) },
+    { label: 'Durée moy.', value: formatDuration(m.duration.avg), cls: 'usage-stat-value-blue', sub: m.duration.count > 0 ? `min: ${formatDuration(m.duration.min)} · max: ${formatDuration(m.duration.max)}` : '' },
+  ];
+}
+
 function _createRunBasedTabConfig(m, { cards, chartTitle, tables }) {
   return {
     cards,
@@ -108,8 +119,7 @@ function _agentTabConfig(metrics) {
     cards: [
       { label: 'Sessions', value: m.totalSessions, cls: '' },
       { label: 'En cours', value: m.activeSessions, cls: m.activeSessions > 0 ? 'usage-stat-value-green' : '' },
-      { label: 'Taux succès', value: `${m.rate.rate}%`, cls: rateCls(m.rate.rate) },
-      { label: 'Durée moy.', value: formatDuration(m.duration.avg), cls: 'usage-stat-value-blue', sub: m.duration.count > 0 ? `min: ${formatDuration(m.duration.min)} · max: ${formatDuration(m.duration.max)}` : '' },
+      ..._runMetricCards(m),
     ],
     chartTitle: 'Sessions par jour',
     tables: [
@@ -185,8 +195,7 @@ function _flowTabConfig(metrics) {
     cards: [
       { label: 'Total Runs', value: f.rate.total, cls: '' },
       { label: 'Flows actifs', value: `${f.activeFlows}/${f.totalFlows}`, cls: '' },
-      { label: 'Taux succès', value: `${f.rate.rate}%`, cls: rateCls(f.rate.rate) },
-      { label: 'Durée moy.', value: formatDuration(f.duration.avg), cls: 'usage-stat-value-blue', sub: f.duration.count > 0 ? `min: ${formatDuration(f.duration.min)} · max: ${formatDuration(f.duration.max)}` : '' },
+      ..._runMetricCards(f),
     ],
     chartTitle: 'Runs par jour',
     tables: [


### PR DESCRIPTION
## Refactoring

Extraction de `_runMetricCards()` qui construit les 2 cards identiques entre `_agentTabConfig` et `_flowTabConfig` (Taux succès + Durée moy. avec min/max). Les deux fonctions utilisent maintenant `..._runMetricCards(m)` au lieu de dupliquer la logique.

Note : `_createRunBasedTabConfig` existait déjà pour la structure commune. Cette PR complète la dédup sur les cards.

Closes #425

## Fichier(s) modifié(s)

- `src/utils/usage-view-helpers.js` — nouvelle fonction `_runMetricCards()`, simplification des cards arrays

## Vérifications

- [x] Build OK
- [x] Tests OK (408/408)

---

📂 Path local : `/Users/rekta/projet/coding/refactor-pikagent`
🤖 PR créée automatiquement par l'Agent Refactor