### PR TITLE
refactor: deduplicate button bar and sanitization patterns

### DIFF
--- a/main/config-helpers.js
+++ b/main/config-helpers.js
@@ -4,7 +4,6 @@
  */
 
 const { buildTimestampedRecord } = require('./record-helpers');
-const { sanitizeName } = require('../shared/string-utils');
 
 const DEFAULT_META = { defaultConfig: null };
 
@@ -23,4 +22,4 @@ function formatConfigList(configs, defaultConfigName) {
     }));
 }
 
-module.exports = { DEFAULT_META, sanitizeName, buildConfigRecord, formatConfigList };
+module.exports = { DEFAULT_META, buildConfigRecord, formatConfigList };

--- a/main/config-manager.js
+++ b/main/config-manager.js
@@ -1,6 +1,7 @@
 const { CONFIG_DIR, META_FILE } = require('./paths');
 const { readJson, writeJson } = require('./fs-utils');
-const { DEFAULT_META, sanitizeName, buildConfigRecord, formatConfigList } = require('./config-helpers');
+const { DEFAULT_META, buildConfigRecord, formatConfigList } = require('./config-helpers');
+const { sanitizeName } = require('../shared/string-utils');
 const { Cache, cachedAsync } = require('./cache');
 const { trySafe } = require('./logger');
 const { JsonStore } = require('./json-store');

--- a/src/components/board-view.js
+++ b/src/components/board-view.js
@@ -1,6 +1,6 @@
 import {
   onTerminalCreated, onTerminalRemoved, onTerminalExited,
-  _el, renderButtonBar, renderList,
+  _el, buildDomainButtonBar, renderList,
   _safeFit, disposeTerminal, disposeTerminalMap, setupTerminalAddons,
   createPtyBoundTerminal,
 } from '../utils/terminal-subsystem.js';
@@ -132,13 +132,7 @@ export class BoardView extends ComponentBase {
       },
     };
 
-    const configs = HEADER_BUTTONS.map(({ text, title, action }) => ({
-      text,
-      title,
-      cls: 'board-card-btn',
-      action,
-    }));
-    const headerBtns = renderButtonBar({ containerClass: 'board-card-btns', configs, handlers: actionHandlers });
+    const headerBtns = buildDomainButtonBar('board-card-btn', 'board-card-btns', HEADER_BUTTONS, actionHandlers);
 
     return _el('div', { className: 'board-card-header' }, nameGroup, headerBtns);
   }

--- a/src/utils/dom-facades.js
+++ b/src/utils/dom-facades.js
@@ -15,7 +15,7 @@ export { _el, renderList } from './dom.js';
 // ── settings domain ─────────────────────────────────────────────────
 // settings-modal, settings-appearance, settings-configs,
 // settings-keybindings, settings-update, settings-section-builder
-export { createActionButton, renderButtonBar } from './dom.js';
+export { createActionButton, renderButtonBar, buildDomainButtonBar } from './dom.js';
 
 // ── git domain ──────────────────────────────────────────────────────
 // worktree-flow, worktree-dialog, open-pr-flow

--- a/src/utils/dom.js
+++ b/src/utils/dom.js
@@ -112,6 +112,28 @@ export function renderButtonBar({ containerClass, configs, handlers }) {
 }
 
 /**
+ * Build a domain-specific button bar from a list of action definitions.
+ * Each action's `cls` is prefixed with `baseClass` and `stopPropagation` is set
+ * to true — the two repetitive steps previously duplicated across renderers.
+ *
+ * @param {string} baseClass   - CSS class prefix for each button (e.g. "flow-card-btn")
+ * @param {string} containerClass - CSS class for the bar container
+ * @param {Array<{text: string, title: string, action: string, cls?: string}>} actions
+ * @param {Record<string, () => void>} handlers
+ * @returns {HTMLElement}
+ */
+export function buildDomainButtonBar(baseClass, containerClass, actions, handlers) {
+  const configs = actions.map(({ text, title, action, cls }) => ({
+    text,
+    title,
+    cls: cls ? `${baseClass} ${cls}` : baseClass,
+    action,
+    stopPropagation: true,
+  }));
+  return renderButtonBar({ containerClass, configs, handlers });
+}
+
+/**
  * Clear a container and populate it by calling `renderItem` for each item.
  * @param {HTMLElement} container
  * @param {Array<unknown>} items

--- a/src/utils/flow-dom.js
+++ b/src/utils/flow-dom.js
@@ -5,28 +5,4 @@
  * flow-category-renderer) import DOM primitives through this facade instead
  * of reaching into the core dom.js hub directly.
  */
-export { _el, createActionButton, renderButtonBar } from './dom.js';
-
-import { renderButtonBar as _renderButtonBar } from './dom.js';
-
-/**
- * Build a domain-specific button bar from a list of action definitions.
- * Each action's `cls` is prefixed with `baseClass` and `stopPropagation` is set
- * to true — the two repetitive steps previously duplicated across renderers.
- *
- * @param {string} baseClass   - CSS class prefix for each button (e.g. "flow-card-btn")
- * @param {string} containerClass - CSS class for the bar container
- * @param {Array<{text: string, title: string, action: string, cls?: string}>} actions
- * @param {Record<string, () => void>} handlers
- * @returns {HTMLElement}
- */
-export function buildDomainButtonBar(baseClass, containerClass, actions, handlers) {
-  const configs = actions.map(({ text, title, action, cls }) => ({
-    text,
-    title,
-    cls: cls ? `${baseClass} ${cls}` : baseClass,
-    action,
-    stopPropagation: true,
-  }));
-  return _renderButtonBar({ containerClass, configs, handlers });
-}
+export { _el, createActionButton, renderButtonBar, buildDomainButtonBar } from './dom.js';

--- a/src/utils/terminal-subsystem.js
+++ b/src/utils/terminal-subsystem.js
@@ -41,7 +41,7 @@ export {
 } from './terminal-events.js';
 
 // ── dom-facades (board-view) ────────────────────────────────────────
-export { _el, renderButtonBar, renderList } from './dom-facades.js';
+export { _el, renderButtonBar, buildDomainButtonBar, renderList } from './dom-facades.js';
 
 // ── terminal-factory (board-view) ───────────────────────────────────
 export {

--- a/tests/main/config-helpers.test.js
+++ b/tests/main/config-helpers.test.js
@@ -1,8 +1,9 @@
 import { describe, it, expect } from 'vitest';
-const { DEFAULT_META, sanitizeName, buildConfigRecord, formatConfigList } = require('../../main/config-helpers');
+const { DEFAULT_META, buildConfigRecord, formatConfigList } = require('../../main/config-helpers');
+const { sanitizeName } = require('../../shared/string-utils');
 
 describe('config-helpers', () => {
-  describe('sanitizeName', () => {
+  describe('sanitizeName (shared/string-utils)', () => {
     it('keeps alphanumeric, dash, underscore and space', () => {
       expect(sanitizeName('my-config_1 test')).toBe('my-config_1 test');
     });


### PR DESCRIPTION
## Summary

- **Button bar deduplication**: Moved `buildDomainButtonBar` from `flow-dom.js` into `dom.js` (the canonical DOM utility module) and re-exported it through `flow-dom.js`, `dom-facades.js`, and `terminal-subsystem.js`. Replaced the manual `.map()` + `renderButtonBar` pattern in `board-view.js` with a single `buildDomainButtonBar` call.
- **Sanitization deduplication**: Removed the `sanitizeName` re-export from `config-helpers.js`. `config-manager.js` now imports `sanitizeName` directly from `shared/string-utils.js` — the single source of truth for all sanitization helpers (`sanitizeName`, `sanitizeSegment`). Updated tests accordingly.

Closes #415

## Test plan

- [x] `npm run build` passes
- [x] All 408 tests pass (26 test files)
- [x] Verified `buildDomainButtonBar` is correctly re-exported through all facade chains
- [x] Verified `sanitizeName` is no longer re-exported through `config-helpers.js`