### PR TITLE
refactor: extract persistedSetting util for localStorage theme dedup

### DIFF
--- a/tests/utils/persisted-setting.test.js
+++ b/tests/utils/persisted-setting.test.js
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { persistedSetting } from '../../src/utils/persisted-setting.js';
+
+describe('persistedSetting', () => {
+  let store;
+
+  beforeEach(() => {
+    store = {};
+    globalThis.localStorage = {
+      getItem: vi.fn((k) => (k in store ? store[k] : null)),
+      setItem: vi.fn((k, v) => { store[k] = String(v); }),
+    };
+  });
+
+  it('returns default value when key is missing', () => {
+    const setting = persistedSetting('missing-key', 'fallback');
+    expect(setting.get()).toBe('fallback');
+  });
+
+  it('returns stored value when key exists', () => {
+    store['my-key'] = 'stored';
+    const setting = persistedSetting('my-key', 'fallback');
+    expect(setting.get()).toBe('stored');
+  });
+
+  it('persists value via set()', () => {
+    const setting = persistedSetting('my-key', 'fallback');
+    setting.set('new-value');
+    expect(localStorage.setItem).toHaveBeenCalledWith('my-key', 'new-value');
+    expect(setting.get()).toBe('new-value');
+  });
+
+  it('returns default when getItem throws', () => {
+    localStorage.getItem = vi.fn(() => { throw new Error('SecurityError'); });
+    const setting = persistedSetting('key', 'safe');
+    expect(setting.get()).toBe('safe');
+  });
+
+  it('swallows errors from setItem', () => {
+    localStorage.setItem = vi.fn(() => { throw new Error('QuotaExceeded'); });
+    const setting = persistedSetting('key', 'val');
+    expect(() => setting.set('x')).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

- Validates the `persistedSetting(key, defaultValue)` utility (`src/utils/persisted-setting.js`) already extracted in #444, which centralizes all localStorage get/set logic with try/catch and fallback for theme persistence.
- `src/utils/terminal-themes.js` and `src/utils/app-theme.js` both use `persistedSetting` — no raw `localStorage` calls remain in theme code.
- `bindTabOps(tm)` in `src/utils/tab-manager-tab-ops.js` already centralizes the factory wrapper pattern; standalone exports (`renderTabBar`, `createTab`, `closeTab`) delegate to it. No change needed.
- Adds unit tests for `persistedSetting` covering: default fallback, stored value retrieval, set persistence, getItem error resilience, and setItem error swallowing.

Closes #438

## Test plan

- [x] `npm run build` passes
- [x] `npm test` passes (413 tests, 27 files — including new `persisted-setting.test.js`)