### PR TITLE
refactor: consolidate facade re-export modules

### DIFF
--- a/main/managers.js
+++ b/main/managers.js
@@ -9,6 +9,8 @@
  *   Data      — sessionManager, usageManager
  *   Workflow  — flowManager, skillsManager
  *   Infra     — gitManager, configManager, updateManager
+ *
+ * @see https://github.com/agentdouble/pikagent/issues/462
  */
 
 // ── IO managers ─────────────────────────────────────────────────────

--- a/src/utils/dom-facades.js
+++ b/src/utils/dom-facades.js
@@ -6,18 +6,18 @@
  *
  * Every consumer imports the exact symbols it needs from this single module;
  * tree-shaking ensures only the used helpers are bundled.
+ *
+ * Consumers:
+ *   workspace  — workspace-layout, workspace-resize, sidebar-manager, usage-view
+ *   settings   — settings-modal, settings-appearance, settings-configs,
+ *                settings-keybindings, settings-update, settings-section-builder
+ *   git        — worktree-flow, worktree-dialog, open-pr-flow
+ *   file       — file-editor-renderer, file-viewer-tabs, file-viewer-mode-bar,
+ *                file-tree-drop, file-tree-renderer, file-tree-section-dom
+ *   tab        — tab-bar-renderer, tab-renderer, tab-lifecycle, tab-color-filter
+ *   terminal   — terminal-panel-helpers, terminal-node-builder, terminal-drop-indicator
+ *
+ * @see https://github.com/agentdouble/pikagent/issues/462
  */
 
-// ── workspace domain ────────────────────────────────────────────────
-// workspace-layout, workspace-resize, sidebar-manager, usage-view, …
-export { _el, renderList } from './dom.js';
-
-// ── settings domain ─────────────────────────────────────────────────
-// settings-modal, settings-appearance, settings-configs,
-// settings-keybindings, settings-update, settings-section-builder
-export { createActionButton, renderButtonBar, buildDomainButtonBar } from './dom.js';
-
-// ── git domain ──────────────────────────────────────────────────────
-// worktree-flow, worktree-dialog, open-pr-flow
-export { _vis } from './dom.js';
-// (also uses _el, createActionButton — already exported above)
+export { _el, _vis, createActionButton, renderButtonBar, buildDomainButtonBar, renderList } from './dom.js';

--- a/src/utils/file-tree-subsystem.js
+++ b/src/utils/file-tree-subsystem.js
@@ -1,6 +1,15 @@
 /**
- * Facade module that re-exports all file-tree-specific utilities.
- * Reduces coupling by providing a single import point for file-tree subsystem.
+ * File Tree Subsystem Facade — single entry-point for file-tree utilities.
+ *
+ * Reduces coupling by providing a single import point for file-tree-context-menu,
+ * file-tree-drop, file-tree-helpers, file-tree-renderer, and file-tree-watcher.
+ *
+ * Kept as-is per issue #462 — 3 active consumers (file-tree.js,
+ * file-tree-dir-ops.js, file-tree-section-dom.js) rely on this facade
+ * as their single import point for 5 source modules.
+ *
+ * @module file-tree-subsystem
+ * @see https://github.com/agentdouble/pikagent/issues/462
  */
 
 export {

--- a/src/utils/file-viewer-subsystem.js
+++ b/src/utils/file-viewer-subsystem.js
@@ -1,9 +1,16 @@
 /**
- * Facade that re-exports rendering-related helpers consumed by FileViewer.
- * Reduces coupling by letting file-viewer.js import from a single module
- * instead of five separate ones.
+ * File Viewer Subsystem Facade — single entry-point for file-viewer.js
+ * to access editor rendering, markdown preview, tabs, mode bar, and listeners.
  *
- * @see https://github.com/user/repo/issues/322
+ * Reduces coupling by letting file-viewer.js import from a single module
+ * instead of five separate ones (file-editor-renderer, markdown-preview-renderer,
+ * file-viewer-tabs, file-viewer-mode-bar, file-viewer-listeners).
+ *
+ * Kept as-is per issue #462 — 2 active consumers (file-viewer.js,
+ * file-viewer-editor.js) rely on this facade as their single import point.
+ *
+ * @module file-viewer-subsystem
+ * @see https://github.com/agentdouble/pikagent/issues/462
  */
 
 export {

--- a/src/utils/flow-view-subsystem.js
+++ b/src/utils/flow-view-subsystem.js
@@ -3,11 +3,16 @@
  * to access helpers, category rendering, and card setup.
  *
  * Reduces the import surface of flow-view.js by consolidating
- * flow-view-helpers, flow-category-renderer, and flow-card-setup.
+ * flow-view-helpers, flow-category-renderer, flow-card-setup,
+ * flow-dom, and form-helpers.
  *
  * Created for issue #384 to reduce coupling in flow-view.js.
+ * Kept as-is per issue #462 — 3 active consumers (flow-view.js,
+ * flow-view-rendering.js, flow-view-categories.js) rely on this facade
+ * as their single import point for 5 source modules.
  *
  * @module flow-view-subsystem
+ * @see https://github.com/agentdouble/pikagent/issues/462
  */
 
 // ── flow-view-helpers ───────────────────────────────────────────────

--- a/src/utils/terminal-subsystem.js
+++ b/src/utils/terminal-subsystem.js
@@ -1,16 +1,20 @@
 /**
- * Terminal subsystem facade — single entry-point for terminal-panel
+ * Terminal Subsystem Facade — single entry-point for terminal-panel
  * and board-view components to access terminal infrastructure.
  *
  * Covers the split-layout, serialization, node-building, drag-drop
  * indicator, terminal-split, terminal-events, dom-facades, and
- * terminal-factory APIs.
+ * terminal-factory APIs (8 source modules).
  *
  * Reduces the import surface of terminal-panel.js and board-view.js.
  *
  * Extended for issue #384 to reduce coupling in board-view.js.
+ * Kept as-is per issue #462 — 2 active consumers (board-view.js,
+ * terminal-panel.js) rely on this facade as their single import point
+ * for 8 source modules.
  *
  * @module terminal-subsystem
+ * @see https://github.com/agentdouble/pikagent/issues/462
  */
 
 // ── terminal-panel-helpers ──────────────────────────────────────────


### PR DESCRIPTION
## Summary

Addresses the 14 facade re-export modules identified in #462:

- **DOM facades (6 files)**: Already consolidated into `dom-facades.js` (old files removed). This PR cleans up the remaining 3 duplicate `from './dom.js'` re-export lines into a single clean export statement and adds a comprehensive consumer inventory in the JSDoc header.
- **Manager barrels (4 files)**: Already consolidated into `managers.js` (old files removed). Added issue reference.
- **Subsystem facades (4 files)**: Kept as-is — each has 2-3 active consumers importing from 5-8 source modules through the facade. Removing them would increase import fan-out in the consumers. Updated JSDoc to document the rationale and reference #462.

## Files changed

| File | Change |
|------|--------|
| `src/utils/dom-facades.js` | Merged 3 separate `from './dom.js'` lines into 1; added consumer inventory |
| `main/managers.js` | Added issue reference |
| `src/utils/flow-view-subsystem.js` | Documented 3 consumers, 5 source modules, issue ref |
| `src/utils/file-viewer-subsystem.js` | Documented 2 consumers, 5 source modules, issue ref |
| `src/utils/file-tree-subsystem.js` | Documented 3 consumers, 5 source modules, issue ref |
| `src/utils/terminal-subsystem.js` | Documented 2 consumers, 8 source modules, issue ref |

## Why subsystem facades are kept

Each subsystem facade has real consumers that would need 5-8 separate imports if the facade were removed. The facades serve their intended purpose of reducing coupling and import surface area in component files.

## Test plan

- [x] `npm run build` passes
- [x] `npm test` passes (26 files, 408 tests)

Closes #462

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>