### PR TITLE
refactor: split long utility functions into named sub-functions

### DIFF
--- a/src/utils/diff-parser.js
+++ b/src/utils/diff-parser.js
@@ -95,6 +95,33 @@ function _pairChanges(removes, adds, oldLine, newLine) {
   return { rows, oldLine, newLine };
 }
 
+/** Build the hunk header row for side-by-side display. */
+function _hunkHeaderRow(hunk) {
+  return {
+    type: 'hunk',
+    left: { content: `@@ -${hunk.oldStart},${hunk.oldCount}${hunk.context}`, type: 'hunk' },
+    right: { content: `+${hunk.newStart},${hunk.newCount} @@${hunk.context}`, type: 'hunk' },
+  };
+}
+
+/** Build a context row (unchanged line appearing on both sides). */
+function _contextRow(content, oldLine, newLine) {
+  return {
+    type: 'context',
+    left: { lineNo: oldLine, content, type: 'context' },
+    right: { lineNo: newLine, content, type: 'context' },
+  };
+}
+
+/** Build a standalone addition row (no paired removal). */
+function _addOnlyRow(content, newLine) {
+  return {
+    type: 'change',
+    left: { content: '', type: 'empty' },
+    right: { lineNo: newLine, content, type: 'add' },
+  };
+}
+
 /**
  * Build side-by-side rows from parsed hunks.
  * Each row: { left: { lineNo, content, type }, right: { lineNo, content, type } }
@@ -103,11 +130,7 @@ export function buildSideBySideRows(hunks) {
   const rows = [];
 
   for (const hunk of hunks) {
-    rows.push({
-      type: 'hunk',
-      left: { content: `@@ -${hunk.oldStart},${hunk.oldCount}${hunk.context}`, type: 'hunk' },
-      right: { content: `+${hunk.newStart},${hunk.newCount} @@${hunk.context}`, type: 'hunk' },
-    });
+    rows.push(_hunkHeaderRow(hunk));
 
     let oldLine = hunk.oldStart;
     let newLine = hunk.newStart;
@@ -118,11 +141,7 @@ export function buildSideBySideRows(hunks) {
       const change = changes[i];
 
       if (change.type === 'context') {
-        rows.push({
-          type: 'context',
-          left: { lineNo: oldLine++, content: change.content, type: 'context' },
-          right: { lineNo: newLine++, content: change.content, type: 'context' },
-        });
+        rows.push(_contextRow(change.content, oldLine++, newLine++));
         i++;
       } else if (change.type === 'remove') {
         const { items: removes, end: afterRem } = _collectRun(changes, i, 'remove');
@@ -133,11 +152,7 @@ export function buildSideBySideRows(hunks) {
         oldLine = paired.oldLine;
         newLine = paired.newLine;
       } else if (change.type === 'add') {
-        rows.push({
-          type: 'change',
-          left: { content: '', type: 'empty' },
-          right: { lineNo: newLine++, content: change.content, type: 'add' },
-        });
+        rows.push(_addOnlyRow(change.content, newLine++));
         i++;
       }
     }

--- a/src/utils/open-pr-flow.js
+++ b/src/utils/open-pr-flow.js
@@ -67,6 +67,40 @@ function buildPrUrl({ host, owner, repo }, branch, baseBranch) {
  */
 
 /**
+ * Handle the result of a failed `gh pr create` call.
+ * Returns true when the failure was surfaced to the user (caller should stop);
+ * false when the caller should fall back to the browser flow.
+ */
+async function _handleGhFailure(result) {
+  if (result?.code === 'gh-not-installed') return false;
+  const retryBrowser = await showConfirmDialog(
+    _el('div', null,
+      _el('p', null, 'gh pr create failed:'),
+      _el('pre', { style: { fontSize: '11px', color: 'var(--text-muted)', whiteSpace: 'pre-wrap' } },
+        result?.error || 'unknown error'),
+      _el('p', null, 'Open in browser instead?'),
+    ),
+    { confirmLabel: 'Open in browser', cancelLabel: 'Close' },
+  );
+  return !retryBrowser;
+}
+
+/**
+ * Handle the result of a successful `gh pr create` call.
+ * Shows a dialog and optionally opens the PR URL in the browser.
+ */
+async function _handleGhSuccess(result, api) {
+  const open = await showConfirmDialog(
+    _el('div', null,
+      _el('p', null, result.existed ? 'PR already open: ' : 'PR created: ',
+        _el('code', null, result.url || '')),
+    ),
+    { confirmLabel: 'Open in browser', cancelLabel: 'Close' },
+  );
+  if (open && result.url) await api.openExternal(result.url);
+}
+
+/**
  * Try to create a PR via the `gh` CLI. Returns true when handled (success
  * or a clean failure already surfaced to the user); returns false when the
  * caller should fall back to the browser-based flow.
@@ -88,73 +122,51 @@ async function _tryGhFlow(cwd, branch, baseBranch, api) {
 
   const result = await api.ghPrCreate({ cwd, baseBranch });
 
-  if (!result?.ok) {
-    if (result?.code === 'gh-not-installed') return false;
-    const retryBrowser = await showConfirmDialog(
-      _el('div', null,
-        _el('p', null, 'gh pr create failed:'),
-        _el('pre', { style: { fontSize: '11px', color: 'var(--text-muted)', whiteSpace: 'pre-wrap' } },
-          result?.error || 'unknown error'),
-        _el('p', null, 'Open in browser instead?'),
-      ),
-      { confirmLabel: 'Open in browser', cancelLabel: 'Close' },
-    );
-    return !retryBrowser;
-  }
+  if (!result?.ok) return _handleGhFailure(result);
 
-  const open = await showConfirmDialog(
-    _el('div', null,
-      _el('p', null, result.existed ? 'PR already open: ' : 'PR created: ',
-        _el('code', null, result.url || '')),
-    ),
-    { confirmLabel: 'Open in browser', cancelLabel: 'Close' },
-  );
-  if (open && result.url) await api.openExternal(result.url);
+  await _handleGhSuccess(result, api);
   return true;
 }
 
 /**
- * Drive the open-PR flow end-to-end for a given repo cwd.
- *
- * For GitHub repos, attempts `gh pr create` first (no secret management
- * required — uses the user's existing gh auth). Falls back to push + open
- * the compare URL in the browser when gh is unavailable or the host is not
- * GitHub.
- *
- * @param {{ cwd: string, baseBranch?: string|null, api: OpenPrApi }} opts
+ * Validate branch and remote, returning the parsed remote info or null
+ * (after showing the appropriate error dialog).
+ * @param {string} cwd
+ * @param {OpenPrApi} api
+ * @returns {Promise<{ branch: string, parsed: { host: string, owner: string, repo: string } } | null>}
  */
-export async function openPrFlow({ cwd, baseBranch = null, api }) {
+async function _validateBranchAndRemote(cwd, api) {
   const [branch, remote] = await Promise.all([api.branch(cwd), api.remoteUrl(cwd)]);
 
   if (!branch) {
     await showErrorAlert('No git branch detected in ', cwd);
-    return;
+    return null;
   }
   if (!remote) {
     await showConfirmDialog(
       _el('p', null, 'No ', _el('code', null, 'origin'), ' remote configured.'),
       { confirmLabel: 'OK', cancelLabel: 'Close' },
     );
-    return;
+    return null;
   }
 
   const parsed = parseRemoteUrl(remote);
   if (!parsed) {
     await showErrorAlert('Could not parse remote URL: ', remote);
-    return;
+    return null;
   }
 
-  if (parsed.host.endsWith('github.com')) {
-    const handled = await _tryGhFlow(cwd, branch, baseBranch, api);
-    if (handled) return;
-  }
+  return { branch, parsed };
+}
 
-  const url = buildPrUrl(parsed, branch, baseBranch);
-  if (!url) {
-    await showErrorAlert('Unsupported git provider: ', parsed.host);
-    return;
-  }
-
+/**
+ * Prompt the user to push and open a browser-based PR flow.
+ * @param {string} cwd
+ * @param {string} branch
+ * @param {string} url - the compare/PR URL to open
+ * @param {OpenPrApi} api
+ */
+async function _browserPrFlow(cwd, branch, url, api) {
   const ok = await showConfirmDialog(
     _el('div', null,
       _el('p', null, 'Push ', _el('code', null, branch), ' to ', _el('code', null, 'origin'), ' and open a PR?'),
@@ -168,6 +180,35 @@ export async function openPrFlow({ cwd, baseBranch = null, api }) {
   if (!push) return;
 
   await api.openExternal(url);
+}
+
+/**
+ * Drive the open-PR flow end-to-end for a given repo cwd.
+ *
+ * For GitHub repos, attempts `gh pr create` first (no secret management
+ * required — uses the user's existing gh auth). Falls back to push + open
+ * the compare URL in the browser when gh is unavailable or the host is not
+ * GitHub.
+ *
+ * @param {{ cwd: string, baseBranch?: string|null, api: OpenPrApi }} opts
+ */
+export async function openPrFlow({ cwd, baseBranch = null, api }) {
+  const result = await _validateBranchAndRemote(cwd, api);
+  if (!result) return;
+  const { branch, parsed } = result;
+
+  if (parsed.host.endsWith('github.com')) {
+    const handled = await _tryGhFlow(cwd, branch, baseBranch, api);
+    if (handled) return;
+  }
+
+  const url = buildPrUrl(parsed, branch, baseBranch);
+  if (!url) {
+    await showErrorAlert('Unsupported git provider: ', parsed.host);
+    return;
+  }
+
+  await _browserPrFlow(cwd, branch, url, api);
 }
 
 /** @internal Exposed for unit tests only. */

--- a/src/utils/tab-lifecycle.js
+++ b/src/utils/tab-lifecycle.js
@@ -175,6 +175,45 @@ export function findTabForTerminal(tabs, termId) {
 }
 
 /**
+ * Auto-rename a tab to the folder name when the first terminal's cwd changes
+ * and the user has not explicitly named the tab.
+ * @param {WorkspaceTab} tab
+ * @param {string} termId
+ * @param {string} cwd
+ * @param {(() => void)|undefined} renderTabBar
+ */
+function _autoRenameTab(tab, termId, cwd, renderTabBar) {
+  const firstTermId = tab.terminalPanel?.terminals
+    ? Array.from(tab.terminalPanel.terminals.keys())[0]
+    : null;
+  if (!tab.userNamed && firstTermId === termId) {
+    const newName = extractFolderName(cwd);
+    if (newName && newName !== tab.name) {
+      tab.name = newName;
+      renderTabBar?.();
+    }
+  }
+}
+
+/**
+ * Update the header path text and branch badge for the active tab.
+ * @param {WorkspaceTab} tab
+ * @param {string} cwd
+ * @param {(cwd: string) => Promise<string|null>} gitBranch
+ */
+function _updateHeaderBranch(tab, cwd, gitBranch) {
+  tab.cwd = cwd;
+  if (tab.pathTextEl) tab.pathTextEl.textContent = cwd;
+  if (tab.branchBadgeEl) {
+    gitBranch(cwd).then((branch) => {
+      if (tab.branchBadgeEl) {
+        tab.branchBadgeEl.textContent = branch ? ` ${branch}` : '';
+      }
+    });
+  }
+}
+
+/**
  * Handle terminal cwd changes — update file tree, active-tab header, and
  * auto-rename the tab (to the folder name) when the first terminal's cwd
  * changes and the user has not explicitly named the tab.
@@ -194,32 +233,13 @@ export function onTerminalCwdChanged(tabs, activeTabId, termId, cwd, { gitBranch
     tab.fileTree.setTerminalRoot(termId, cwd);
   }
 
-  // Auto-rename tab when the first terminal moves and the user hasn't
-  // defined a custom name.
-  const firstTermId = tab.terminalPanel?.terminals
-    ? Array.from(tab.terminalPanel.terminals.keys())[0]
-    : null;
-  if (!tab.userNamed && firstTermId === termId) {
-    const newName = extractFolderName(cwd);
-    if (newName && newName !== tab.name) {
-      tab.name = newName;
-      renderTabBar?.();
-    }
-  }
+  _autoRenameTab(tab, termId, cwd, renderTabBar);
 
   // Update header path/branch only for the active tab's active terminal
   if (
     tab.id === activeTabId &&
     tab.terminalPanel?.activeTerminal?.terminal?.id === termId
   ) {
-    tab.cwd = cwd;
-    if (tab.pathTextEl) tab.pathTextEl.textContent = cwd;
-    if (tab.branchBadgeEl) {
-      gitBranch(cwd).then((branch) => {
-        if (tab.branchBadgeEl) {
-          tab.branchBadgeEl.textContent = branch ? ` ${branch}` : '';
-        }
-      });
-    }
+    _updateHeaderBranch(tab, cwd, gitBranch);
   }
 }

--- a/src/utils/workspace-resize.js
+++ b/src/utils/workspace-resize.js
@@ -33,16 +33,14 @@ export function buildSidePanel(deps, { side, contentCls, title }) {
 }
 
 /**
- * Build the center panel with path info, branch badge, and terminal area.
+ * Build the path-info bar with collapse arrows, path text, and branch badge.
  * @param {PanelInteractionDeps} deps
  * @param {import('./tab-types.js').WorkspaceTab} tab
  * @param {HTMLElement} leftPanel
  * @param {HTMLElement} rightPanel
+ * @returns {HTMLElement}
  */
-export function buildCenterPanel(deps, tab, leftPanel, rightPanel) {
-  const panel = _el('div', 'panel panel-center');
-  const header = _el('div', 'panel-header');
-
+function _buildPathInfo(deps, tab, leftPanel, rightPanel) {
   const pathInfo = _el('div', 'path-info');
 
   const pathArrowLeft = _el('span', 'path-arrow', '\u2190');
@@ -57,14 +55,29 @@ export function buildCenterPanel(deps, tab, leftPanel, rightPanel) {
   pathArrowRight.addEventListener('click', () => togglePanel(deps, rightPanel, 'right', pathArrowRight));
 
   pathInfo.append(pathArrowLeft, pathText, branchBadge, pathArrowRight);
-  header.appendChild(pathInfo);
+
+  tab.pathTextEl = pathText;
+  tab.branchBadgeEl = branchBadge;
+
+  return pathInfo;
+}
+
+/**
+ * Build the center panel with path info, branch badge, and terminal area.
+ * @param {PanelInteractionDeps} deps
+ * @param {import('./tab-types.js').WorkspaceTab} tab
+ * @param {HTMLElement} leftPanel
+ * @param {HTMLElement} rightPanel
+ */
+export function buildCenterPanel(deps, tab, leftPanel, rightPanel) {
+  const panel = _el('div', 'panel panel-center');
+  const header = _el('div', 'panel-header');
+
+  header.appendChild(_buildPathInfo(deps, tab, leftPanel, rightPanel));
   panel.appendChild(header);
 
   const termContainer = _el('div', 'terminal-area');
   panel.appendChild(termContainer);
-
-  tab.pathTextEl = pathText;
-  tab.branchBadgeEl = branchBadge;
 
   return { panel, termContainer };
 }

--- a/src/utils/workspace-serializer.js
+++ b/src/utils/workspace-serializer.js
@@ -84,6 +84,38 @@ export function serialize({ tabs, activeTabId }) {
 // ── Restore ──
 
 /**
+ * Create a single WorkspaceTab from a serialized tab config entry.
+ * Handles legacy `userNamed` inference and cwd resolution.
+ *
+ * @param {Partial<SerializedTab> & { name: string }} tabData
+ * @param {string} defaultCwd
+ * @returns {WorkspaceTab}
+ */
+function _restoreTab(tabData, defaultCwd) {
+  const id = generateId('tab');
+  const firstCwd = firstTerminalCwd(tabData.splitTree);
+  const resolvedCwd = firstCwd || tabData.cwd || defaultCwd || '/';
+  const derived = extractFolderName(resolvedCwd);
+  const folderName = derived && derived !== '/' ? derived : null;
+  // Legacy configs predate `userNamed`. Infer it: a literal `Workspace N`
+  // name is the old default and is considered auto; anything else is
+  // treated as a name the user explicitly chose and must be preserved.
+  const userNamed = typeof tabData.userNamed === 'boolean'
+    ? tabData.userNamed
+    : !/^Workspace \d+$/.test(tabData.name || '');
+  const name = userNamed
+    ? tabData.name
+    : folderName || tabData.name;
+  const tab = new WorkspaceTab(id, name, resolvedCwd);
+  tab.userNamed = userNamed;
+  tab.noShortcut = tabData.noShortcut || false;
+  tab.colorGroup = tabData.colorGroup || null;
+  tab.worktree = tabData.worktree || null;
+  tab._restoreData = tabData;
+  return tab;
+}
+
+/**
  * Restore workspace from a saved config.
  * @param {RestoreConfigDeps} deps
  * @param {{ tabs: Array<Partial<SerializedTab> & { name: string }>, activeTabIndex?: number }} config
@@ -99,27 +131,8 @@ export async function restoreConfig({ tabs, setActiveTabId, defaultCwd, renderTa
 
   // Create tabs from config
   for (const tabData of config.tabs) {
-    const id = generateId('tab');
-    const firstCwd = firstTerminalCwd(tabData.splitTree);
-    const resolvedCwd = firstCwd || tabData.cwd || defaultCwd || '/';
-    const derived = extractFolderName(resolvedCwd);
-    const folderName = derived && derived !== '/' ? derived : null;
-    // Legacy configs predate `userNamed`. Infer it: a literal `Workspace N`
-    // name is the old default and is considered auto; anything else is
-    // treated as a name the user explicitly chose and must be preserved.
-    const userNamed = typeof tabData.userNamed === 'boolean'
-      ? tabData.userNamed
-      : !/^Workspace \d+$/.test(tabData.name || '');
-    const name = userNamed
-      ? tabData.name
-      : folderName || tabData.name;
-    const tab = new WorkspaceTab(id, name, resolvedCwd);
-    tab.userNamed = userNamed;
-    tab.noShortcut = tabData.noShortcut || false;
-    tab.colorGroup = tabData.colorGroup || null;
-    tab.worktree = tabData.worktree || null;
-    tab._restoreData = tabData;
-    tabs.set(id, tab);
+    const tab = _restoreTab(tabData, defaultCwd);
+    tabs.set(tab.id, tab);
   }
 
   renderTabBar();


### PR DESCRIPTION
## Summary

Extract named sub-functions from the longest utility functions in `src/utils/`, improving readability and maintainability without changing any business logic.

Closes #492

### Changes by file

- **`open-pr-flow.js`**: Extract `_validateBranchAndRemote`, `_browserPrFlow`, `_handleGhFailure`, `_handleGhSuccess` from `openPrFlow()` and `_tryGhFlow()`
- **`workspace-serializer.js`**: Extract `_restoreTab` from `restoreConfig()` to isolate per-tab restoration logic (including legacy `userNamed` inference)
- **`diff-parser.js`**: Extract `_hunkHeaderRow`, `_contextRow`, `_addOnlyRow` from `buildSideBySideRows()` to clarify row-building intent
- **`workspace-resize.js`**: Extract `_buildPathInfo` from `buildCenterPanel()` to separate path-info bar construction
- **`tab-lifecycle.js`**: Extract `_autoRenameTab`, `_updateHeaderBranch` from `onTerminalCwdChanged()` to isolate side-effects

### Notes

- All extracted functions remain in the same file (no new modules)
- No business logic changes — structure only
- All 408 tests pass, build succeeds

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>