### PR TITLE
refactor: deduplicate persistence cache and timestamp patterns

### DIFF
--- a/main/command-utils.js
+++ b/main/command-utils.js
@@ -1,0 +1,36 @@
+/**
+ * Shared helper for running external commands via execFile.
+ *
+ * Consolidates the duplicated promisify(execFile) + trySafe pattern
+ * shared by git-manager.js and git-metrics-collector.js.
+ */
+
+const { execFile } = require('child_process');
+const { promisify } = require('util');
+
+const execFileAsync = promisify(execFile);
+
+/**
+ * Run an external command and return trimmed stdout, or `fallback` on error.
+ *
+ * @param {string} cmd          - executable name (e.g. 'git')
+ * @param {string[]} args       - command arguments
+ * @param {object} opts         - options forwarded to execFile
+ * @param {{ fallback?: *, trySafe: Function, log: object, label: string }} ctx
+ *   trySafe - the trySafe wrapper to use for error handling
+ *   log     - logger instance
+ *   label   - human-readable label for the log message
+ * @returns {Promise<string|*>}
+ */
+async function runCommand(cmd, args, opts, { fallback = null, trySafe, log, label }) {
+  return trySafe(
+    async () => {
+      const { stdout } = await execFileAsync(cmd, args, opts);
+      return stdout.trim();
+    },
+    fallback,
+    { log, label },
+  );
+}
+
+module.exports = { execFileAsync, runCommand };

--- a/main/config-helpers.js
+++ b/main/config-helpers.js
@@ -4,10 +4,11 @@
  */
 
 const { buildTimestampedRecord } = require('./record-helpers');
+const { nowISO } = require('../shared/date-utils');
 
 const DEFAULT_META = { defaultConfig: null };
 
-function buildConfigRecord(name, data, existing, now = new Date().toISOString()) {
+function buildConfigRecord(name, data, existing, now = nowISO()) {
   return buildTimestampedRecord({ ...data, name }, existing, now);
 }
 

--- a/main/config-manager.js
+++ b/main/config-manager.js
@@ -1,23 +1,16 @@
 const { CONFIG_DIR, META_FILE } = require('./paths');
-const { readJson, writeJson } = require('./fs-utils');
 const { DEFAULT_META, buildConfigRecord, formatConfigList } = require('./config-helpers');
 const { sanitizeName } = require('../shared/string-utils');
-const { Cache, cachedAsync } = require('./cache');
 const { trySafe } = require('./logger');
-const { JsonStore } = require('./json-store');
+const { JsonStore, CachedJsonFile } = require('./json-store');
 
 const store = new JsonStore(CONFIG_DIR, 'config-manager', {
   idToFile: (name) => `${sanitizeName(name)}.json`,
 });
-const _metaCache = new Cache();
+const _meta = new CachedJsonFile(META_FILE, () => store.ensureDir(), DEFAULT_META);
 
-const readMeta = cachedAsync(_metaCache, async () => (await readJson(META_FILE)) || { ...DEFAULT_META });
-
-async function writeMeta(meta) {
-  await store.ensureDir();
-  _metaCache.set(meta);
-  await writeJson(META_FILE, meta);
-}
+const readMeta = () => _meta.read();
+const writeMeta = (meta) => _meta.write(meta);
 
 async function save(name, data) {
   await store.ensureDir();

--- a/main/flow-executor-run.js
+++ b/main/flow-executor-run.js
@@ -5,6 +5,7 @@
  */
 
 const { MAX_RUN_HISTORY } = require('./flow-helpers');
+const { nowISO, extractDateString } = require('../shared/date-utils');
 
 /**
  * Appends a run record to the flow's history.
@@ -17,10 +18,10 @@ const { MAX_RUN_HISTORY } = require('./flow-helpers');
 async function recordRun(deps, flowId, status, runTimestamp) {
   const flow = await deps.getFlow(flowId);
   if (!flow) return;
-  const now = new Date().toISOString();
+  const now = nowISO();
   const runs = flow.runs || [];
   runs.push({
-    date: now.slice(0, 10),
+    date: extractDateString(now),
     timestamp: now,
     logTimestamp: runTimestamp,
     status,

--- a/main/flow-executor.js
+++ b/main/flow-executor.js
@@ -17,6 +17,7 @@ const {
 } = require('./flow-helpers');
 const { saveLog, getRunLog, cleanLogs } = require('./flow-executor-log');
 const { recordRun } = require('./flow-executor-run');
+const { toLogFilename } = require('../shared/date-utils');
 
 // --- Top-level helpers ---
 
@@ -80,7 +81,7 @@ function execute(deps, runningFlows, flow) {
 
   const ptyId = `flow-${flow.id}-${Date.now()}`;
   const cwd = flow.cwd || os.homedir();
-  const runTimestamp = new Date().toISOString().replace(/[:.]/g, '-');
+  const runTimestamp = toLogFilename();
 
   try {
     const proc = ptyManager.create({

--- a/main/flow-helpers.js
+++ b/main/flow-helpers.js
@@ -3,6 +3,7 @@ const { LOGS_DIR } = require('./paths');
 const { createStreamParser } = require('./flow-stream-parser');
 const { getLastRun } = require('../shared/flow-utils');
 const { AGENT_IDS } = require('../shared/agent-registry');
+const { extractDateString } = require('../shared/date-utils');
 
 const MS_PER_HOUR = 3_600_000;
 const SCHEDULER_INTERVAL_MS = 60_000;
@@ -61,7 +62,7 @@ function _isTimeMatch(schedule, now) {
 }
 
 function _notRunToday(lastRun, now) {
-  return !lastRun || lastRun.date !== now.toISOString().slice(0, 10);
+  return !lastRun || lastRun.date !== extractDateString(now.toISOString());
 }
 
 function shouldRun(flow, now) {

--- a/main/git-manager.js
+++ b/main/git-manager.js
@@ -1,11 +1,9 @@
-const { execFile } = require('child_process');
-const { promisify } = require('util');
 const { DIFF_MAX_BUFFER, execOpts, parseNameStatus, parseUntracked } = require('./git-helpers');
 const { splitLines, matchFirst } = require('./parse-utils');
 const { createLogger, trySafe } = require('./logger');
+const { execFileAsync, runCommand } = require('./command-utils');
 
 const log = createLogger('git-manager');
-const execFileAsync = promisify(execFile);
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -13,15 +11,8 @@ const execFileAsync = promisify(execFile);
 
 /** Run a git command, return trimmed stdout or `fallback` on error. */
 async function runGit(cwd, args, { fallback = null, maxBuffer } = {}) {
-  return trySafe(
-    async () => {
-      const opts = maxBuffer ? execOpts(cwd, { maxBuffer }) : execOpts(cwd);
-      const { stdout } = await execFileAsync('git', args, opts);
-      return stdout.trim();
-    },
-    fallback,
-    { log, label: `git ${args[0]} in ${cwd}` },
-  );
+  const opts = maxBuffer ? execOpts(cwd, { maxBuffer }) : execOpts(cwd);
+  return runCommand('git', args, opts, { fallback, trySafe, log, label: `git ${args[0]} in ${cwd}` });
 }
 
 // ---------------------------------------------------------------------------

--- a/main/git-metrics-collector.js
+++ b/main/git-metrics-collector.js
@@ -1,5 +1,3 @@
-const { execFile } = require('child_process');
-const { promisify } = require('util');
 const { DEFAULT_DAYS } = require('./stats-helpers');
 const {
   rankModifiedFiles,
@@ -7,25 +5,21 @@ const {
   GIT_TIMEOUT_MS,
 } = require('./usage-helpers');
 const { createLogger, trySafe } = require('./logger');
+const { runCommand } = require('./command-utils');
 
 const log = createLogger('git-metrics-collector');
-const execFileAsync = promisify(execFile);
 
 async function getMostModifiedFiles(cwds) {
   const results = await Promise.all(
     cwds.map(async (cwd) => {
-      return trySafe(
-        async () => {
-          const { stdout } = await execFileAsync(
-            'git',
-            ['log', `--since=${DEFAULT_DAYS} days ago`, '--name-only', '--pretty=format:', '--diff-filter=ACMR'],
-            { cwd, encoding: 'utf-8', timeout: GIT_TIMEOUT_MS }
-          );
-          return { cwd, files: stdout.split('\n').map((l) => l.trim()).filter(Boolean) };
-        },
-        { cwd, files: [] },
-        { log, label: `git log in ${cwd}` },
+      const stdout = await runCommand(
+        'git',
+        ['log', `--since=${DEFAULT_DAYS} days ago`, '--name-only', '--pretty=format:', '--diff-filter=ACMR'],
+        { cwd, encoding: 'utf-8', timeout: GIT_TIMEOUT_MS },
+        { fallback: '', trySafe, log, label: `git log in ${cwd}` },
       );
+      const files = stdout ? stdout.split('\n').map((l) => l.trim()).filter(Boolean) : [];
+      return { cwd, files };
     })
   );
 

--- a/main/json-store.js
+++ b/main/json-store.js
@@ -125,4 +125,63 @@ class JsonStore {
   }
 }
 
-module.exports = { JsonStore };
+/**
+ * A single JSON file backed by an in-memory cache.
+ *
+ * Eliminates the repetitive cache + readJson / writeJson / ensureDir pattern
+ * shared by config-manager (meta file) and session-manager (sessions file).
+ *
+ * Usage:
+ *   const meta = new CachedJsonFile(META_FILE, ensureDirFn, { defaultConfig: null });
+ *   const data = await meta.read();   // cached after first read
+ *   await meta.write(newData);        // updates cache + disk
+ */
+class CachedJsonFile {
+  /**
+   * @param {string} filePath   - absolute path to the JSON file
+   * @param {() => Promise<void>} ensureDirFn - idempotent directory-creation function
+   * @param {T} defaultValue    - value returned when the file does not exist
+   * @template T
+   */
+  constructor(filePath, ensureDirFn, defaultValue) {
+    this._filePath = filePath;
+    this._ensureDir = ensureDirFn;
+    this._default = defaultValue;
+    this._cache = null;
+    this._loaded = false;
+  }
+
+  /** Read the file, returning the cached value after the first successful read. */
+  async read() {
+    if (this._loaded) return this._cache;
+    const data = await readJson(this._filePath);
+    this._cache = data != null ? data : (
+      typeof this._default === 'object' && this._default !== null
+        ? { ...this._default }
+        : this._default
+    );
+    this._loaded = true;
+    return this._cache;
+  }
+
+  /** Write data to disk and update the in-memory cache. */
+  async write(data) {
+    await this._ensureDir();
+    this._cache = data;
+    this._loaded = true;
+    await writeJson(this._filePath, data);
+  }
+
+  /** Return the cached value (or null if not yet loaded). */
+  get() {
+    return this._cache;
+  }
+
+  /** Manually set the cached value without writing to disk. */
+  set(value) {
+    this._cache = value;
+    this._loaded = true;
+  }
+}
+
+module.exports = { JsonStore, CachedJsonFile };

--- a/main/record-helpers.js
+++ b/main/record-helpers.js
@@ -2,6 +2,8 @@
  * Utility for building immutable record objects with automatic timestamp.
  */
 
+const { nowISO } = require('../shared/date-utils');
+
 /**
  * Merges base and overrides into a new record, automatically setting updatedAt
  * to the current ISO timestamp.
@@ -10,7 +12,7 @@
  * @returns {Record<string, unknown> & { updatedAt: string }} merged record with updatedAt set to now
  */
 function buildRecord(base, overrides) {
-  return { ...base, updatedAt: new Date().toISOString(), ...overrides };
+  return { ...base, updatedAt: nowISO(), ...overrides };
 }
 
 /**
@@ -20,10 +22,10 @@ function buildRecord(base, overrides) {
  *
  * @param {Record<string, unknown>} base - The base object to spread
  * @param {Record<string, unknown> | null | undefined} existing - Existing record (may have createdAt)
- * @param {string} [now=new Date().toISOString()] - ISO timestamp; injectable for tests
+ * @param {string} [now=nowISO()] - ISO timestamp; injectable for tests
  * @returns {Record<string, unknown> & { createdAt: string, updatedAt: string }}
  */
-function buildTimestampedRecord(base, existing, now = new Date().toISOString()) {
+function buildTimestampedRecord(base, existing, now = nowISO()) {
   return buildRecord(base, { createdAt: existing?.createdAt || now, updatedAt: now });
 }
 

--- a/main/session-helpers.js
+++ b/main/session-helpers.js
@@ -1,4 +1,5 @@
 const { buildRecord } = require('./record-helpers');
+const { nowISO } = require('../shared/date-utils');
 
 const MAX_SESSIONS = 200;
 const MS_PER_SEC = 1000;
@@ -19,7 +20,7 @@ function isFlowTerminal(termId) {
 
 function buildEndedRecord(session, status) {
   return buildRecord(session, {
-    endedAt: new Date().toISOString(),
+    endedAt: nowISO(),
     durationSec: durationSec(session.startedAt),
     status,
   });

--- a/main/session-manager.js
+++ b/main/session-manager.js
@@ -1,9 +1,10 @@
 const os = require('os');
 const { BASE_DIR, SESSIONS_FILE } = require('./paths');
-const { readJson, writeJson, ensureDirOnce } = require('./fs-utils');
+const { ensureDirOnce } = require('./fs-utils');
 const { generateSessionId, durationSec, isFlowTerminal, buildEndedRecord, buildActiveRecord, trimSessions } = require('./session-helpers');
+const { nowISO } = require('../shared/date-utils');
 const { createPollingManager } = require('../shared/polling-manager');
-const { Cache } = require('./cache');
+const { CachedJsonFile } = require('./json-store');
 const { createLogger, trySafe } = require('./logger');
 
 const log = createLogger('session-manager');
@@ -25,7 +26,7 @@ class SessionManager {
     this._previousAgents = {};
     this._activeSessions = {};
     this._polling = false;
-    this._sessionsCache = new Cache();
+    this._sessionsFile = new CachedJsonFile(SESSIONS_FILE, ensureDir, []);
   }
 
   async start(ptyManager) {
@@ -78,7 +79,7 @@ class SessionManager {
       termId,
       agent: agentName,
       cwd: cwd || os.homedir(),
-      startedAt: new Date().toISOString(),
+      startedAt: nowISO(),
     };
   }
 
@@ -98,24 +99,22 @@ class SessionManager {
   }
 
   async _saveRecord(record) {
-    await ensureDir();
-
-    const sessions = trimSessions([...(this._sessionsCache.get() || []), record]);
-    this._sessionsCache.set(sessions);
+    const current = this._sessionsFile.get() || [];
+    const sessions = trimSessions([...current, record]);
 
     trySafe(
-      () => writeJson(SESSIONS_FILE, sessions),
+      () => this._sessionsFile.write(sessions),
       undefined,
       { log, label: 'write' },
     );
   }
 
   async _loadAll() {
-    this._sessionsCache.set((await readJson(SESSIONS_FILE)) || []);
+    await this._sessionsFile.read();
   }
 
   getSessions() {
-    return this._sessionsCache.get() || [];
+    return this._sessionsFile.get() || [];
   }
 
   getActiveSessions() {

--- a/shared/date-utils.js
+++ b/shared/date-utils.js
@@ -53,4 +53,33 @@ function generateDateRange(days = 30) {
   });
 }
 
-module.exports = { formatDateTime, extractDateString, generateDateRange };
+/**
+ * Return the current instant as an ISO 8601 string (e.g. "2025-03-29T14:32:00.000Z").
+ * Replaces the widespread `new Date().toISOString()` pattern.
+ * @returns {string}
+ */
+function nowISO() {
+  return new Date().toISOString();
+}
+
+/**
+ * Return today's date as "YYYY-MM-DD".
+ * Replaces `new Date().toISOString().slice(0, 10)`.
+ * @returns {string}
+ */
+function todayISO() {
+  return new Date().toISOString().slice(0, 10);
+}
+
+/**
+ * Convert an ISO timestamp into a filename-safe string by replacing
+ * colons and dots with dashes (e.g. "2025-03-29T14-32-00-000Z").
+ * Replaces `.toISOString().replace(/[:.]/g, '-')`.
+ * @param {string} [iso] - ISO string; defaults to nowISO()
+ * @returns {string}
+ */
+function toLogFilename(iso) {
+  return (iso || nowISO()).replace(/[:.]/g, '-');
+}
+
+module.exports = { formatDateTime, extractDateString, generateDateRange, nowISO, todayISO, toLogFilename };


### PR DESCRIPTION
## Summary

- **CachedJsonFile class** (`main/json-store.js`): new class that encapsulates the repeated `Cache + readJson/writeJson/ensureDir` pattern. Applied in `config-manager.js` (meta file) and `session-manager.js` (sessions file), removing direct `Cache`/`readJson`/`writeJson` imports
- **Date helpers** (`shared/date-utils.js`): added `nowISO()`, `todayISO()`, `toLogFilename()` to replace scattered `new Date().toISOString()` calls across 6+ files (`record-helpers`, `session-helpers`, `session-manager`, `config-helpers`, `flow-executor`, `flow-executor-run`, `flow-helpers`)
- **runCommand helper** (`main/command-utils.js`): consolidates the duplicated `promisify(execFile) + trySafe` pattern from `git-manager.js` and `git-metrics-collector.js` into a single reusable function

## Test plan

- [x] `npm run build` passes
- [x] All 408 tests pass across 26 test files (`npm test`)
- [x] No new dependencies added

Closes #493