### PR TITLE
refactor: remove unused durationSec import (partial #505)

### DIFF
--- a/main/session-manager.js
+++ b/main/session-manager.js
@@ -1,7 +1,7 @@
 const os = require('os');
 const { BASE_DIR, SESSIONS_FILE } = require('./paths');
 const { ensureDirOnce } = require('./fs-utils');
-const { generateSessionId, durationSec, isFlowTerminal, buildEndedRecord, buildActiveRecord, trimSessions } = require('./session-helpers');
+const { generateSessionId, isFlowTerminal, buildEndedRecord, buildActiveRecord, trimSessions } = require('./session-helpers');
 const { nowISO } = require('../shared/date-utils');
 const { createPollingManager } = require('../shared/polling-manager');
 const { CachedJsonFile } = require('./json-store');


### PR DESCRIPTION
## Refactoring

- Retrait de l'import `durationSec` inutilisé dans `main/session-manager.js`

### Pourquoi `shared/agent-registry.js` n'a PAS été supprimé

L'issue #505 indique que `shared/agent-registry.js` est du code mort, mais la vérification par grep montre qu'il est activement importé par 3 fichiers :
- `main/pty-helpers.js` → importe `AGENTS`
- `main/flow-helpers.js` → importe `AGENT_IDS`
- `src/utils/flow-modal-helpers.js` → importe `AGENT_OPTIONS`

Supprimer ce fichier casserait le build. L'issue doit être corrigée/fermée pour cette partie.

Partial fix for #505

## Vérifications

- [x] Build OK
- [x] Tests OK (409 tests, 27 suites)

---

📂 Path local : `/Users/rekta/projet/coding/refactor-pikagent`
🤖 PR créée automatiquement par l'Agent Refactor