### PR TITLE
fix: add logging to empty catch blocks

### DIFF
--- a/main/fs-manager.js
+++ b/main/fs-manager.js
@@ -3,6 +3,9 @@ const fsp = fs.promises;
 const path = require('path');
 const os = require('os');
 const { MAX_FILE_SIZE, wrapSafe, doCopy, dirFirstCompare } = require('./fs-manager-helpers');
+const { createLogger } = require('./logger');
+
+const log = createLogger('fs-manager');
 
 // ---------------------------------------------------------------------------
 // File Watcher
@@ -18,7 +21,7 @@ function watchDir(id, dirPath, callback) {
     });
     watcher.on('error', () => unwatchDir(id));
     watchers.set(id, watcher);
-  } catch {}
+  } catch (err) { log.warn('watchDir failed', dirPath, err); }
 }
 
 function unwatchDir(id) {

--- a/main/pty-manager.js
+++ b/main/pty-manager.js
@@ -130,7 +130,7 @@ class PtyManager {
 
       const psOut = await this._exec('ps', ['-o', 'args=', '-p', childPids.join(',')]);
       return matchAgent(psOut);
-    } catch {}
+    } catch (err) { log.warn('_checkAgent failed', err); }
     return null;
   }
 

--- a/src/utils/file-tree-dir-ops.js
+++ b/src/utils/file-tree-dir-ops.js
@@ -166,7 +166,7 @@ export async function refreshSection(ft, watchIdOrCwd, renderDirFn) {
     section._refreshing = false;
     if (section._pendingRefresh) {
       section._pendingRefresh = false;
-      ft.refreshSection(cwd).catch(() => {});
+      ft.refreshSection(cwd).catch((err) => console.warn('refreshSection failed', err));
     }
   }
 }

--- a/src/utils/file-tree-watcher.js
+++ b/src/utils/file-tree-watcher.js
@@ -20,7 +20,7 @@ export function listenForChanges(debounceTimers, refreshSection, fsApi) {
       id,
       setTimeout(() => {
         debounceTimers.delete(id);
-        refreshSection(id).catch(() => {});
+        refreshSection(id).catch((err) => console.warn('refreshSection failed', err));
       }, DEBOUNCE_DELAY),
     );
   });

--- a/src/utils/sidebar-manager.js
+++ b/src/utils/sidebar-manager.js
@@ -40,7 +40,7 @@ const SIDE_VIEW_RENDERERS = {
       const boardView = viewStore.getView('boardView');
       if (boardView) {
         for (const [, card] of boardView.cards) {
-          try { card.fitAddon.fit(); } catch {}
+          try { card.fitAddon.fit(); } catch (e) { /* fit may fail on detached terminal */ }
         }
         boardView.resume();
       }

--- a/src/utils/terminal-factory.js
+++ b/src/utils/terminal-factory.js
@@ -7,7 +7,7 @@ import { disposeResources } from './disposable.js';
 
 /** Safely call fitAddon.fit(), swallowing errors from detached terminals. */
 export function _safeFit(fitAddon) {
-  try { fitAddon.fit(); } catch {}
+  try { fitAddon.fit(); } catch (e) { /* fit may fail on detached terminal */ }
 }
 
 const BASE_FONT_FAMILY =


### PR DESCRIPTION
## Summary

- Add `log.warn()` to 2 empty catch blocks in `main/` files (`pty-manager.js`, `fs-manager.js`)
- Add `console.warn()` to 2 empty `.catch()` handlers in `src/utils/` files (`file-tree-watcher.js`, `file-tree-dir-ops.js`)
- Add intent-documenting comments to 2 catch blocks in `src/utils/` files (`terminal-factory.js`, `sidebar-manager.js`)
- 5 intentionally-silent catch blocks left unchanged (best-effort kill, JSON fallback, access check, best-effort ops, localStorage fallback)

Closes #504

## Test plan

- [x] `npm run build` passes
- [x] `npm test` passes (27 files, 409 tests)
- [ ] Manual: trigger a watchDir failure and verify log output
- [ ] Manual: trigger a _checkAgent failure and verify log output

🤖 Generated with [Claude Code](https://claude.com/claude-code)