### PR TITLE
refactor: extract _createRunBasedTabConfig factory in usage-view-helpers

### DIFF
--- a/src/utils/usage-view-helpers.js
+++ b/src/utils/usage-view-helpers.js
@@ -78,17 +78,6 @@ export function createSection(title) {
 // --- Tab configurations ---
 
 /**
- * Factory that builds the common { cards, chart, tables } shape shared by
- * run-based tabs (agents and flows).
- *
- * @param {object}   m               The metrics slice (metrics.agent or metrics.flow).
- * @param {object}   options
- * @param {Array<{label: string, value: string|number, cls: string, sub?: string}>} options.cards Four card descriptors (label/value/cls/sub).
- * @param {string}   options.chartTitle  Title displayed above the chart.
- * @param {Array<{title: string, headers: string[], tableCls: string, data: Array<object>, renderRow: (item: object) => HTMLTableRowElement}>} options.tables One or more table descriptors.
- * @returns {{ cards: Array, chart: object, tables: Array }}
- */
-/**
  * Build the two run-metric cards shared by agents and flows tabs:
  * success rate + average duration (with min/max sub-text).
  */
@@ -99,6 +88,17 @@ function _runMetricCards(m) {
   ];
 }
 
+/**
+ * Factory that builds the common { cards, chart, tables } shape shared by
+ * run-based tabs (agents and flows).
+ *
+ * @param {object}   m               The metrics slice (metrics.agent or metrics.flow).
+ * @param {object}   options
+ * @param {Array<{label: string, value: string|number, cls: string, sub?: string}>} options.cards Four card descriptors (label/value/cls/sub).
+ * @param {string}   options.chartTitle  Title displayed above the chart.
+ * @param {Array<{title: string, headers: string[], tableCls: string, data: Array<object>, renderRow: (item: object) => HTMLTableRowElement}>} options.tables One or more table descriptors.
+ * @returns {{ cards: Array, chart: object, tables: Array }}
+ */
 function _createRunBasedTabConfig(m, { cards, chartTitle, tables }) {
   return {
     cards,


### PR DESCRIPTION
## Summary

- Fixes misplaced JSDoc: moves the `_createRunBasedTabConfig` factory JSDoc block to its correct position directly above the factory function, instead of being orphaned above `_runMetricCards`
- The `_createRunBasedTabConfig` factory and `_runMetricCards` helper already deduplicate the shared pattern (cards with total/active/successRate/avgDuration, chart, tables) between `_agentTabConfig` and `_flowTabConfig`

Closes #425

## Test plan

- [x] `npm run build` passes
- [x] `npm test` passes (27 test files, 409 tests)
- [x] No behavioral changes -- JSDoc-only repositioning