### PR TITLE
docs: document sanitization divergence between config and git-ref helpers

### DIFF
--- a/main/config-manager.js
+++ b/main/config-manager.js
@@ -1,5 +1,8 @@
 const { CONFIG_DIR, META_FILE } = require('./paths');
 const { DEFAULT_META, buildConfigRecord, formatConfigList } = require('./config-helpers');
+// sanitizeName: config-oriented sanitization — keeps spaces, replaces
+// special chars with underscores, truncates at 64 chars.  This differs from
+// sanitizeSegment (git-ref-safe, hyphen-based) by design; see string-utils.js.
 const { sanitizeName } = require('../shared/string-utils');
 const { trySafe } = require('./logger');
 const { JsonStore, CachedJsonFile } = require('./json-store');

--- a/shared/string-utils.js
+++ b/shared/string-utils.js
@@ -5,9 +5,20 @@
  */
 
 /**
- * Sanitize a name by replacing non-alphanumeric characters (except dash,
- * underscore, and space) with underscores, then truncating to 64 characters.
- * Used for config names and similar identifiers.
+ * Sanitize a name for use as a **config identifier / display name**.
+ *
+ * Rules (intentionally different from {@link sanitizeSegment}):
+ * - Keeps alphanumerics, dashes, underscores, and **spaces** (spaces are
+ *   meaningful in user-facing config names).
+ * - Replaces everything else with underscores (`_`).
+ * - Truncates to 64 characters to avoid overly long filenames.
+ *
+ * **Why not reuse `sanitizeSegment`?**
+ * Config names are displayed to the user and may contain spaces; they are
+ * mapped to filenames via `sanitizeName(name) + '.json'`.  Git branch names
+ * (handled by `sanitizeSegment`) forbid spaces and use hyphens as the
+ * replacement character instead, following `git check-ref-format` conventions.
+ *
  * @param {string} name
  * @returns {string}
  */
@@ -16,10 +27,20 @@ function sanitizeName(name) {
 }
 
 /**
- * Sanitize a string into a filesystem-safe path segment by replacing
- * non-alphanumeric characters (except dot, underscore, dash) with hyphens
- * and trimming leading/trailing hyphens.
- * Used for branch names and worktree paths.
+ * Sanitize a string into a **filesystem-safe / git-ref-safe path segment**.
+ *
+ * Rules (intentionally different from {@link sanitizeName}):
+ * - Keeps alphanumerics, dots, underscores, and dashes.
+ * - Collapses any other characters (including spaces) into a single hyphen.
+ * - Trims leading and trailing hyphens.
+ *
+ * **Why not reuse `sanitizeName`?**
+ * Branch names and worktree directory names must not contain spaces and
+ * should follow `git check-ref-format` conventions.  Using hyphens as the
+ * replacement character produces idiomatic branch names (e.g.
+ * `feat/my-branch`) whereas `sanitizeName` would yield underscores and
+ * preserve spaces, which are invalid in refs.
+ *
  * @param {string} name
  * @returns {string}
  */

--- a/src/utils/worktree-dialog.js
+++ b/src/utils/worktree-dialog.js
@@ -12,6 +12,10 @@
 import { _el, createActionButton, _vis } from './dom-facades.js';
 import { createDialogBase } from './dom-dialogs.js';
 import { onKeyAction } from './event-helpers.js';
+// sanitizeSegment: git-ref-safe sanitization — collapses invalid chars into
+// hyphens, trims leading/trailing hyphens, no spaces allowed.  This differs
+// from sanitizeName (config-oriented, keeps spaces, uses underscores) by
+// design; see string-utils.js for the rationale.
 import { sanitizeSegment } from '../../shared/string-utils.js';
 import { buildSelect } from './form-helpers.js';
 


### PR DESCRIPTION
## Summary

- Enhanced JSDoc in `shared/string-utils.js` for both `sanitizeName` and `sanitizeSegment`, explaining **why** the two functions intentionally use different regex patterns (config names allow spaces and use underscores; git refs forbid spaces and use hyphens per `git check-ref-format`).
- Added inline comments at each import site (`main/config-manager.js`, `src/utils/worktree-dialog.js`) pointing to the rationale so future contributors don't mistakenly merge them.
- **No code changes** to the button bar renderers — `flow-card-renderer.js` and `flow-category-renderer.js` already use `buildDomainButtonBar` from `flow-dom.js` (resolved in #499).

Closes #415

## Test plan

- [x] `npm run build` passes
- [x] `npm test` — all 409 tests pass
- [ ] Review JSDoc comments for accuracy and clarity

🤖 Generated with [Claude Code](https://claude.com/claude-code)