### PR TITLE
refactor: unify 3 async safe wrappers into createSafeWrapper factory

### DIFF
--- a/main/fs-manager-helpers.js
+++ b/main/fs-manager-helpers.js
@@ -1,7 +1,7 @@
 const fs = require('fs');
 const fsp = fs.promises;
 const path = require('path');
-const { runSafe } = require('./safe-handler');
+const { createSafeWrapper } = require('./safe-handler');
 
 const MAX_FILE_SIZE = 2 * 1024 * 1024; // 2MB
 
@@ -16,11 +16,7 @@ const MAX_FILE_SIZE = 2 * 1024 * 1024; // 2MB
  * @param {(...args: unknown[]) => Promise<unknown>} fn - async function to wrap
  * @returns {(...args: unknown[]) => Promise<unknown>} wrapped function with same signature
  */
-function wrapSafe(fn) {
-  return function (...args) {
-    return runSafe(() => fn(...args), (err) => ({ error: err.message }));
-  };
-}
+const wrapSafe = createSafeWrapper();
 
 async function pathExists(filePath) {
   try {

--- a/main/logger.js
+++ b/main/logger.js
@@ -1,4 +1,4 @@
-const { runSafe } = require('./safe-handler');
+const { createSafeWrapper } = require('./safe-handler');
 
 /**
  * Lightweight logger factory for main-process modules.
@@ -37,11 +37,8 @@ function createLogger(module) {
  * @param {{ log: { warn: (msg: string, err?: unknown) => void }, label: string }} [opts] - optional logger & label
  * @returns {Promise<unknown>}
  */
-async function trySafe(fn, defaultValue, { log, label } = {}) {
-  return runSafe(fn, (err) => {
-    if (log && label) log.warn(`${label} failed`, err);
-    return defaultValue;
-  });
+function trySafe(fn, defaultValue, { log, label } = {}) {
+  return createSafeWrapper({ defaultValue, log, label })(fn)();
 }
 
 module.exports = { createLogger, trySafe };

--- a/main/safe-handler.js
+++ b/main/safe-handler.js
@@ -2,7 +2,8 @@
  * Shared factory for wrapping async functions with try-catch error handling.
  *
  * IPC handlers use the { success, data, error } shape.
- * Lower-level helpers (safeAsync, trySafe) are unified via runSafe.
+ * Lower-level helpers (wrapSafe, trySafe) are unified via createSafeWrapper
+ * which itself delegates to runSafe.
  */
 
 /**
@@ -23,6 +24,46 @@ async function runSafe(fn, onError) {
 }
 
 /**
+ * Configurable factory that returns a higher-order wrapper around async fns.
+ *
+ * The returned wrapper catches errors and applies the configured strategy:
+ *
+ * - `envelope` (default false): when true, wraps success results in
+ *   `{ success: true, data }` and errors in `{ error: message }`.
+ *   When false, returns the raw result on success and `{ error: message }` on
+ *   failure (passthrough mode).
+ * - `defaultValue`: if provided, returned instead of an error object on failure.
+ * - `log` + `label`: if both provided, `log.warn('<label> failed', err)` is
+ *   called on failure.
+ *
+ * @param {{ envelope?: boolean, defaultValue?: unknown, log?: { warn: Function }, label?: string }} [opts]
+ * @returns {(fn: (...args: unknown[]) => Promise<unknown>) => (...args: unknown[]) => Promise<unknown>}
+ */
+function createSafeWrapper({ envelope = false, defaultValue, log, label } = {}) {
+  const hasDefault = arguments.length > 0 && 'defaultValue' in (arguments[0] || {});
+
+  return function wrap(fn) {
+    return function (...args) {
+      return runSafe(
+        () => {
+          const result = fn(...args);
+          if (!envelope) return result;
+          // Envelope mode: wrap in { success, data }
+          return Promise.resolve(result).then((r) =>
+            r === undefined ? { success: true } : { success: true, data: r },
+          );
+        },
+        (err) => {
+          if (log && label) log.warn(`${label} failed`, err);
+          if (hasDefault) return defaultValue;
+          return { error: err.message };
+        },
+      );
+    };
+  };
+}
+
+/**
  * Factory that returns a wrapped async function.
  * On success: returns { success: true, data: <result> }.
  * On failure: returns { error: <message> }.
@@ -32,15 +73,6 @@ async function runSafe(fn, onError) {
  * @param {(...args: unknown[]) => Promise<unknown>} asyncFn
  * @returns {(...args: unknown[]) => Promise<{ success: true, data: unknown } | { error: string }>}
  */
-function createSafeHandler(asyncFn) {
-  return async (...args) => {
-    try {
-      const result = await asyncFn(...args);
-      return result === undefined ? { success: true } : { success: true, data: result };
-    } catch (err) {
-      return { error: err.message };
-    }
-  };
-}
+const createSafeHandler = createSafeWrapper({ envelope: true });
 
-module.exports = { runSafe, createSafeHandler };
+module.exports = { runSafe, createSafeWrapper, createSafeHandler };


### PR DESCRIPTION
## Summary

- Introduced `createSafeWrapper({ envelope, defaultValue, log, label })` factory in `main/safe-handler.js` that delegates to the existing `runSafe` primitive
- Reimplemented `wrapSafe` (fs-manager-helpers.js) as `createSafeWrapper()` — passthrough mode, `{ error }` on failure
- Reimplemented `createSafeHandler` (safe-handler.js) as `createSafeWrapper({ envelope: true })` — `{ success, data }` envelope
- Reimplemented `trySafe` (logger.js) to use `createSafeWrapper({ defaultValue, log, label })` — default value + optional logging
- All public signatures remain unchanged; no caller modifications needed

Closes #506

## Test plan

- [x] `npm run build` passes
- [x] `npm test` passes (27 test files, 409 tests)
- [x] Verified all callers of `wrapSafe` (fs-manager.js), `createSafeHandler` (ipc-handlers.js), and `trySafe` (skills-manager, token-collector, flow-executor-log, command-utils, git-manager, json-store, config-manager, session-manager) still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)