### PR TITLE
refactor: deduplicate localStorage theme + factory wrappers tab-ops

### DIFF
--- a/src/components/tab-manager.js
+++ b/src/components/tab-manager.js
@@ -26,9 +26,7 @@ import {
   disposeSideView, disposeAllSideViews, disposeAllTabs,
 } from '../utils/tab-manager-sidebar.js';
 import {
-  renderTabBar as doRenderTabBar,
-  createTab as doCreateTab,
-  closeTab as doCloseTab,
+  bindTabOps,
   reorderTab as doReorderTab,
   renameTab as doRenameTab,
 } from '../utils/tab-manager-tab-ops.js';
@@ -53,6 +51,7 @@ export class TabManager {
     this.sidebarMode = 'work';
     this.activeColorFilter = null;
     this.excludedColors = new Set();
+    this._tabOps = bindTabOps(this);
   }
 
   _initApi() { this._api = { gitBranch: tabViewFacade.gitBranch }; }
@@ -105,12 +104,12 @@ export class TabManager {
 
   // --- Tab lifecycle (delegated) ---
 
-  createTab(name = null, cwd = null) { return doCreateTab(this, (id) => this.switchTo(id), name, cwd); }
-  closeTab(id) { return doCloseTab(this, () => this.createTab(), (tabId) => this.switchTo(tabId), id); }
+  createTab(name = null, cwd = null) { return this._tabOps.createTab((id) => this.switchTo(id), name, cwd); }
+  closeTab(id) { return this._tabOps.closeTab(() => this.createTab(), (tabId) => this.switchTo(tabId), id); }
 
   switchTo(id) { return doSwitchTo(buildSwitchToDeps(this), id); }
 
-  renderTabBar() { this._tabElements = doRenderTabBar(this); }
+  renderTabBar() { this._tabElements = this._tabOps.renderTabBar(); }
   reorderTab(fromId, toId, before) { doReorderTab(this, fromId, toId, before); }
   renameTab(id, nameEl) { doRenameTab(this, id)(nameEl); }
 

--- a/src/utils/tab-manager-tab-ops.js
+++ b/src/utils/tab-manager-tab-ops.js
@@ -30,7 +30,7 @@ import {
  *
  * @param {object} tm - TabManager instance
  */
-function bindTabOps(tm) {
+export function bindTabOps(tm) {
   // Stable closures over `tm`, captured once.
   const renderTabBar = () => tm.renderTabBar();
   const switchTo = (id) => tm.switchTo(id);


### PR DESCRIPTION
## Summary

- **localStorage theme (task 1)**: Already resolved — `src/utils/app-theme.js` and `src/utils/terminal-themes.js` both use `persistedSetting` from `src/utils/persisted-setting.js`. No duplicate localStorage code remains in theme files.
- **Factory wrappers (task 2)**: Exported `bindTabOps` from `tab-manager-tab-ops.js` and wired `TabManager._tabOps = bindTabOps(this)` once in `_initState()`. The three tab-ops methods (`renderTabBar`, `createTab`, `closeTab`) now reuse the cached ops object instead of each rebuilding all closures via a fresh `bindTabOps(tm)` call.

## Changed files

- `src/utils/tab-manager-tab-ops.js` — export `bindTabOps`
- `src/components/tab-manager.js` — import `bindTabOps`, cache in `_tabOps`, use for lifecycle methods

## Test plan

- [x] `npm run build` passes
- [x] `npm test` passes (27 files, 409 tests)
- [ ] Manual smoke: create/close/reorder/rename tabs, switch themes

Closes #438