### PR TITLE
refactor: deduplicate last execFileAsync pattern in pty-manager

### DIFF
--- a/main/pty-manager.js
+++ b/main/pty-manager.js
@@ -1,8 +1,7 @@
 const os = require('os');
 const fs = require('fs');
 const pty = require('node-pty');
-const { execFile } = require('child_process');
-const { promisify } = require('util');
+const { execFileAsync } = require('./command-utils');
 const { createLogger } = require('./logger');
 
 const log = createLogger('pty-manager');
@@ -29,8 +28,6 @@ const {
   parseChildPids,
   parseCwdFromLsof,
 } = require('./pty-helpers');
-
-const execFileAsync = promisify(execFile);
 
 class PtyManager {
   constructor() {


### PR DESCRIPTION
## Summary

Closes #493

This PR addresses the final remaining duplication identified in issue #493 (persistence/cache/timestamp patterns across 6+ files).

**Prior work** (already merged in earlier PRs): the bulk of issue #493 was resolved by:
- `shared/date-utils.js` — `nowISO()`, `todayISO()`, `toLogFilename()` already extracted and used across all source files
- `main/command-utils.js` — `execFileAsync` and `runCommand` already shared by `git-manager.js` and `git-metrics-collector.js`
- `main/json-store.js` — `CachedJsonFile` class already used by `config-manager.js` and `session-manager.js`

**This PR**: removes the last remaining `promisify(execFile)` duplication in `pty-manager.js`, which still had its own local copy instead of importing from `command-utils.js`.

### Changes
- `main/pty-manager.js`: replaced local `const execFileAsync = promisify(execFile)` with `const { execFileAsync } = require('./command-utils')`, removing the `child_process` and `util` imports.

### Not changed (and why)
- **`skills-manager.js`** manual cache (`_rootCache`): not a `CachedJsonFile` candidate because it caches a sub-property and re-creates `ensureDirOnce` on write — different semantics.
- **`flow-helpers.js:65`** `now.toISOString()`: `now` is a Date parameter (not `new Date()`), so this is correct API usage of `extractDateString`.
- **`usage-helpers.js:82`** `new Date(ts).toISOString()`: converts a specific timestamp, not current time — not the `nowISO()` pattern.
- **Test files**: inline `new Date().toISOString().slice(0,10)` in assertions is acceptable for self-contained test verification.

## Test plan
- [x] `npm run build` passes
- [x] `npm test` passes (27 files, 409 tests)