### PR TITLE
refactor: remove dead camelCase export aliases in managers

### DIFF
--- a/main/fs-manager.js
+++ b/main/fs-manager.js
@@ -11,17 +11,17 @@ const { MAX_FILE_SIZE, wrapSafe, doCopy, dirFirstCompare } = require('./fs-manag
 const watchers = new Map();
 
 function watchDir(id, dirPath, callback) {
-  unwatchDir(id);
+  unwatch(id);
   try {
     const watcher = fs.watch(dirPath, { recursive: true }, (eventType, filename) => {
       callback({ id, dirPath, eventType, filename });
     });
-    watcher.on('error', () => unwatchDir(id));
+    watcher.on('error', () => unwatch(id));
     watchers.set(id, watcher);
   } catch {}
 }
 
-function unwatchDir(id) {
+function unwatch(id) {
   const w = watchers.get(id);
   if (w) {
     w.close();
@@ -38,7 +38,7 @@ function unwatchAll() {
 // Public API
 // ---------------------------------------------------------------------------
 
-async function readDirectory(dirPath) {
+async function readdir(dirPath) {
   try {
     const entries = await fsp.readdir(dirPath, { withFileTypes: true });
     return entries.sort(dirFirstCompare).map((e) => ({
@@ -51,40 +51,40 @@ async function readDirectory(dirPath) {
   }
 }
 
-const readFile = wrapSafe(async (filePath) => {
+const readfile = wrapSafe(async (filePath) => {
   const stat = await fsp.stat(filePath);
   if (stat.size > MAX_FILE_SIZE) return { error: 'File too large (>2MB)' };
   const content = await fsp.readFile(filePath, 'utf-8');
   return { content, size: stat.size };
 });
 
-const writeFile = wrapSafe(async (filePath, content) => {
+const writefile = wrapSafe(async (filePath, content) => {
   await fsp.writeFile(filePath, content, 'utf-8');
   return { success: true };
 });
 
-const makeDir = wrapSafe(async (dirPath) => {
+const mkdir = wrapSafe(async (dirPath) => {
   await fsp.mkdir(dirPath, { recursive: true });
   return { success: true };
 });
 
-const copyEntry = wrapSafe(async (srcPath) => {
+const copy = wrapSafe(async (srcPath) => {
   const destPath = await doCopy(srcPath, path.dirname(srcPath), true);
   return { success: true, destPath };
 });
 
-const copyFileTo = wrapSafe(async (srcPath, destDir) => {
+const copyTo = wrapSafe(async (srcPath, destDir) => {
   const destPath = await doCopy(srcPath, destDir, false);
   return { success: true, destPath };
 });
 
-const renameEntry = wrapSafe(async (oldPath, newName) => {
+const rename = wrapSafe(async (oldPath, newName) => {
   const newPath = path.join(path.dirname(oldPath), newName);
   await fsp.rename(oldPath, newPath);
   return { success: true, newPath };
 });
 
-function getHomedir() {
+function homedir() {
   return os.homedir();
 }
 
@@ -93,16 +93,8 @@ function cleanup() {
 }
 
 module.exports = {
-  // Method aliases matching channel suffixes (fs:readdir → readdir, etc.)
-  readdir: readDirectory,
-  readfile: readFile,
-  writefile: writeFile,
-  mkdir: makeDir,
-  copy: copyEntry,
-  copyTo: copyFileTo,
-  rename: renameEntry,
-  homedir: getHomedir,
-  unwatch: unwatchDir,
+  readdir, readfile, writefile, mkdir,
+  copy, copyTo, rename, homedir, unwatch,
   // Used directly by ipc-handlers.js (custom fs:watch handler) and manager-init.js (cleanup)
   watchDir, cleanup,
 };

--- a/main/git-manager.js
+++ b/main/git-manager.js
@@ -19,11 +19,11 @@ async function runGit(cwd, args, { fallback = null, maxBuffer } = {}) {
 // Public API
 // ---------------------------------------------------------------------------
 
-async function getBranch(cwd) {
+async function branch(cwd) {
   return runGit(cwd, ['rev-parse', '--abbrev-ref', 'HEAD']);
 }
 
-async function getLocalChanges(cwd) {
+async function localChanges(cwd) {
   return trySafe(
     async () => {
       const [stagedRaw, unstagedRaw, untrackedRaw] = await Promise.all([
@@ -39,11 +39,11 @@ async function getLocalChanges(cwd) {
       };
     },
     { staged: [], unstaged: [], untracked: [] },
-    { log, label: 'getLocalChanges' },
+    { log, label: 'localChanges' },
   );
 }
 
-async function getFileDiff(cwd, filePath, isStaged) {
+async function fileDiff(cwd, filePath, isStaged) {
   const args = isStaged ? ['diff', '--cached', '--', filePath] : ['diff', '--', filePath];
   const result = await runGit(cwd, args, { fallback: '', maxBuffer: DIFF_MAX_BUFFER });
   return result;
@@ -53,7 +53,7 @@ async function getFileDiff(cwd, filePath, isStaged) {
 // Worktree / branch API
 // ---------------------------------------------------------------------------
 
-async function isGitRepo(cwd) {
+async function isRepo(cwd) {
   const out = await runGit(cwd, ['rev-parse', '--is-inside-work-tree']);
   return out === 'true';
 }
@@ -138,7 +138,7 @@ async function worktreeRemove(cwd, worktreePath, force) {
   return executeGitCommand(cwd, args, `worktree remove ${worktreePath}`);
 }
 
-async function getRemoteUrl(cwd) {
+async function remoteUrl(cwd) {
   return runGit(cwd, ['config', '--get', 'remote.origin.url']);
 }
 
@@ -203,17 +203,7 @@ async function ghPrCreate(cwd, baseBranch) {
 }
 
 module.exports = {
-  // Method aliases matching channel suffixes (git:branch → branch, etc.)
-  branch: getBranch,
-  localChanges: getLocalChanges,
-  fileDiff: getFileDiff,
-  isRepo: isGitRepo,
-  listBranches,
-  worktreeList,
-  worktreeAdd,
-  worktreeRemove,
-  remoteUrl: getRemoteUrl,
-  pushBranch,
-  ghAvailable,
-  ghPrCreate,
+  branch, localChanges, fileDiff, isRepo,
+  listBranches, worktreeList, worktreeAdd, worktreeRemove,
+  remoteUrl, pushBranch, ghAvailable, ghPrCreate,
 };

--- a/main/skills-manager.js
+++ b/main/skills-manager.js
@@ -193,7 +193,7 @@ async function _isAllowedPath(p) {
 module.exports = {
   list, read, write, create,
   getRoot, setRoot, resetRoot,
-  // Channel-suffix aliases
+  // `delete` and `import` are reserved words — aliases required.
   delete: remove,
   import: importFrom,
 };


### PR DESCRIPTION
## Summary

- **fs-manager.js**: Renamed 9 internal functions (`readDirectory`, `readFile`, `writeFile`, `makeDir`, `copyEntry`, `copyFileTo`, `renameEntry`, `getHomedir`, `unwatchDir`) to match their IPC channel suffixes (`readdir`, `readfile`, `writefile`, `mkdir`, `copy`, `copyTo`, `rename`, `homedir`, `unwatch`). Switched `module.exports` to shorthand notation, eliminating the aliasing layer.
- **git-manager.js**: Renamed 5 internal functions (`getBranch`, `getLocalChanges`, `getFileDiff`, `isGitRepo`, `getRemoteUrl`) to match their export keys (`branch`, `localChanges`, `fileDiff`, `isRepo`, `remoteUrl`). Switched `module.exports` to shorthand notation.
- **skills-manager.js**: Clarified comment on `delete`/`import` aliases (reserved words prevent renaming the internal functions `remove`/`importFrom`).
- **tab-manager-tab-ops.js**: No change needed — `bindTabOps` was already private (no `export` keyword).

Closes #474

## Verification

- `npm run build` passes
- `npm test` — 409 tests pass (27 files)
- grep confirmed no external imports reference the old camelCase names

## Test plan

- [x] Build passes (`node build.js`)
- [x] All 409 tests pass (`vitest run`)
- [x] Verified no consumers reference the renamed internal function names

🤖 Generated with [Claude Code](https://claude.com/claude-code)