### PR TITLE
refactor: add logging to 6 silent catch blocks

### DIFF
--- a/src/utils/sidebar-manager.js
+++ b/src/utils/sidebar-manager.js
@@ -37,7 +37,7 @@ const SIDE_VIEW_REATTACH_OVERRIDES = {
     const boardView = viewStore.getView('boardView');
     if (!boardView) return;
     for (const [, card] of boardView.cards) {
-      try { card.fitAddon.fit(); } catch (e) { /* fit may fail on detached terminal */ }
+      try { card.fitAddon.fit(); } catch (e) { console.warn('card.fitAddon.fit() failed (detached terminal?)', e); }
     }
     boardView.resume();
   },

--- a/src/utils/terminal-factory.js
+++ b/src/utils/terminal-factory.js
@@ -7,7 +7,7 @@ import { disposeResources } from './disposable.js';
 
 /** Safely call fitAddon.fit(), swallowing errors from detached terminals. */
 export function _safeFit(fitAddon) {
-  try { fitAddon.fit(); } catch (e) { /* fit may fail on detached terminal */ }
+  try { fitAddon.fit(); } catch (e) { console.warn('fitAddon.fit() failed (detached terminal?)', e); }
 }
 
 const BASE_FONT_FAMILY =


### PR DESCRIPTION
## Refactoring

Ajout de logging dans 6 blocs catch vides qui masquaient les erreurs silencieusement.

**Fichiers modifiés :**
- `main/pty-manager.js` — _checkAgent catch
- `main/fs-manager.js` — fs.watch catch
- `src/utils/file-tree-watcher.js` — refreshSection catch
- `src/utils/file-tree-dir-ops.js` — refreshSection catch
- `src/utils/terminal-factory.js` — fitAddon.fit catch
- `src/utils/sidebar-manager.js` — card.fitAddon.fit catch

5 autres blocs catch laissés en l'état (best-effort légitime).

Closes #504

## Vérifications

- [x] Build OK
- [x] Tests OK

---

📂 Path local : `/Users/rekta/projet/coding/refactor-pikagent`
🤖 PR créée automatiquement par l'Agent Refactor