### PR TITLE
refactor: unify wrapSafe, createSafeHandler and trySafe into single factory

### DIFF
--- a/main/fs-manager-helpers.js
+++ b/main/fs-manager-helpers.js
@@ -1,22 +1,9 @@
 const fs = require('fs');
 const fsp = fs.promises;
 const path = require('path');
-const { createSafeWrapper } = require('./safe-handler');
+const { wrapSafe } = require('./safe-handler');
 
 const MAX_FILE_SIZE = 2 * 1024 * 1024; // 2MB
-
-/**
- * Factory that wraps an async function with error handling.
- * On success returns the result of fn directly (passthrough — no envelope).
- * On failure returns { error: err.message }.
- *
- * Distinct from `createSafeHandler` in safe-handler.js, which wraps results
- * in a { success, data } envelope for IPC.
- *
- * @param {(...args: unknown[]) => Promise<unknown>} fn - async function to wrap
- * @returns {(...args: unknown[]) => Promise<unknown>} wrapped function with same signature
- */
-const wrapSafe = createSafeWrapper();
 
 async function pathExists(filePath) {
   try {

--- a/main/logger.js
+++ b/main/logger.js
@@ -1,4 +1,4 @@
-const { createSafeWrapper } = require('./safe-handler');
+const { trySafe } = require('./safe-handler');
 
 /**
  * Lightweight logger factory for main-process modules.
@@ -27,18 +27,6 @@ function createLogger(module) {
   };
 }
 
-/**
- * Generic safe-execution wrapper.
- * Runs `fn`, returns its result on success or `defaultValue` on error.
- * Optionally logs failures via a logger's `warn` method.
- *
- * @param {() => unknown} fn - async or sync function to execute
- * @param {unknown} defaultValue - value returned when fn throws
- * @param {{ log: { warn: (msg: string, err?: unknown) => void }, label: string }} [opts] - optional logger & label
- * @returns {Promise<unknown>}
- */
-function trySafe(fn, defaultValue, { log, label } = {}) {
-  return createSafeWrapper({ defaultValue, log, label })(fn)();
-}
-
+// Re-export trySafe from safe-handler.js so existing consumers that import
+// { trySafe } from './logger' continue to work without changes.
 module.exports = { createLogger, trySafe };

--- a/main/safe-handler.js
+++ b/main/safe-handler.js
@@ -1,9 +1,12 @@
 /**
  * Shared factory for wrapping async functions with try-catch error handling.
  *
- * IPC handlers use the { success, data, error } shape.
- * Lower-level helpers (wrapSafe, trySafe) are unified via createSafeWrapper
- * which itself delegates to runSafe.
+ * Every safe-execution variant in the codebase is built on top of
+ * `createSafeWrapper`, the single configurable factory:
+ *
+ * - `wrapSafe`          – passthrough mode (no envelope, returns `{ error }` on failure)
+ * - `createSafeHandler` – IPC envelope mode (`{ success, data }` / `{ error }`)
+ * - `trySafe`           – one-shot execution with defaultValue + optional logging
  */
 
 /**
@@ -63,16 +66,41 @@ function createSafeWrapper({ envelope = false, defaultValue, log, label } = {}) 
   };
 }
 
+// ---------------------------------------------------------------------------
+// Pre-built variants — every safe-execution helper is a thin alias.
+// ---------------------------------------------------------------------------
+
 /**
- * Factory that returns a wrapped async function.
+ * Higher-order wrapper: passthrough mode (no envelope).
+ * On success returns the result of fn directly.
+ * On failure returns { error: err.message }.
+ *
+ * @param {(...args: unknown[]) => Promise<unknown>} fn - async function to wrap
+ * @returns {(...args: unknown[]) => Promise<unknown>} wrapped function with same signature
+ */
+const wrapSafe = createSafeWrapper();
+
+/**
+ * Higher-order wrapper: IPC envelope mode.
  * On success: returns { success: true, data: <result> }.
  * On failure: returns { error: <message> }.
- *
- * Intended for IPC handlers that need a uniform {success/error} envelope.
  *
  * @param {(...args: unknown[]) => Promise<unknown>} asyncFn
  * @returns {(...args: unknown[]) => Promise<{ success: true, data: unknown } | { error: string }>}
  */
 const createSafeHandler = createSafeWrapper({ envelope: true });
 
-module.exports = { runSafe, createSafeWrapper, createSafeHandler };
+/**
+ * One-shot safe execution with a fallback value and optional logging.
+ * Runs `fn` once, returns its result on success or `defaultValue` on error.
+ *
+ * @param {() => unknown} fn - async or sync function to execute
+ * @param {unknown} defaultValue - value returned when fn throws
+ * @param {{ log?: { warn: (msg: string, err?: unknown) => void }, label?: string }} [opts]
+ * @returns {Promise<unknown>}
+ */
+function trySafe(fn, defaultValue, { log, label } = {}) {
+  return createSafeWrapper({ defaultValue, log, label })(fn)();
+}
+
+module.exports = { runSafe, createSafeWrapper, createSafeHandler, wrapSafe, trySafe };


### PR DESCRIPTION
## Refactoring

Unification des 3 wrappers async quasi-identiques en une seule factory dans `main/safe-handler.js` :
- `wrapSafe()` (fs-manager-helpers.js) -> appel factory
- `createSafeHandler()` (safe-handler.js) -> factory avec envelope
- `trySafe()` (logger.js) -> factory avec logging + fallback

Closes #506

## Vérifications

- [x] Build OK
- [x] Tests OK (27 fichiers, 406 tests)

---

📂 Path local : `/Users/rekta/projet/coding/refactor-pikagent`
🤖 PR créée automatiquement par l'Agent Refactor