### PR TITLE
refactor: deduplicate persistence patterns and timestamp helpers

### DIFF
--- a/main/flow-helpers.js
+++ b/main/flow-helpers.js
@@ -3,7 +3,7 @@ const { LOGS_DIR } = require('./paths');
 const { createStreamParser } = require('./flow-stream-parser');
 const { getLastRun } = require('../shared/flow-utils');
 const AGENT_IDS = ['claude', 'codex', 'opencode'];
-const { extractDateString } = require('../shared/date-utils');
+const { toDateString } = require('../shared/date-utils');
 
 const MS_PER_HOUR = 3_600_000;
 const SCHEDULER_INTERVAL_MS = 60_000;
@@ -62,7 +62,7 @@ function _isTimeMatch(schedule, now) {
 }
 
 function _notRunToday(lastRun, now) {
-  return !lastRun || lastRun.date !== extractDateString(now.toISOString());
+  return !lastRun || lastRun.date !== toDateString(now);
 }
 
 function shouldRun(flow, now) {

--- a/main/usage-helpers.js
+++ b/main/usage-helpers.js
@@ -1,7 +1,7 @@
 const os = require('os');
 const path = require('path');
 const { computeRate, computeDuration, perDay, DEFAULT_DAYS } = require('./stats-helpers');
-const { extractDateString } = require('../shared/date-utils');
+const { extractDateString, toDateString } = require('../shared/date-utils');
 const {
   aggregateByKey,
   groupAndAggregate,
@@ -79,7 +79,7 @@ function parseTokenUsage(line, cutoffMs) {
   if (entry.timestamp) {
     const ts = typeof entry.timestamp === 'number' ? entry.timestamp : new Date(entry.timestamp).getTime();
     if (ts < cutoffMs) return null;
-    dateKey = extractDateString(new Date(ts).toISOString());
+    dateKey = toDateString(ts);
   }
 
   return {

--- a/shared/date-utils.js
+++ b/shared/date-utils.js
@@ -82,4 +82,19 @@ function toLogFilename(iso) {
   return (iso || nowISO()).replace(/[:.]/g, '-');
 }
 
-module.exports = { formatDateTime, extractDateString, generateDateRange, nowISO, todayISO, toLogFilename };
+/**
+ * Extract "YYYY-MM-DD" from a Date object or numeric timestamp.
+ *
+ * Unlike `extractDateString` (which operates on an existing ISO string),
+ * this helper avoids the intermediate `new Date(x).toISOString()` step
+ * callers would otherwise need.
+ *
+ * @param {Date|number} dateOrTs - Date instance or epoch-ms timestamp
+ * @returns {string} "YYYY-MM-DD"
+ */
+function toDateString(dateOrTs) {
+  const d = typeof dateOrTs === 'number' ? new Date(dateOrTs) : dateOrTs;
+  return d.toISOString().slice(0, 10);
+}
+
+module.exports = { formatDateTime, extractDateString, generateDateRange, nowISO, todayISO, toLogFilename, toDateString };

--- a/tests/main/date-utils.test.js
+++ b/tests/main/date-utils.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-const { extractDateString, generateDateRange, formatDateTime } = require('../../shared/date-utils');
+const { extractDateString, generateDateRange, formatDateTime, nowISO, todayISO, toLogFilename, toDateString } = require('../../shared/date-utils');
 
 describe('date-utils', () => {
   describe('extractDateString', () => {
@@ -58,6 +58,63 @@ describe('date-utils', () => {
     it('returns date only when no timestamp', () => {
       expect(formatDateTime('2025-03-15', null)).toBe('2025-03-15');
       expect(formatDateTime('2025-03-15', 0)).toBe('2025-03-15');
+    });
+  });
+
+  describe('nowISO', () => {
+    it('returns a valid ISO 8601 string', () => {
+      const result = nowISO();
+      expect(result).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/);
+    });
+
+    it('is close to current time', () => {
+      const before = Date.now();
+      const result = new Date(nowISO()).getTime();
+      const after = Date.now();
+      expect(result).toBeGreaterThanOrEqual(before);
+      expect(result).toBeLessThanOrEqual(after);
+    });
+  });
+
+  describe('todayISO', () => {
+    it('returns YYYY-MM-DD format', () => {
+      expect(todayISO()).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    });
+
+    it('matches current date', () => {
+      const today = new Date().toISOString().slice(0, 10);
+      expect(todayISO()).toBe(today);
+    });
+  });
+
+  describe('toLogFilename', () => {
+    it('replaces colons and dots with dashes', () => {
+      expect(toLogFilename('2025-03-29T14:32:00.000Z')).toBe('2025-03-29T14-32-00-000Z');
+    });
+
+    it('defaults to current timestamp when no argument', () => {
+      const result = toLogFilename();
+      expect(result).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}-\d{3}Z$/);
+    });
+  });
+
+  describe('toDateString', () => {
+    it('extracts YYYY-MM-DD from a Date object', () => {
+      const d = new Date('2025-06-15T14:30:00.000Z');
+      expect(toDateString(d)).toBe('2025-06-15');
+    });
+
+    it('extracts YYYY-MM-DD from a numeric timestamp', () => {
+      const ts = new Date('2025-06-15T14:30:00.000Z').getTime();
+      expect(toDateString(ts)).toBe('2025-06-15');
+    });
+
+    it('handles epoch zero', () => {
+      expect(toDateString(0)).toBe('1970-01-01');
+    });
+
+    it('handles Date constructed from epoch', () => {
+      expect(toDateString(new Date(0))).toBe('1970-01-01');
     });
   });
 });


### PR DESCRIPTION
## Summary

- Add `toDateString(dateOrTs)` helper to `shared/date-utils.js` that extracts `YYYY-MM-DD` from a `Date` object or numeric timestamp, eliminating the redundant `new Date(x).toISOString().slice(0,10)` pattern
- Replace inline `extractDateString(now.toISOString())` in `flow-helpers.js` and `extractDateString(new Date(ts).toISOString())` in `usage-helpers.js` with the cleaner `toDateString()` call
- Add tests for `nowISO`, `todayISO`, `toLogFilename`, and `toDateString` (previously untested helpers in `date-utils.js`)

**Note:** Patterns 1 (CachedJsonFile/JsonStore) and 3 (execFile/runCommand) from the issue were already extracted in prior refactors. This PR completes the timestamp deduplication (pattern 2).

## Test plan
- [x] `npm run build` passes
- [x] `npm test` passes (416 tests, 27 test files)
- [x] New tests cover `nowISO`, `todayISO`, `toLogFilename`, and `toDateString`
- [x] Verified no remaining inline `toISOString()` patterns in production code (only in `date-utils.js` itself and test files)

Closes #493

Generated with [Claude Code](https://claude.com/claude-code)