### PR TITLE
refactor: extract shared settings UI helpers to reduce duplication

### DIFF
--- a/src/components/settings-appearance.js
+++ b/src/components/settings-appearance.js
@@ -6,7 +6,7 @@ import { TERMINAL_THEMES, getTerminalThemeName, setTerminalTheme, getTerminalThe
 import { getAppTheme, setAppTheme } from '../utils/app-theme.js';
 import { _el, createActionButton } from '../utils/dom.js';
 import { MODE_BUTTONS, THEME_PREVIEW_LINES, COLOR_DOT_KEYS } from '../utils/settings-helpers.js';
-import { buildSettingsSection } from '../utils/settings-section-builder.js';
+import { buildSettingsSection, createSettingsItem } from '../utils/settings-section-builder.js';
 import { registerComponent } from '../utils/component-registry.js';
 import { createAsyncHandler } from '../utils/event-helpers.js';
 
@@ -32,11 +32,7 @@ function _createThemePreviewLine(segments, theme) {
   return line;
 }
 
-function _createThemeCard(name, theme, isActive, tabManager, renderAppearanceFn) {
-  const card = _el('div', 'theme-card');
-  if (isActive) card.classList.add('theme-active');
-
-  // Preview block
+function _buildThemePreview(name, theme) {
   const preview = _el('div', 'theme-preview');
   preview.style.background = theme.background;
 
@@ -53,15 +49,23 @@ function _createThemeCard(name, theme, isActive, tabManager, renderAppearanceFn)
   }
   preview.appendChild(dots);
 
-  card.appendChild(preview);
-  card.appendChild(_el('div', 'theme-card-label', name));
+  return preview;
+}
 
-  card.addEventListener('click', createAsyncHandler(
-    { stopProp: false, onSuccess: renderAppearanceFn },
-    () => { setTerminalTheme(name); applyThemeToTerminals(tabManager); },
-  ));
-
-  return card;
+function _createThemeCard(name, theme, isActive, tabManager, renderAppearanceFn) {
+  return createSettingsItem({
+    cls: 'theme-card',
+    isActive,
+    activeCls: 'theme-active',
+    onClick: {
+      handler: () => { setTerminalTheme(name); applyThemeToTerminals(tabManager); },
+      opts: { stopProp: false, onSuccess: renderAppearanceFn },
+    },
+    content: [
+      _buildThemePreview(name, theme),
+      _el('div', 'theme-card-label', name),
+    ],
+  });
 }
 
 /**

--- a/src/components/settings-configs.js
+++ b/src/components/settings-configs.js
@@ -4,9 +4,8 @@
  */
 import { _el } from '../utils/dom.js';
 import { CONFIG_ACTIONS, BOTTOM_CONFIG_BUTTONS, formatConfigMeta } from '../utils/settings-helpers.js';
-import { buildSettingsSection, createActionBar } from '../utils/settings-section-builder.js';
+import { buildSettingsSection, createActionBar, createSettingsItem } from '../utils/settings-section-builder.js';
 import { registerComponent } from '../utils/component-registry.js';
-import { createAsyncHandler } from '../utils/event-helpers.js';
 import configApi from '../services/config-api.js';
 
 function _createConfigActions(config, tabManager, renderConfigsFn) {
@@ -43,17 +42,19 @@ function _buildConfigRowLeft(config) {
 }
 
 function _createConfigRow(config, currentName, tabManager, renderConfigsFn) {
-  const row = _el('div', 'config-row');
-  if (config.name === currentName) row.classList.add('config-active');
-
-  row.addEventListener('click', createAsyncHandler(
-    { stopProp: false, guard: () => !!tabManager, onSuccess: renderConfigsFn },
-    () => tabManager.configManager.switchConfig(config.name),
-  ));
-
-  row.appendChild(_buildConfigRowLeft(config));
-  row.appendChild(_createConfigActions(config, tabManager, renderConfigsFn));
-  return row;
+  return createSettingsItem({
+    cls: 'config-row',
+    isActive: config.name === currentName,
+    activeCls: 'config-active',
+    onClick: {
+      handler: () => tabManager.configManager.switchConfig(config.name),
+      opts: { stopProp: false, guard: () => !!tabManager, onSuccess: renderConfigsFn },
+    },
+    content: [
+      _buildConfigRowLeft(config),
+      _createConfigActions(config, tabManager, renderConfigsFn),
+    ],
+  });
 }
 
 function _createBottomActions(currentName, tabManager, renderConfigsFn) {

--- a/src/components/settings-keybindings.js
+++ b/src/components/settings-keybindings.js
@@ -5,7 +5,7 @@
 import { formatCombo } from '../utils/shortcut-helpers.js';
 import { _el, createActionButton } from '../utils/dom.js';
 import { onClickStopped } from '../utils/event-helpers.js';
-import { buildSettingsSection } from '../utils/settings-section-builder.js';
+import { buildSettingsSection, createSettingsItem } from '../utils/settings-section-builder.js';
 import { registerComponent } from '../utils/component-registry.js';
 
 /**
@@ -46,10 +46,7 @@ function createKeyBadge(binding, index, shortcutManager, startRecordingFn, rende
 /**
  * Build a single keybinding row with badge elements and an add button.
  */
-function _renderBindingRow(binding, shortcutManager, startRecordingFn, renderKeybindingsFn) {
-  const row = _el('div', 'keybinding-row');
-  row.appendChild(_el('div', 'keybinding-label', binding.label));
-
+function _buildKeysContainer(binding, shortcutManager, startRecordingFn, renderKeybindingsFn) {
   const keysContainer = _el('div', 'keybinding-keys');
   for (let i = 0; i < binding.keys.length; i++) {
     keysContainer.appendChild(createKeyBadge(binding, i, shortcutManager, startRecordingFn, renderKeybindingsFn));
@@ -67,8 +64,17 @@ function _renderBindingRow(binding, shortcutManager, startRecordingFn, renderKey
   });
   keysContainer.appendChild(addBtn);
 
-  row.appendChild(keysContainer);
-  return row;
+  return keysContainer;
+}
+
+function _renderBindingRow(binding, shortcutManager, startRecordingFn, renderKeybindingsFn) {
+  return createSettingsItem({
+    cls: 'keybinding-row',
+    content: [
+      _el('div', 'keybinding-label', binding.label),
+      _buildKeysContainer(binding, shortcutManager, startRecordingFn, renderKeybindingsFn),
+    ],
+  });
 }
 
 /**

--- a/src/utils/settings-section-builder.js
+++ b/src/utils/settings-section-builder.js
@@ -7,6 +7,44 @@ import { _el, renderButtonBar, renderList } from './dom.js';
 import { createAsyncHandler } from './event-helpers.js';
 
 /**
+ * Create a settings row or card container with optional active state and click handler.
+ *
+ * Encapsulates the repeated pattern across settings components where a container
+ * element is created, conditionally receives an "active" CSS class, and optionally
+ * gets a click handler attached.
+ *
+ * @param {{
+ *   cls: string,
+ *   content: HTMLElement[],
+ *   isActive?: boolean,
+ *   activeCls?: string,
+ *   onClick?: ((e: MouseEvent) => void) | { handler: () => void, opts?: object },
+ * }} opts
+ * @returns {HTMLElement}
+ */
+export function createSettingsItem({ cls, content, isActive = false, activeCls, onClick }) {
+  const el = _el('div', cls);
+  if (isActive && activeCls) el.classList.add(activeCls);
+
+  if (onClick) {
+    if (typeof onClick === 'function') {
+      el.addEventListener('click', onClick);
+    } else {
+      el.addEventListener('click', createAsyncHandler(
+        onClick.opts || {},
+        onClick.handler,
+      ));
+    }
+  }
+
+  for (const child of content) {
+    if (child) el.appendChild(child);
+  }
+
+  return el;
+}
+
+/**
  * Build a settings section and populate the given container.
  *
  * @param {HTMLElement} contentEl - the settings content container (will be cleared)


### PR DESCRIPTION
## Refactoring

Extraction de helpers partagés pour les patterns de rendu UI dupliqués dans les composants settings :

- Factory `createSettingsItem()` dans `settings-section-builder.js` pour le pattern row/card avec état actif
- Migration des 3 composants settings (appearance, configs, keybindings) vers ces helpers
- Utilisation cohérente des button bar helpers existants

Closes #530

## Fichier(s) modifié(s)

- `src/utils/settings-section-builder.js`
- `src/components/settings-appearance.js`
- `src/components/settings-configs.js`
- `src/components/settings-keybindings.js`

## Vérifications

- [x] Build OK
- [x] Tests OK

---

📂 Path local : `/Users/rekta/projet/coding/refactor-pikagent`
🤖 PR créée automatiquement par l'Agent Refactor