### PR TITLE
refactor: extract listDirNames helper for readdir+isDirectory pattern

### DIFF
--- a/main/fs-utils.js
+++ b/main/fs-utils.js
@@ -29,8 +29,13 @@ async function readDirJson(dirPath) {
   }
 }
 
+async function listDirNames(dirPath) {
+  const entries = await fsp.readdir(dirPath, { withFileTypes: true });
+  return entries.filter((e) => e.isDirectory()).map((e) => e.name);
+}
+
 async function writeJson(filePath, data) {
   await fsp.writeFile(filePath, JSON.stringify(data, null, 2), 'utf-8');
 }
 
-module.exports = { readJson, writeJson, ensureDirOnce, readDirJson };
+module.exports = { readJson, writeJson, ensureDirOnce, readDirJson, listDirNames };

--- a/main/skills-manager.js
+++ b/main/skills-manager.js
@@ -3,7 +3,7 @@ const fsp = fs.promises;
 const path = require('path');
 const os = require('os');
 const { BASE_DIR } = require('./paths');
-const { readJson, writeJson, ensureDirOnce } = require('./fs-utils');
+const { readJson, writeJson, ensureDirOnce, listDirNames } = require('./fs-utils');
 const { trySafe } = require('./logger');
 const { pathExists } = require('./fs-manager-helpers');
 const { JsonStore } = require('./json-store');
@@ -76,8 +76,7 @@ const _readSkillDir = _safe(async function readSkillDir(rootDir, skillName) {
 
 const list = _safe(async function list() {
   const root = await _loadRoot();
-  const entries = await fsp.readdir(root, { withFileTypes: true });
-  const dirs = entries.filter((e) => e.isDirectory()).map((e) => e.name);
+  const dirs = await listDirNames(root);
   const skills = await Promise.all(dirs.map((name) => _readSkillDir(root, name)));
   return skills.filter(Boolean).sort((a, b) => a.name.localeCompare(b.name));
 }, []);

--- a/main/token-collector.js
+++ b/main/token-collector.js
@@ -1,7 +1,7 @@
 const fsp = require('fs/promises');
 const path = require('path');
 const { FLOWS_DIR, CLAUDE_PROJECTS_DIR } = require('./paths');
-const { readDirJson } = require('./fs-utils');
+const { readDirJson, listDirNames } = require('./fs-utils');
 const { DEFAULT_DAYS } = require('./stats-helpers');
 const { generateDateRange } = require('../shared/date-utils');
 const {
@@ -51,8 +51,7 @@ async function collectProjectTokens(days) {
 
   return trySafe(
     async () => {
-      const allEntries = await fsp.readdir(CLAUDE_PROJECTS_DIR, { withFileTypes: true });
-      const projects = allEntries.filter((d) => d.isDirectory()).map((d) => d.name);
+      const projects = await listDirNames(CLAUDE_PROJECTS_DIR);
       return Promise.all(
         projects.map(async (proj) => {
           const data = await readProjectTokens(path.join(CLAUDE_PROJECTS_DIR, proj), cutoffMs);


### PR DESCRIPTION
## Refactoring

Extraction du pattern `readdir(dir, { withFileTypes: true }) → filter(isDirectory) → map(name)` dans un helper `listDirNames(dirPath)` ajouté à `main/fs-utils.js`. Les deux call sites (`token-collector.js` et `skills-manager.js`) utilisent désormais ce helper.

Closes #534

## Fichier(s) modifié(s)

- \`main/fs-utils.js\` — ajout de \`listDirNames\` (export)
- \`main/token-collector.js\` — utilise \`listDirNames\`
- \`main/skills-manager.js\` — utilise \`listDirNames\`

## Vérifications

- [x] Build OK (\`npm run build\`)
- [x] Tests OK (\`npm test\` — 405/405)

---

📂 Path local : \`/Users/claude/flux/review/pikagent/\`
🤖 PR créée automatiquement par l'Agent Refactor