### PR TITLE
refactor: extract rankTopByDesc helper for entries→sort→slice pattern

### DIFF
--- a/main/usage-helpers.js
+++ b/main/usage-helpers.js
@@ -9,6 +9,7 @@ const {
   sumByKeys,
   mapFields,
   countBy,
+  rankTopByDesc,
   initializeCounters,
   createDomainMetricsBuilder,
 } = require('../shared/aggregation-utils');
@@ -124,10 +125,12 @@ function buildPerProjectRanking(projectResults) {
     },
   );
 
-  return Object.entries(perProjectAgg)
-    .map(([project, data]) => ({ project, ...data }))
-    .sort((a, b) => b.total - a.total)
-    .slice(0, TOP_PROJECTS_LIMIT);
+  return rankTopByDesc(
+    perProjectAgg,
+    (project, data) => ({ project, ...data }),
+    'total',
+    TOP_PROJECTS_LIMIT,
+  );
 }
 
 function aggregateTokenData(labels, projectResults) {
@@ -252,10 +255,12 @@ function buildFileKey(cwd, filePath) {
 
 function rankModifiedFiles(results, limit = TOP_FILES_LIMIT) {
   const allFiles = results.flatMap(({ cwd, files }) => files.map(f => buildFileKey(cwd, f)));
-  return Object.entries(countBy(allFiles, k => k))
-    .map(([file, count]) => ({ file, count }))
-    .sort((a, b) => b.count - a.count)
-    .slice(0, limit);
+  return rankTopByDesc(
+    countBy(allFiles, k => k),
+    (file, count) => ({ file, count }),
+    'count',
+    limit,
+  );
 }
 
 function collectUniqueCwds(flowRuns, sessions) {

--- a/shared/aggregation-utils.js
+++ b/shared/aggregation-utils.js
@@ -112,6 +112,24 @@ function countBy(items, keyFn) {
 }
 
 /**
+ * Rank entries of a map into a sorted, truncated array of records.
+ * For each `[key, value]` pair, calls `itemBuilder(key, value)` to produce a record,
+ * then sorts records by `record[valueKey]` descending and keeps the top `limit`.
+ *
+ * @param {Record<string, unknown>} map
+ * @param {(key: string, value: unknown) => Record<string, unknown>} itemBuilder
+ * @param {string} valueKey - record property name used for descending sort
+ * @param {number} limit
+ * @returns {Array<Record<string, unknown>>}
+ */
+function rankTopByDesc(map, itemBuilder, valueKey, limit) {
+  return Object.entries(map)
+    .map(([k, v]) => itemBuilder(k, v))
+    .sort((a, b) => b[valueKey] - a[valueKey])
+    .slice(0, limit);
+}
+
+/**
  * Build a Map keyed by `keyFn(item)` for O(1) lookup.
  * @param {Array<unknown>} items
  * @param {(item: unknown) => string} keyFn - extracts the lookup key from each item
@@ -226,6 +244,7 @@ module.exports = {
   sumByKeys,
   mapFields,
   countBy,
+  rankTopByDesc,
   createLookupMap,
   resolveFromMap,
   initializeCounters,


### PR DESCRIPTION
## Refactoring

Extraction du pattern `Object.entries → map → sort desc → slice` dans un helper `rankTopByDesc(map, itemBuilder, valueKey, limit)` ajouté à `shared/aggregation-utils.js`. Les deux call sites dans `main/usage-helpers.js` (`buildPerProjectRanking` et `rankModifiedFiles`) utilisent désormais ce helper.

Closes #535

## Fichier(s) modifié(s)

- \`shared/aggregation-utils.js\` — ajout de \`rankTopByDesc\` (export)
- \`main/usage-helpers.js\` — utilise \`rankTopByDesc\` dans \`buildPerProjectRanking\` et \`rankModifiedFiles\`

## Vérifications

- [x] Build OK (\`npm run build\`)
- [x] Tests OK (\`npm test\` — 405/405)

---

📂 Path local : \`/Users/claude/flux/review/pikagent/\`
🤖 PR créée automatiquement par l'Agent Refactor