### PR TITLE
refactor: type _safe wrapper with JSDoc generics in skills-manager

### DIFF
--- a/main/skills-manager.js
+++ b/main/skills-manager.js
@@ -23,9 +23,11 @@ let _ensureRootDir = ensureDirOnce(DEFAULT_SKILLS_DIR);
  * Returns a new function with the same signature that catches errors
  * and returns `fallback` instead, logging via the module logger.
  *
- * @param {Function} fn       - named async function to wrap
- * @param {*} fallback        - value returned on error
- * @returns {Function}        - wrapped function (...args) => Promise<*>
+ * @template T
+ * @template {any[]} A
+ * @param {(...args: A) => Promise<T>} fn   - named async function to wrap
+ * @param {T} fallback                       - value returned on error
+ * @returns {(...args: A) => Promise<T>}    - wrapped function
  */
 const _safe = (fn, fallback) => (...args) =>
   trySafe(() => fn(...args), fallback, { log, label: fn.name || 'skills-op' });


### PR DESCRIPTION
## Refactoring

Renforcement des annotations JSDoc du wrapper higher-order `_safe` dans \`main/skills-manager.js\` : remplacement de \`{Function}\` et \`{*}\` (génériques) par des templates JSDoc-TS (\`@template T\`, \`@template {any[]} A\`) pour exprimer la préservation de signature entre l'entrée et la sortie. Régression de #456.

Closes #536

## Fichier(s) modifié(s)

- \`main/skills-manager.js\` — JSDoc du \`_safe\` wrapper

## Vérifications

- [x] Build OK (\`npm run build\`)
- [x] Tests OK (\`npm test\` — 405/405)

---

📂 Path local : \`/Users/claude/flux/review/pikagent/\`
🤖 PR créée automatiquement par l'Agent Refactor