### PR TITLE
refactor: split dom.js into domain-specific modules

### DIFF
--- a/src/utils/dom-element.js
+++ b/src/utils/dom-element.js
@@ -1,0 +1,68 @@
+/**
+ * DOM element creation utilities.
+ *
+ * Extracted from dom.js (issue #541) — contains core element factories:
+ *   _el, createActionButton
+ */
+import { onClickStopped } from './event-helpers.js';
+
+/**
+ * Create a DOM element.
+ *
+ * Supports two calling conventions:
+ *   _el('div', { className: 'c', textContent: 't', onClick: fn }, child...)  -- object attrs
+ *   _el('div', 'className', 'text' | { prop: v } | child...)               -- positional
+ *
+ * @param {string} tag
+ * @param {Record<string, unknown>|string|null} [attrsOrClass]
+ * @param {...(Node|string|Record<string, unknown>|null|false)} children
+ */
+export function _el(tag, attrsOrClass, ...children) {
+  const el = document.createElement(tag);
+  if (typeof attrsOrClass === 'string') {
+    if (attrsOrClass) el.className = attrsOrClass;
+  } else if (attrsOrClass) {
+    for (const [k, v] of Object.entries(attrsOrClass)) {
+      if (k === 'className') el.className = v;
+      else if (k === 'textContent') el.textContent = v;
+      else if (k === 'style' && typeof v === 'object') Object.assign(el.style, v);
+      else if (k.startsWith('on')) el.addEventListener(k.slice(2).toLowerCase(), v);
+      else el[k] = v;
+    }
+  }
+  for (const child of children) {
+    if (typeof child === 'string') el.appendChild(document.createTextNode(child));
+    else if (child && typeof child === 'object' && !(child instanceof Node)) Object.assign(el, child);
+    else if (child) el.appendChild(child);
+  }
+  return el;
+}
+
+/**
+ * Create a <button> element with common options.
+ *
+ * Unified factory that accepts both legacy (`label`, `className`) and
+ * short-form (`text`, `cls`) parameter names so every call-site can
+ * converge on a single helper.
+ *
+ * Supports text labels, child nodes (e.g. SVG icons), and optional
+ * stopPropagation wrapping on the click handler.
+ *
+ * @param {{ text?: string, label?: string, title?: string,
+ *           cls?: string, className?: string,
+ *           onClick?: (e: MouseEvent) => void, childNode?: Node,
+ *           stopPropagation?: boolean }} opts
+ * @returns {HTMLButtonElement}
+ */
+export function createActionButton({ text, label = '', title, cls, className, onClick, childNode, stopPropagation = false } = {}) {
+  const content = text ?? label;
+  const cssClass = cls ?? className ?? '';
+  const btn = _el('button', cssClass, content);
+  if (title) btn.title = title;
+  if (childNode) btn.appendChild(childNode);
+  if (onClick) {
+    if (stopPropagation) onClickStopped(btn, onClick);
+    else btn.addEventListener('click', onClick);
+  }
+  return btn;
+}

--- a/src/utils/dom-rendering.js
+++ b/src/utils/dom-rendering.js
@@ -1,0 +1,118 @@
+/**
+ * DOM rendering utilities.
+ *
+ * Extracted from dom.js (issue #541) — contains list/bar/row renderers:
+ *   renderButtonBar, buildDomainButtonBar, renderList, buildChevronRow
+ */
+import { _el, createActionButton } from './dom-element.js';
+
+/**
+ * Render a row of buttons from an array of config descriptors.
+ *
+ * Each entry in `configs` is an object with button properties
+ * (text, label, title, className, childNode, stopPropagation) plus an
+ * `action` key that maps into the `handlers` object.
+ *
+ * @param {{ containerClass: string,
+ *           configs: Array<{ action: string, text?: string, label?: string,
+ *                            title?: string, cls?: string, className?: string,
+ *                            childNode?: Node, stopPropagation?: boolean }>,
+ *           handlers: Record<string, (e: MouseEvent) => void> }} opts
+ * @returns {HTMLElement}
+ */
+export function renderButtonBar({ containerClass, configs, handlers }) {
+  const bar = _el('div', containerClass);
+  for (const cfg of configs) {
+    bar.appendChild(createActionButton({
+      text: cfg.text || cfg.label || '',
+      title: cfg.title,
+      cls: cfg.className || cfg.cls,
+      childNode: cfg.childNode,
+      stopPropagation: cfg.stopPropagation ?? false,
+      onClick: handlers[cfg.action],
+    }));
+  }
+  return bar;
+}
+
+/**
+ * Build a domain-specific button bar from a list of action definitions.
+ * Each action's `cls` is prefixed with `baseClass` and `stopPropagation` is set
+ * to true -- the two repetitive steps previously duplicated across renderers.
+ *
+ * @param {string} baseClass   - CSS class prefix for each button (e.g. "flow-card-btn")
+ * @param {string} containerClass - CSS class for the bar container
+ * @param {Array<{text: string, title: string, action: string, cls?: string}>} actions
+ * @param {Record<string, () => void>} handlers
+ * @returns {HTMLElement}
+ */
+export function buildDomainButtonBar(baseClass, containerClass, actions, handlers) {
+  const configs = actions.map(({ text, title, action, cls }) => ({
+    text,
+    title,
+    cls: cls ? `${baseClass} ${cls}` : baseClass,
+    action,
+    stopPropagation: true,
+  }));
+  return renderButtonBar({ containerClass, configs, handlers });
+}
+
+/**
+ * Clear a container and populate it by calling `renderItem` for each item.
+ * @param {HTMLElement} container
+ * @param {Array<unknown>} items
+ * @param {(item: unknown, index: number) => HTMLElement|null} renderItem
+ */
+export function renderList(container, items, renderItem) {
+  container.replaceChildren();
+  for (let i = 0; i < items.length; i++) {
+    const el = renderItem(items[i], i);
+    if (el) container.appendChild(el);
+  }
+}
+
+/**
+ * Build a row containing an optional chevron span and a name span.
+ *
+ * Used by file-tree rows, flow-category headers, and tab elements -- any
+ * place that needs the common "chevron + label" or "label-only" pattern.
+ *
+ * When `containerClass` is provided, a wrapper `<div>` is returned as `row`.
+ * An optional `depth` + `computeIndent` pair applies padding-left for
+ * tree-style indentation.
+ *
+ * When `chevronClass` is omitted or null, no chevron element is created and
+ * the returned `chevron` field is `null`.
+ *
+ * @param {{ chevronClass?: string|null, nameClass?: string|null,
+ *           name: string, chevronText?: string, containerClass?: string,
+ *           depth?: number, computeIndent?: (depth: number) => number,
+ *           prefixChildren?: HTMLElement[],
+ *           extraChildren?: HTMLElement[] }} opts
+ * @returns {{ chevron: HTMLElement|null, name: HTMLElement, row?: HTMLElement }}
+ */
+export function buildChevronRow(opts) {
+  const chevron = opts.chevronClass
+    ? _el('span', { className: opts.chevronClass, textContent: opts.chevronText || '' })
+    : null;
+  const name = _el('span', { className: opts.nameClass || '', textContent: opts.name });
+
+  if (opts.containerClass) {
+    const style = (opts.depth != null && opts.computeIndent)
+      ? { paddingLeft: `${opts.computeIndent(opts.depth)}px` }
+      : undefined;
+    const parts = [
+      ...(opts.prefixChildren || []),
+      ...(chevron ? [chevron] : []),
+      name,
+      ...(opts.extraChildren || []),
+    ];
+    const row = _el('div', {
+      className: opts.containerClass,
+      ...(style && { style }),
+    }, ...parts);
+    return { chevron, name, row };
+  }
+
+  return { chevron, name };
+}

--- a/src/utils/dom-visibility.js
+++ b/src/utils/dom-visibility.js
@@ -1,0 +1,16 @@
+/**
+ * DOM visibility utilities.
+ *
+ * Extracted from dom.js (issue #541) — contains visibility helpers:
+ *   _vis
+ */
+
+/**
+ * Toggle element visibility by setting display style.
+ * @param {HTMLElement} el
+ * @param {boolean} show
+ * @param {string} [display=''] - Display value when visible (e.g. 'flex', 'block').
+ */
+export function _vis(el, show, display = '') {
+  el.style.display = show ? display : 'none';
+}

--- a/src/utils/dom.js
+++ b/src/utils/dom.js
@@ -1,11 +1,18 @@
 /**
- * Core DOM utilities.
+ * Core DOM utilities — barrel re-export.
  *
- * This module keeps only the essential DOM factories:
- *   _el, _vis, createActionButton, renderButtonBar, renderList
+ * This module has been split into domain-specific sub-modules (issue #541):
+ *   - ./dom-element.js     (_el, createActionButton)
+ *   - ./dom-rendering.js   (renderButtonBar, buildDomainButtonBar, renderList, buildChevronRow)
+ *   - ./dom-visibility.js  (_vis)
  *
- * The following helpers have been extracted to dedicated modules — import
- * them directly from there instead of going through this file:
+ * All exports are re-exported here so that the 49 existing consumers
+ * keep working without any import-path changes.
+ *
+ * New code should import directly from the sub-module it needs.
+ *
+ * The following helpers were previously extracted to dedicated modules —
+ * import them directly from there:
  *   - createModalOverlay, showPromptDialog,
  *     showConfirmDialog                     → ./dom-dialogs.js
  *   - setupInlineInput, startInlineRename   → ./form-helpers.js
@@ -14,192 +21,8 @@
  *   - _safeFit                              → ./terminal-factory.js
  *   - createSelect                          → ./flow-modal-helpers.js (private)
  *   - positionInViewport                    → ./context-menu.js (private)
- *
- * All consumers now import directly from this module (dom-facades.js and
- * flow-dom.js were removed as redundant pass-through re-exports — see #462).
  */
-import { onClickStopped } from './event-helpers.js';
 
-/**
- * Create a DOM element.
- *
- * Supports two calling conventions:
- *   _el('div', { className: 'c', textContent: 't', onClick: fn }, child…)  — object attrs
- *   _el('div', 'className', 'text' | { prop: v } | child…)               — positional
- *
- * @param {string} tag
- * @param {Record<string, unknown>|string|null} [attrsOrClass]
- * @param {...(Node|string|Record<string, unknown>|null|false)} children
- */
-export function _el(tag, attrsOrClass, ...children) {
-  const el = document.createElement(tag);
-  if (typeof attrsOrClass === 'string') {
-    if (attrsOrClass) el.className = attrsOrClass;
-  } else if (attrsOrClass) {
-    for (const [k, v] of Object.entries(attrsOrClass)) {
-      if (k === 'className') el.className = v;
-      else if (k === 'textContent') el.textContent = v;
-      else if (k === 'style' && typeof v === 'object') Object.assign(el.style, v);
-      else if (k.startsWith('on')) el.addEventListener(k.slice(2).toLowerCase(), v);
-      else el[k] = v;
-    }
-  }
-  for (const child of children) {
-    if (typeof child === 'string') el.appendChild(document.createTextNode(child));
-    else if (child && typeof child === 'object' && !(child instanceof Node)) Object.assign(el, child);
-    else if (child) el.appendChild(child);
-  }
-  return el;
-}
-
-/**
- * Create a <button> element with common options.
- *
- * Unified factory that accepts both legacy (`label`, `className`) and
- * short-form (`text`, `cls`) parameter names so every call-site can
- * converge on a single helper.
- *
- * Supports text labels, child nodes (e.g. SVG icons), and optional
- * stopPropagation wrapping on the click handler.
- *
- * @param {{ text?: string, label?: string, title?: string,
- *           cls?: string, className?: string,
- *           onClick?: (e: MouseEvent) => void, childNode?: Node,
- *           stopPropagation?: boolean }} opts
- * @returns {HTMLButtonElement}
- */
-export function createActionButton({ text, label = '', title, cls, className, onClick, childNode, stopPropagation = false } = {}) {
-  const content = text ?? label;
-  const cssClass = cls ?? className ?? '';
-  const btn = _el('button', cssClass, content);
-  if (title) btn.title = title;
-  if (childNode) btn.appendChild(childNode);
-  if (onClick) {
-    if (stopPropagation) onClickStopped(btn, onClick);
-    else btn.addEventListener('click', onClick);
-  }
-  return btn;
-}
-
-/**
- * Render a row of buttons from an array of config descriptors.
- *
- * Each entry in `configs` is an object with button properties
- * (text, label, title, className, childNode, stopPropagation) plus an
- * `action` key that maps into the `handlers` object.
- *
- * @param {{ containerClass: string,
- *           configs: Array<{ action: string, text?: string, label?: string,
- *                            title?: string, cls?: string, className?: string,
- *                            childNode?: Node, stopPropagation?: boolean }>,
- *           handlers: Record<string, (e: MouseEvent) => void> }} opts
- * @returns {HTMLElement}
- */
-export function renderButtonBar({ containerClass, configs, handlers }) {
-  const bar = _el('div', containerClass);
-  for (const cfg of configs) {
-    bar.appendChild(createActionButton({
-      text: cfg.text || cfg.label || '',
-      title: cfg.title,
-      cls: cfg.className || cfg.cls,
-      childNode: cfg.childNode,
-      stopPropagation: cfg.stopPropagation ?? false,
-      onClick: handlers[cfg.action],
-    }));
-  }
-  return bar;
-}
-
-/**
- * Build a domain-specific button bar from a list of action definitions.
- * Each action's `cls` is prefixed with `baseClass` and `stopPropagation` is set
- * to true — the two repetitive steps previously duplicated across renderers.
- *
- * @param {string} baseClass   - CSS class prefix for each button (e.g. "flow-card-btn")
- * @param {string} containerClass - CSS class for the bar container
- * @param {Array<{text: string, title: string, action: string, cls?: string}>} actions
- * @param {Record<string, () => void>} handlers
- * @returns {HTMLElement}
- */
-export function buildDomainButtonBar(baseClass, containerClass, actions, handlers) {
-  const configs = actions.map(({ text, title, action, cls }) => ({
-    text,
-    title,
-    cls: cls ? `${baseClass} ${cls}` : baseClass,
-    action,
-    stopPropagation: true,
-  }));
-  return renderButtonBar({ containerClass, configs, handlers });
-}
-
-/**
- * Clear a container and populate it by calling `renderItem` for each item.
- * @param {HTMLElement} container
- * @param {Array<unknown>} items
- * @param {(item: unknown, index: number) => HTMLElement|null} renderItem
- */
-/**
- * Toggle element visibility by setting display style.
- * @param {HTMLElement} el
- * @param {boolean} show
- * @param {string} [display=''] - Display value when visible (e.g. 'flex', 'block').
- */
-export function _vis(el, show, display = '') {
-  el.style.display = show ? display : 'none';
-}
-
-export function renderList(container, items, renderItem) {
-  container.replaceChildren();
-  for (let i = 0; i < items.length; i++) {
-    const el = renderItem(items[i], i);
-    if (el) container.appendChild(el);
-  }
-}
-
-/**
- * Build a row containing an optional chevron span and a name span.
- *
- * Used by file-tree rows, flow-category headers, and tab elements — any
- * place that needs the common "chevron + label" or "label-only" pattern.
- *
- * When `containerClass` is provided, a wrapper `<div>` is returned as `row`.
- * An optional `depth` + `computeIndent` pair applies padding-left for
- * tree-style indentation.
- *
- * When `chevronClass` is omitted or null, no chevron element is created and
- * the returned `chevron` field is `null`.
- *
- * @param {{ chevronClass?: string|null, nameClass?: string|null,
- *           name: string, chevronText?: string, containerClass?: string,
- *           depth?: number, computeIndent?: (depth: number) => number,
- *           prefixChildren?: HTMLElement[],
- *           extraChildren?: HTMLElement[] }} opts
- * @returns {{ chevron: HTMLElement|null, name: HTMLElement, row?: HTMLElement }}
- */
-export function buildChevronRow(opts) {
-  const chevron = opts.chevronClass
-    ? _el('span', { className: opts.chevronClass, textContent: opts.chevronText || '' })
-    : null;
-  const name = _el('span', { className: opts.nameClass || '', textContent: opts.name });
-
-  if (opts.containerClass) {
-    const style = (opts.depth != null && opts.computeIndent)
-      ? { paddingLeft: `${opts.computeIndent(opts.depth)}px` }
-      : undefined;
-    const parts = [
-      ...(opts.prefixChildren || []),
-      ...(chevron ? [chevron] : []),
-      name,
-      ...(opts.extraChildren || []),
-    ];
-    const row = _el('div', {
-      className: opts.containerClass,
-      ...(style && { style }),
-    }, ...parts);
-    return { chevron, name, row };
-  }
-
-  return { chevron, name };
-}
-
-
+export { _el, createActionButton } from './dom-element.js';
+export { renderButtonBar, buildDomainButtonBar, renderList, buildChevronRow } from './dom-rendering.js';
+export { _vis } from './dom-visibility.js';


### PR DESCRIPTION
## Refactoring

Decoupage de dom.js (hotspot importe par 49+ fichiers) en sous-modules par responsabilite. dom.js conserve comme barrel re-export pour compatibilite.

Closes #541

## Fichier(s) modifie(s)

- `src/utils/dom.js` (transforme en barrel re-export)
- `src/utils/dom-element.js` (nouveau - _el, createActionButton)
- `src/utils/dom-rendering.js` (nouveau - renderButtonBar, buildDomainButtonBar, renderList, buildChevronRow)
- `src/utils/dom-visibility.js` (nouveau - _vis)

## Verifications

- [x] Tests OK (27 fichiers, 408 tests)
- [x] Aucun import existant modifie - barrel re-export preserve la compatibilite

---

PR creee automatiquement par l'Agent Refactor