### PR TITLE
refactor: extract shared UI rendering patterns

### DIFF
--- a/src/components/flow-modal.js
+++ b/src/components/flow-modal.js
@@ -1,5 +1,5 @@
 import { generateId } from '../utils/id.js';
-import { _el, createActionButton } from '../utils/dom.js';
+import { _el, createActionButton, toggleInSet } from '../utils/dom.js';
 import { createModalOverlay } from '../utils/dom-dialogs.js';
 import {
   SCHEDULE_LABELS, DAY_NAMES, WEEKDAY_INDICES, INTERVAL_HOURS,
@@ -132,7 +132,7 @@ function _buildDaysChip(existing) {
       cls: 'flow-day-btn',
       onClick: (e) => {
         e.preventDefault();
-        selectedDays.has(d) ? selectedDays.delete(d) : selectedDays.add(d);
+        toggleInSet(selectedDays, d);
         dayBtn.classList.toggle('active');
       },
     });

--- a/src/components/flow-view.js
+++ b/src/components/flow-view.js
@@ -1,6 +1,6 @@
 import { registerComponent, getComponent } from '../utils/component-registry.js';
 import { ComponentBase } from '../utils/component-base.js';
-import { moveFlowInOrder } from '../utils/flow-view-helpers.js';
+import { moveFlowInOrder, toggleInSet } from '../utils/flow-view-helpers.js';
 import {
   addCategory, renameCategoryInline, deleteCategory,
 } from '../utils/flow-view-categories.js';
@@ -99,8 +99,7 @@ export class FlowView extends ComponentBase {
   }
 
   _toggleCollapse(catId) {
-    if (this._collapsedCategories.has(catId)) this._collapsedCategories.delete(catId);
-    else this._collapsedCategories.add(catId);
+    toggleInSet(this._collapsedCategories, catId);
     this._renderList();
   }
 

--- a/src/components/settings-appearance.js
+++ b/src/components/settings-appearance.js
@@ -6,7 +6,7 @@ import { TERMINAL_THEMES, getTerminalThemeName, setTerminalTheme, getTerminalThe
 import { getAppTheme, setAppTheme } from '../utils/app-theme.js';
 import { _el, createActionButton } from '../utils/dom.js';
 import { MODE_BUTTONS, THEME_PREVIEW_LINES, COLOR_DOT_KEYS } from '../utils/settings-helpers.js';
-import { buildSettingsSection, createSettingsItem } from '../utils/settings-section-builder.js';
+import { buildSettingsSection, createListItem } from '../utils/settings-section-builder.js';
 import { registerComponent } from '../utils/component-registry.js';
 import { createAsyncHandler } from '../utils/event-helpers.js';
 
@@ -53,7 +53,7 @@ function _buildThemePreview(name, theme) {
 }
 
 function _createThemeCard(name, theme, isActive, tabManager, renderAppearanceFn) {
-  return createSettingsItem({
+  return createListItem({
     cls: 'theme-card',
     isActive,
     activeCls: 'theme-active',

--- a/src/components/settings-configs.js
+++ b/src/components/settings-configs.js
@@ -4,7 +4,7 @@
  */
 import { _el } from '../utils/dom.js';
 import { CONFIG_ACTIONS, BOTTOM_CONFIG_BUTTONS, formatConfigMeta } from '../utils/settings-helpers.js';
-import { buildSettingsSection, createActionBar, createSettingsItem } from '../utils/settings-section-builder.js';
+import { buildSettingsSection, createActionBar, createListItem } from '../utils/settings-section-builder.js';
 import { registerComponent } from '../utils/component-registry.js';
 import configApi from '../services/config-api.js';
 
@@ -42,7 +42,7 @@ function _buildConfigRowLeft(config) {
 }
 
 function _createConfigRow(config, currentName, tabManager, renderConfigsFn) {
-  return createSettingsItem({
+  return createListItem({
     cls: 'config-row',
     isActive: config.name === currentName,
     activeCls: 'config-active',

--- a/src/components/settings-keybindings.js
+++ b/src/components/settings-keybindings.js
@@ -5,7 +5,7 @@
 import { formatCombo } from '../utils/shortcut-helpers.js';
 import { _el, createActionButton } from '../utils/dom.js';
 import { onClickStopped } from '../utils/event-helpers.js';
-import { buildSettingsSection, createSettingsItem } from '../utils/settings-section-builder.js';
+import { buildSettingsSection, createListItem } from '../utils/settings-section-builder.js';
 import { registerComponent } from '../utils/component-registry.js';
 
 /**
@@ -68,7 +68,7 @@ function _buildKeysContainer(binding, shortcutManager, startRecordingFn, renderK
 }
 
 function _renderBindingRow(binding, shortcutManager, startRecordingFn, renderKeybindingsFn) {
-  return createSettingsItem({
+  return createListItem({
     cls: 'keybinding-row',
     content: [
       _el('div', 'keybinding-label', binding.label),

--- a/src/utils/dom.js
+++ b/src/utils/dom.js
@@ -157,6 +157,40 @@ export function renderList(container, items, renderItem) {
 }
 
 /**
+ * Toggle a value in a Set (add if absent, delete if present).
+ * Centralises the repeated `set.has(v) ? set.delete(v) : set.add(v)` pattern
+ * found across flow-view, tab-color-filter, flow-modal, etc.
+ *
+ * @param {Set<unknown>} set
+ * @param {unknown} value
+ * @returns {boolean} true if the value is now in the set
+ */
+export function toggleInSet(set, value) {
+  if (set.has(value)) { set.delete(value); return false; }
+  set.add(value);
+  return true;
+}
+
+/**
+ * Toggle a collapsible section: flip the `collapsed` CSS class on `contentEl`
+ * and update `chevronEl` text between `expandedText` and `collapsedText`.
+ *
+ * Extracts the repeated pattern shared by file-tree-section-dom and similar
+ * collapsible UI widgets.
+ *
+ * @param {HTMLElement} contentEl  - element whose `collapsed` class is toggled
+ * @param {HTMLElement} chevronEl  - chevron element whose textContent is updated
+ * @param {string} expandedText    - chevron text when section is expanded
+ * @param {string} collapsedText   - chevron text when section is collapsed
+ * @returns {boolean} true if the section is now collapsed
+ */
+export function toggleCollapsible(contentEl, chevronEl, expandedText, collapsedText) {
+  const collapsed = contentEl.classList.toggle('collapsed');
+  chevronEl.textContent = collapsed ? collapsedText : expandedText;
+  return collapsed;
+}
+
+/**
  * Build a row containing an optional chevron span and a name span.
  *
  * Used by file-tree rows, flow-category headers, and tab elements — any

--- a/src/utils/file-tree-section-dom.js
+++ b/src/utils/file-tree-section-dom.js
@@ -8,8 +8,7 @@
  * @typedef {{ setupDropZone: (el: HTMLElement, targetDir: string|(() => string|null)) => void, promptNewEntry: (dirPath: string, cEl: HTMLElement, depth: number, eDirs: Set<string>, type: string) => void, promptRename: (path: string, nameEl: HTMLElement) => void, refreshSection: (cwd: string) => void, contextMenuApi: unknown }} SectionDOMCallbacks
  */
 
-import { _el } from './dom.js';
-import { buildChevronRow } from './dom.js';
+import { _el, buildChevronRow, toggleCollapsible } from './dom.js';
 import { attachContextMenu } from './context-menu.js';
 import { emitWorkspaceCreateWorktree, emitWorkspaceOpenPr } from './workspace-events.js';
 import {
@@ -70,8 +69,7 @@ function _buildSectionHeader(cwd, contentEl, wasCollapsed, expandedDirs, callbac
   labelEl.title = cwd;
 
   header.addEventListener('click', () => {
-    const collapsed = contentEl.classList.toggle('collapsed');
-    chevron.textContent = collapsed ? CHEVRON_COLLAPSED : CHEVRON_EXPANDED;
+    toggleCollapsible(contentEl, chevron, CHEVRON_EXPANDED, CHEVRON_COLLAPSED);
   });
 
   attachContextMenu(header, () => buildDirContextItems(

--- a/src/utils/flow-view-helpers.js
+++ b/src/utils/flow-view-helpers.js
@@ -7,17 +7,9 @@ import { formatDateTime } from '../../shared/date-utils.js';
 import { getLastRun } from '../../shared/flow-utils.js';
 import { countBy, createLookupMap, resolveFromMap } from '../../shared/aggregation-utils.js';
 
-/**
- * Toggle a value in a Set (add if absent, delete if present).
- * @param {Set<string>} set
- * @param {string} value
- * @returns {boolean} true if the value is now in the set
- */
-export function toggleInSet(set, value) {
-  if (set.has(value)) { set.delete(value); return false; }
-  set.add(value);
-  return true;
-}
+// Re-export toggleInSet from its canonical location in dom.js so that
+// existing consumers of flow-view-helpers continue to work unchanged.
+export { toggleInSet } from './dom.js';
 
 export const FIT_DELAY_MS = 50;
 export const LOG_SCROLLBACK = 5000;

--- a/src/utils/settings-section-builder.js
+++ b/src/utils/settings-section-builder.js
@@ -7,11 +7,14 @@ import { _el, renderButtonBar, renderList } from './dom.js';
 import { createAsyncHandler } from './event-helpers.js';
 
 /**
- * Create a settings row or card container with optional active state and click handler.
+ * Create a list-item / row / card container with optional active state and click handler.
  *
- * Encapsulates the repeated pattern across settings components where a container
- * element is created, conditionally receives an "active" CSS class, and optionally
- * gets a click handler attached.
+ * Encapsulates the repeated pattern across settings components (and other list
+ * renderers) where a container element is created, conditionally receives an
+ * "active" CSS class, and optionally gets a click handler attached.
+ *
+ * Exported as both `createListItem` (generic name) and `createSettingsItem`
+ * (legacy alias kept for backward compatibility with existing consumers).
  *
  * @param {{
  *   cls: string,
@@ -22,7 +25,7 @@ import { createAsyncHandler } from './event-helpers.js';
  * }} opts
  * @returns {HTMLElement}
  */
-export function createSettingsItem({ cls, content, isActive = false, activeCls, onClick }) {
+export function createListItem({ cls, content, isActive = false, activeCls, onClick }) {
   const el = _el('div', cls);
   if (isActive && activeCls) el.classList.add(activeCls);
 
@@ -43,6 +46,9 @@ export function createSettingsItem({ cls, content, isActive = false, activeCls, 
 
   return el;
 }
+
+/** @deprecated Use {@link createListItem} instead. */
+export const createSettingsItem = createListItem;
 
 /**
  * Build a settings section and populate the given container.

--- a/src/utils/tab-color-filter.js
+++ b/src/utils/tab-color-filter.js
@@ -2,7 +2,7 @@
  * Color filter logic for tab manager.
  * Extracted from tab-manager.js to reduce component size.
  */
-import { _el } from './dom.js';
+import { _el, toggleInSet } from './dom.js';
 import { COLOR_GROUPS } from './tab-constants.js';
 import { attachContextMenu } from './context-menu.js';
 
@@ -46,8 +46,7 @@ export function setColorFilter(state, colorGroupId, renderTabBar, ensureVisibleT
  */
 export function toggleExcludeColor(state, colorGroupId, renderTabBar, ensureVisibleTabActive) {
   state.activeColorFilter = null;
-  if (state.excludedColors.has(colorGroupId)) state.excludedColors.delete(colorGroupId);
-  else state.excludedColors.add(colorGroupId);
+  toggleInSet(state.excludedColors, colorGroupId);
   renderTabBar();
   ensureVisibleTabActive();
 }


### PR DESCRIPTION
## Refactoring

Extraction de patterns UI dupliqués dans les settings et composants de listes :
1. Factory `createSettingsItem` renommée en `createListItem` pour les sections settings (alias backward-compat conservé)
2. `toggleInSet` centralisé dans `dom.js` et utilisé dans flow-view, tab-color-filter, flow-modal
3. Helper `toggleCollapsible` extrait dans `dom.js` pour file-tree-section-dom
4. Migration des 3 settings components vers `createListItem`

Closes #530

## Fichier(s) modifié(s)

- `src/utils/dom.js` — ajout de `toggleInSet` et `toggleCollapsible`
- `src/utils/settings-section-builder.js` — rename `createSettingsItem` -> `createListItem` + alias
- `src/utils/flow-view-helpers.js` — re-export `toggleInSet` depuis dom.js
- `src/utils/file-tree-section-dom.js` — utilisation de `toggleCollapsible`
- `src/utils/tab-color-filter.js` — utilisation de `toggleInSet`
- `src/components/flow-view.js` — utilisation de `toggleInSet`
- `src/components/flow-modal.js` — utilisation de `toggleInSet`
- `src/components/settings-appearance.js` — migration vers `createListItem`
- `src/components/settings-configs.js` — migration vers `createListItem`
- `src/components/settings-keybindings.js` — migration vers `createListItem`

## Notes

- `buildDomainButtonBar` est déjà utilisé de manière cohérente via `createActionBar` dans settings-configs — pas de changement nécessaire.
- Le pattern toggle dans `workspace-resize.js` est structurellement différent (animation, arrow avec title) — pas refactoré pour éviter les risques.
- L'alias `createSettingsItem` est conservé avec `@deprecated` pour la backward compatibility.

## Vérifications

- [x] Tests OK (405 passed, 27 test files)

---

Path local : `/Users/rekta/projet/coding/refactor-pikagent`
PR créée automatiquement par l'Agent Refactor