### PR TITLE
refactor: extract composeFacade helper for domain facade boilerplate (closes #546)

### DIFF
--- a/src/components/terminal-panel.js
+++ b/src/components/terminal-panel.js
@@ -24,7 +24,8 @@ export class TerminalPanel {
     this.container = container;
     this.cwd = cwd;
     this._initState();
-    this._initApi();
+    // Injected API methods forwarded to TerminalInstance (read-only, never mutated).
+    this._terminalApi = terminalPanelFacade;
     this._initDragState();
     this.init();
   }
@@ -33,22 +34,6 @@ export class TerminalPanel {
     this.root = null;
     this.activeTerminal = null;
     this.terminals = new Map();
-  }
-
-  _initApi() {
-    // Injected API methods forwarded to TerminalInstance
-    this._terminalApi = {
-      openExternal: terminalPanelFacade.openExternal,
-      homedir: terminalPanelFacade.homedir,
-      openPath: terminalPanelFacade.openPath,
-      ptyWrite: terminalPanelFacade.ptyWrite,
-      ptyOnData: terminalPanelFacade.ptyOnData,
-      ptyOnExit: terminalPanelFacade.ptyOnExit,
-      ptyCreate: terminalPanelFacade.ptyCreate,
-      ptyGetCwd: terminalPanelFacade.ptyGetCwd,
-      ptyResize: terminalPanelFacade.ptyResize,
-      ptyKill: terminalPanelFacade.ptyKill,
-    };
   }
 
   _initDragState() {

--- a/src/facades/board-facade.js
+++ b/src/facades/board-facade.js
@@ -7,15 +7,10 @@
 import ptyApi from '../services/terminal-api.js';
 import shellApi from '../services/shell-api.js';
 import fsApi from '../services/fs-api.js';
+import { composeFacade } from './compose-facade.js';
 
-export const boardFacade = {
-  // shell
-  openExternal: (...a) => shellApi.openExternal(...a),
-  openPath:     (...a) => shellApi.openPath(...a),
-  // fs
-  homedir:      (...a) => fsApi.homedir(...a),
-  // pty
-  ptyWrite:       (...a) => ptyApi.write(...a),
-  ptyOnData:      (...a) => ptyApi.onData(...a),
-  ptyCheckAgents: (...a) => ptyApi.checkAgents(...a),
-};
+export const boardFacade = composeFacade([
+  [shellApi, ['openExternal', 'openPath']],
+  [fsApi, ['homedir']],
+  [ptyApi, { ptyWrite: 'write', ptyOnData: 'onData', ptyCheckAgents: 'checkAgents' }],
+]);

--- a/src/facades/compose-facade.js
+++ b/src/facades/compose-facade.js
@@ -1,0 +1,34 @@
+/**
+ * Helper to build a domain facade from a service→methods map.
+ *
+ * Each domain facade is a flat object of trivial delegation wrappers
+ * (`alias: (...a) => service.method(...a)`). `composeFacade` removes that
+ * boilerplate: it takes a list of `[service, methods]` entries and generates
+ * the variadic wrappers automatically.
+ *
+ * `methods` accepts two forms:
+ *  - an array of strings — same name on facade and service (identity), e.g.
+ *    `['homedir', 'copy']` produces `{ homedir, copy }` delegating to `service.homedir` / `service.copy`.
+ *  - an object `{ facadeKey: 'serviceMethod' }` — renamed wrappers, e.g.
+ *    `{ gitBranch: 'branch' }` produces `gitBranch` delegating to `service.branch`.
+ *
+ * @param {Array<[Record<string, (...a: unknown[]) => unknown>, string[] | Record<string, string>]>} entries
+ *   list of `[service, methods]` pairs
+ * @returns {Record<string, (...a: unknown[]) => unknown>} the composed facade object
+ */
+export function composeFacade(entries) {
+  /** @type {Record<string, (...a: unknown[]) => unknown>} */
+  const facade = {};
+
+  for (const [service, methods] of entries) {
+    const pairs = Array.isArray(methods)
+      ? methods.map((name) => /** @type {[string, string]} */ ([name, name]))
+      : Object.entries(methods);
+
+    for (const [facadeKey, serviceMethod] of pairs) {
+      facade[facadeKey] = (...a) => service[serviceMethod](...a);
+    }
+  }
+
+  return facade;
+}

--- a/src/facades/file-tree-facade.js
+++ b/src/facades/file-tree-facade.js
@@ -7,21 +7,10 @@
 import fsApi from '../services/fs-api.js';
 import shellApi from '../services/shell-api.js';
 import clipboardApi from '../services/clipboard-api.js';
+import { composeFacade } from './compose-facade.js';
 
-export const fileTreeViewFacade = {
-  // fs
-  copy:       (...a) => fsApi.copy(...a),
-  copyTo:     (...a) => fsApi.copyTo(...a),
-  rename:     (...a) => fsApi.rename(...a),
-  mkdir:      (...a) => fsApi.mkdir(...a),
-  writefile:  (...a) => fsApi.writefile(...a),
-  readdir:    (...a) => fsApi.readdir(...a),
-  watch:      (...a) => fsApi.watch(...a),
-  unwatch:    (...a) => fsApi.unwatch(...a),
-  onChanged:  (...a) => fsApi.onChanged(...a),
-  trash:      (...a) => fsApi.trash(...a),
-  // shell
-  showInFolder: (...a) => shellApi.showInFolder(...a),
-  // clipboard
-  clipboardWrite: (...a) => clipboardApi.write(...a),
-};
+export const fileTreeViewFacade = composeFacade([
+  [fsApi, ['copy', 'copyTo', 'rename', 'mkdir', 'writefile', 'readdir', 'watch', 'unwatch', 'onChanged', 'trash']],
+  [shellApi, ['showInFolder']],
+  [clipboardApi, { clipboardWrite: 'write' }],
+]);

--- a/src/facades/skills-facade.js
+++ b/src/facades/skills-facade.js
@@ -7,19 +7,10 @@
 import skillsApi from '../services/skills-api.js';
 import shellApi from '../services/shell-api.js';
 import dialogApi from '../services/dialog-api.js';
+import { composeFacade } from './compose-facade.js';
 
-export const skillsViewFacade = {
-  // skills
-  list:         (...a) => skillsApi.list(...a),
-  getRoot:      (...a) => skillsApi.getRoot(...a),
-  read:         (...a) => skillsApi.read(...a),
-  write:        (...a) => skillsApi.write(...a),
-  importSkill:  (...a) => skillsApi.importSkill(...a),
-  create:       (...a) => skillsApi.create(...a),
-  deleteSkill:  (...a) => skillsApi.deleteSkill(...a),
-  setRoot:      (...a) => skillsApi.setRoot(...a),
-  // shell
-  openPath:     (...a) => shellApi.openPath(...a),
-  // dialog
-  openFolder:   (...a) => dialogApi.openFolder(...a),
-};
+export const skillsViewFacade = composeFacade([
+  [skillsApi, ['list', 'getRoot', 'read', 'write', 'importSkill', 'create', 'deleteSkill', 'setRoot']],
+  [shellApi, ['openPath']],
+  [dialogApi, ['openFolder']],
+]);

--- a/src/facades/tab-facade.js
+++ b/src/facades/tab-facade.js
@@ -11,13 +11,10 @@
 import gitApi from '../services/git-api.js';
 import fsApi from '../services/fs-api.js';
 import configApi from '../services/config-api.js';
+import { composeFacade } from './compose-facade.js';
 
-export const tabViewFacade = {
-  // git
-  gitBranch:    (...a) => gitApi.branch(...a),
-  // fs
-  homedir:      (...a) => fsApi.homedir(...a),
-  // config
-  getDefault:   (...a) => configApi.getDefault(...a),
-  loadDefault:  (...a) => configApi.loadDefault(...a),
-};
+export const tabViewFacade = composeFacade([
+  [gitApi, { gitBranch: 'branch' }],
+  [fsApi, ['homedir']],
+  [configApi, ['getDefault', 'loadDefault']],
+]);

--- a/src/facades/terminal-panel-facade.js
+++ b/src/facades/terminal-panel-facade.js
@@ -7,19 +7,18 @@
 import ptyApi from '../services/terminal-api.js';
 import shellApi from '../services/shell-api.js';
 import fsApi from '../services/fs-api.js';
+import { composeFacade } from './compose-facade.js';
 
-export const terminalPanelFacade = {
-  // shell
-  openExternal: (...a) => shellApi.openExternal(...a),
-  openPath:     (...a) => shellApi.openPath(...a),
-  // fs
-  homedir:      (...a) => fsApi.homedir(...a),
-  // pty
-  ptyWrite:     (...a) => ptyApi.write(...a),
-  ptyOnData:    (...a) => ptyApi.onData(...a),
-  ptyOnExit:    (...a) => ptyApi.onExit(...a),
-  ptyCreate:    (...a) => ptyApi.create(...a),
-  ptyGetCwd:    (...a) => ptyApi.getCwd(...a),
-  ptyResize:    (...a) => ptyApi.resize(...a),
-  ptyKill:      (...a) => ptyApi.kill(...a),
-};
+export const terminalPanelFacade = composeFacade([
+  [shellApi, ['openExternal', 'openPath']],
+  [fsApi, ['homedir']],
+  [ptyApi, {
+    ptyWrite: 'write',
+    ptyOnData: 'onData',
+    ptyOnExit: 'onExit',
+    ptyCreate: 'create',
+    ptyGetCwd: 'getCwd',
+    ptyResize: 'resize',
+    ptyKill: 'kill',
+  }],
+]);


### PR DESCRIPTION
## Refactoring

Élimination du boilerplate de wrappers de délégation dans la couche façade.

Nouveau helper `composeFacade(entries)` (`src/facades/compose-facade.js`) qui génère un objet façade à partir d'une liste de paires `[service, méthodes]` — `méthodes` étant un tableau de noms (identité) ou un objet `{ cléFaçade: 'méthodeService' }` (alias). Les 5 façades de domaine sont réécrites avec ce helper, supprimant ~60 lignes de wrappers variadiques quasi identiques.

`TerminalPanel._initApi()` reconstruisait un objet `_terminalApi` re-listant 1:1 les 10 méthodes de `terminalPanelFacade`. Vérification faite : `_terminalApi` est uniquement transmis à `createTerminalNode` puis à `TerminalInstance` (qui ne fait que lire/appeler ses méthodes, jamais de mutation). `_initApi` est donc supprimé et remplacé par une assignation directe `this._terminalApi = terminalPanelFacade`.

Comportement public strictement identique : mêmes clés, même délégation, aucune logique métier modifiée.

Closes #546

## Fichier(s) modifié(s)

- `src/facades/compose-facade.js` (nouveau — helper `composeFacade`)
- `src/facades/board-facade.js`
- `src/facades/file-tree-facade.js`
- `src/facades/skills-facade.js`
- `src/facades/tab-facade.js`
- `src/facades/terminal-panel-facade.js`
- `src/components/terminal-panel.js` (suppression de `_initApi`)

## Vérifications

- [x] Build OK
- [x] Tests OK (405/405)

---

📂 Path local : `/Users/claude/flux/review/pikagent/`
🤖 PR créée automatiquement par l'Agent Refactor