### PR TITLE
refactor: extract buildTabBar helper for active-tab bars (closes #547)

### DIFF
--- a/src/components/settings-modal.js
+++ b/src/components/settings-modal.js
@@ -1,5 +1,5 @@
 import { formatCombo, eventToCombo } from '../utils/shortcut-helpers.js';
-import { _el, createActionButton } from '../utils/dom.js';
+import { _el, createActionButton, buildTabBar } from '../utils/dom.js';
 import { createModalOverlay } from '../utils/dom-dialogs.js';
 import { MODAL_CLOSE_TRANSITION_MS, MODIFIER_KEYS, NAV_SECTIONS } from '../utils/settings-helpers.js';
 import { getComponent } from '../utils/component-registry.js';
@@ -50,19 +50,22 @@ export class SettingsModal {
 
   _buildBody() {
     const body = _el('div', 'settings-body');
-    const nav = _el('div', 'settings-nav');
 
-    this.navItems = {};
-    for (const { key, label } of NAV_SECTIONS) {
-      const item = _el('div', 'settings-nav-item', label);
-      if (key === this.activeSection) item.classList.add('active');
-      item.addEventListener('click', () => this.showSection(key));
-      nav.appendChild(item);
-      this.navItems[key] = item;
-    }
+    const { bar, setActive } = buildTabBar(
+      NAV_SECTIONS.map(({ key, label }) => ({ id: key, label })),
+      {
+        activeId: this.activeSection,
+        barClass: 'settings-nav',
+        tag: 'div',
+        itemClass: 'settings-nav-item',
+        activeClass: 'active',
+        onSelect: (key) => this.showSection(key),
+      },
+    );
+    this._setActiveNav = setActive;
 
     this.content = _el('div', 'settings-content');
-    body.appendChild(nav);
+    body.appendChild(bar);
     body.appendChild(this.content);
     return body;
   }
@@ -70,9 +73,7 @@ export class SettingsModal {
   showSection(section) {
     if (this._updateUnsub) { this._updateUnsub(); this._updateUnsub = null; }
     this.activeSection = section;
-    for (const [key, el] of Object.entries(this.navItems)) {
-      el.classList.toggle('active', key === section);
-    }
+    this._setActiveNav(section);
     this.sectionRenderers[section]?.();
   }
 

--- a/src/components/usage-view.js
+++ b/src/components/usage-view.js
@@ -1,4 +1,4 @@
-import { _el } from '../utils/dom.js';
+import { _el, buildTabBar } from '../utils/dom.js';
 import { TABS, getTabConfig, createSection } from '../utils/usage-view-helpers.js';
 import { registerComponent } from '../utils/component-registry.js';
 import { ComponentBase } from '../utils/component-base.js';
@@ -26,23 +26,18 @@ export class UsageView extends ComponentBase {
       _el('button', { className: 'usage-refresh-btn', textContent: 'Refresh', onClick: () => this.render() }),
     ));
 
-    const tabBar = _el('div', { className: 'usage-tabs' });
-    const tabBtns = [];
-    for (const tab of TABS) {
-      const btn = _el('button', {
-        className: `usage-tab ${this.activeTab === tab.id ? 'usage-tab-active' : ''}`,
-        textContent: tab.label,
-        onClick: () => {
-          this.activeTab = tab.id;
-          this._renderBody();
-          for (const b of tabBtns) b.classList.remove('usage-tab-active');
-          btn.classList.add('usage-tab-active');
-        },
-      });
-      tabBtns.push(btn);
-      tabBar.appendChild(btn);
-    }
-    this.el.appendChild(tabBar);
+    const { bar, setActive } = buildTabBar(TABS, {
+      activeId: this.activeTab,
+      barClass: 'usage-tabs',
+      itemClass: 'usage-tab',
+      activeClass: 'usage-tab-active',
+      onSelect: (id) => {
+        this.activeTab = id;
+        this._renderBody();
+        setActive(id);
+      },
+    });
+    this.el.appendChild(bar);
 
     this.bodyEl = _el('div', { className: 'usage-body' });
     this.el.appendChild(this.bodyEl);

--- a/src/utils/dom.js
+++ b/src/utils/dom.js
@@ -2,7 +2,8 @@
  * Core DOM utilities.
  *
  * This module keeps only the essential DOM factories:
- *   _el, _vis, createActionButton, renderButtonBar, renderList
+ *   _el, _vis, createActionButton, renderButtonBar, renderList,
+ *   buildTabButton, buildTabBar
  *
  * The following helpers have been extracted to dedicated modules — import
  * them directly from there instead of going through this file:
@@ -154,6 +155,62 @@ export function renderList(container, items, renderItem) {
     const el = renderItem(items[i], i);
     if (el) container.appendChild(el);
   }
+}
+
+/**
+ * Build a single tab/nav element from an `{ id, label }` definition.
+ *
+ * Applies `itemClass` plus `activeClass` (when the item is currently active)
+ * and wires a `click` listener that invokes `onSelect(id)`.
+ *
+ * Shared building block for tab bars — used directly when a component owns
+ * its own container layout (e.g. mode bars that mix tabs with other
+ * controls), and internally by `buildTabBar`.
+ *
+ * @param {{ id: string, label: string }} item
+ * @param {{ activeId?: string, onSelect?: (id: string) => void,
+ *           tag?: string, itemClass: string, activeClass: string }} opts
+ * @returns {HTMLElement}
+ */
+export function buildTabButton(item, { activeId, onSelect, tag = 'button', itemClass, activeClass }) {
+  const isActive = item.id === activeId;
+  const el = _el(tag, isActive ? `${itemClass} ${activeClass}` : itemClass, item.label);
+  el.addEventListener('click', () => onSelect?.(item.id));
+  return el;
+}
+
+/**
+ * Build a tab/nav bar from a list of `{ id, label }` definitions.
+ *
+ * Each item becomes an element (`<button>` by default, override via `tag`)
+ * carrying `itemClass`, with `activeClass` toggled on the active one. Clicking
+ * an item invokes `onSelect(id)`.
+ *
+ * Returns the bar container plus a `setActive(id)` function that re-applies
+ * `activeClass` to the matching item only. Components that need extra side
+ * effects on selection (re-rendering a body, etc.) should do that work in
+ * `onSelect` and call `setActive` themselves.
+ *
+ * @param {Array<{ id: string, label: string }>} items
+ * @param {{ activeId?: string, onSelect?: (id: string) => void,
+ *           barClass?: string, tag?: string,
+ *           itemClass: string, activeClass: string }} opts
+ * @returns {{ bar: HTMLElement, setActive: (id: string) => void }}
+ */
+export function buildTabBar(items, { activeId, onSelect, barClass = '', tag = 'button', itemClass, activeClass }) {
+  const bar = _el('div', barClass);
+  const elements = new Map();
+  for (const item of items) {
+    const el = buildTabButton(item, { activeId, onSelect, tag, itemClass, activeClass });
+    elements.set(item.id, el);
+    bar.appendChild(el);
+  }
+  const setActive = (id) => {
+    for (const [itemId, el] of elements) {
+      el.classList.toggle(activeClass, itemId === id);
+    }
+  };
+  return { bar, setActive };
 }
 
 /**

--- a/src/utils/file-viewer-mode-bar.js
+++ b/src/utils/file-viewer-mode-bar.js
@@ -3,7 +3,7 @@
  * Extracted from file-viewer.js to reduce component size.
  */
 
-import { _el, renderList } from './dom.js';
+import { buildTabButton, renderList } from './dom.js';
 import { STATIC_MODES } from './editor-helpers.js';
 
 /**
@@ -16,11 +16,10 @@ import { STATIC_MODES } from './editor-helpers.js';
  */
 export function renderModeBar(modeBar, currentMode, { switchMode }, webviewMgr) {
   const allItems = [
-    ...STATIC_MODES.map(({ key, label }) => {
-      const btn = _el('button', `mode-btn${currentMode === key ? ' active' : ''}`, label);
-      btn.addEventListener('click', () => switchMode(key));
-      return btn;
-    }),
+    ...STATIC_MODES.map(({ key, label }) => buildTabButton(
+      { id: key, label },
+      { activeId: currentMode, onSelect: switchMode, itemClass: 'mode-btn', activeClass: 'active' },
+    )),
     ...webviewMgr.webviewTabs.map(wt => webviewMgr.buildWebviewModeBtn(wt, currentMode)),
     webviewMgr.buildAddWebviewBtn(modeBar),
   ];


### PR DESCRIPTION
## Refactoring

Trois composants construisaient indépendamment une barre d'onglets / navigation suivant le même schéma (itération sur `{ id, label }`, création d'un bouton, classe `active` conditionnelle, listener `click` qui rebascule la classe).

Deux helpers ont été ajoutés dans `src/utils/dom.js` :

- `buildTabButton(item, opts)` — construit un élément d'onglet unitaire (classe `itemClass` + `activeClass` conditionnelle + listener `click` → `onSelect(id)`). Bloc de construction réutilisable.
- `buildTabBar(items, opts)` — construit le conteneur complet et retourne `{ bar, setActive(id) }`. `setActive` centralise le toggle de classe sur le bon item uniquement.

Les trois call-sites sont réécrits :

- **usage-view** : `buildTabBar` ; le re-render du body reste dans `onSelect`, qui appelle `setActive` lui-même — comportement préservé.
- **settings-modal** : `buildTabBar` (tag `div`) ; `showSection` conserve sa logique métier (`_updateUnsub`, set `activeSection`, appel du renderer) et délègue le toggle de classe à `setActive`.
- **file-viewer-mode-bar** : la barre re-render entièrement et mélange onglets statiques + webview tabs + bouton "add" dans un même conteneur ; seule la création des boutons statiques est factorisée via `buildTabButton` (le `bar`/`setActive` de `buildTabBar` n'a pas de sens ici).

Aucune logique métier modifiée. Les classes CSS produites sont identiques.

Closes #547

## Fichier(s) modifié(s)

- `src/utils/dom.js` — ajout de `buildTabButton` et `buildTabBar`
- `src/components/usage-view.js` — call-site réécrit
- `src/components/settings-modal.js` — call-site réécrit
- `src/utils/file-viewer-mode-bar.js` — call-site réécrit

## Vérifications

- [x] Build OK
- [x] Tests OK (405 tests)

---

📂 Path local : `/Users/claude/flux/review/pikagent/`
🤖 PR créée automatiquement par l'Agent Refactor

🤖 Generated with [Claude Code](https://claude.com/claude-code)