### PR TITLE
refactor: extract buildViewHeader and renderStatusBar helpers (closes #548)

### DIFF
--- a/src/components/git-changes-view.js
+++ b/src/components/git-changes-view.js
@@ -1,5 +1,6 @@
 import { emitFileOpen } from '../utils/workspace-events.js';
 import { _el } from '../utils/dom.js';
+import { buildViewHeader } from '../utils/view-header.js';
 import { onClickStopped } from '../utils/event-helpers.js';
 import { STATUS_LABELS, CHEVRON, CHANGE_SECTIONS, computeTotalChanges, buildFileKey } from '../utils/git-changes-helpers.js';
 import { registerComponent, getComponent } from '../utils/component-registry.js';
@@ -48,10 +49,13 @@ export class GitChangesView extends ComponentBase {
   }
 
   _createHeader(total) {
-    return _el('div', { className: 'git-header' },
-      _el('span', { textContent: `Local Changes (${total})` }),
-      _el('span', { className: 'git-refresh-btn', textContent: '↻', title: 'Refresh', onClick: () => this.loadChanges() }),
-    );
+    return buildViewHeader({
+      baseClass: 'git',
+      title: `Local Changes (${total})`,
+      titleTag: 'span',
+      titleClass: null,
+      actions: _el('span', { className: 'git-refresh-btn', textContent: '↻', title: 'Refresh', onClick: () => this.loadChanges() }),
+    });
   }
 
   _renderChanges(changes) {

--- a/src/components/usage-view.js
+++ b/src/components/usage-view.js
@@ -1,4 +1,5 @@
 import { _el, buildTabBar } from '../utils/dom.js';
+import { buildViewHeader } from '../utils/view-header.js';
 import { TABS, getTabConfig, createSection } from '../utils/usage-view-helpers.js';
 import { registerComponent } from '../utils/component-registry.js';
 import { ComponentBase } from '../utils/component-base.js';
@@ -19,12 +20,12 @@ export class UsageView extends ComponentBase {
   async render() {
     this.el.replaceChildren();
 
-    this.el.appendChild(_el('div', { className: 'usage-header' },
-      _el('div', { className: 'usage-header-left' },
-        _el('h2', { className: 'usage-title', textContent: 'Usage' }),
-      ),
-      _el('button', { className: 'usage-refresh-btn', textContent: 'Refresh', onClick: () => this.render() }),
-    ));
+    this.el.appendChild(buildViewHeader({
+      baseClass: 'usage',
+      title: 'Usage',
+      wrapLeft: true,
+      actions: _el('button', { className: 'usage-refresh-btn', textContent: 'Refresh', onClick: () => this.render() }),
+    }));
 
     const { bar, setActive } = buildTabBar(TABS, {
       activeId: this.activeTab,

--- a/src/utils/file-editor-renderer.js
+++ b/src/utils/file-editor-renderer.js
@@ -4,6 +4,7 @@
  */
 
 import { _el } from './dom.js';
+import { renderStatusBar } from './view-header.js';
 import { getCursorPosition, insertTab, SAVE_FLASH_MS, TAB_SPACES } from './editor-helpers.js';
 
 /**
@@ -117,13 +118,13 @@ export function updateStatusBar(statusBar, editorEl, file) {
   if (!statusBar || !editorEl || !file) return;
   const { line, col, totalLines } = getCursorPosition(editorEl.value, editorEl.selectionStart);
   const modified = file.content !== file.savedContent;
-  statusBar.replaceChildren(
-    _el('span', 'status-item', file.lang),
-    _el('span', 'status-item', `Ln ${line}, Col ${col}`),
-    _el('span', 'status-item', `${totalLines} lines`),
-    _el('span', modified ? 'status-item status-modified' : 'status-item status-saved', modified ? 'Modified' : 'Saved'),
-    _el('span', 'status-save-hint', modified ? '\u2318S to save' : ''),
-  );
+  renderStatusBar(statusBar, [
+    { text: file.lang },
+    { text: `Ln ${line}, Col ${col}` },
+    { text: `${totalLines} lines` },
+    { text: modified ? 'Modified' : 'Saved', cls: modified ? 'status-modified' : 'status-saved' },
+    { text: modified ? '\u2318S to save' : '', isHint: true },
+  ]);
 }
 
 /**

--- a/src/utils/flow-view-rendering.js
+++ b/src/utils/flow-view-rendering.js
@@ -13,6 +13,7 @@ import {
 import { createCategoryGroup } from './flow-category-renderer.js';
 import { createFlowCard } from './flow-card-setup.js';
 import { _el, buildDomainButtonBar } from './dom.js';
+import { buildViewHeader } from './view-header.js';
 
 /**
  * Build the outer shell DOM for the FlowView (wrapper + header + listEl).
@@ -23,15 +24,13 @@ import { _el, buildDomainButtonBar } from './dom.js';
 export function renderFlowViewShell(container, handlers) {
   container.replaceChildren();
   const wrapper = _el('div', 'flow-container');
-  const header = _el('div', 'flow-header');
-  header.appendChild(_el('h2', 'flow-title', 'Flows'));
 
   const headerHandlers = { addCategory: handlers.onAddCategory, addFlow: handlers.onAddFlow };
   const headerRight = buildDomainButtonBar('flow-add-btn', 'flow-header-right', HEADER_BUTTONS, headerHandlers);
   headerRight.style.display = 'flex';
   headerRight.style.gap = '8px';
 
-  header.appendChild(headerRight);
+  const header = buildViewHeader({ baseClass: 'flow', title: 'Flows', actions: headerRight });
   wrapper.appendChild(header);
   const listEl = _el('div', 'flow-list');
   wrapper.appendChild(listEl);

--- a/src/utils/markdown-preview-renderer.js
+++ b/src/utils/markdown-preview-renderer.js
@@ -5,6 +5,7 @@
  */
 
 import { _el } from './dom.js';
+import { renderStatusBar } from './view-header.js';
 import { renderMarkdown } from './markdown-renderer.js';
 
 /**
@@ -39,10 +40,10 @@ export function createMarkdownPreviewDOM(editorWrapper, file) {
 export function updatePreviewStatusBar(statusBar, file) {
   if (!statusBar || !file) return;
   const lines = (file.content || '').split('\n').length;
-  statusBar.replaceChildren(
-    _el('span', 'status-item', 'markdown'),
-    _el('span', 'status-item', 'Preview'),
-    _el('span', 'status-item', `${lines} lines`),
-    _el('span', 'status-save-hint', 'Right-click tab to edit'),
-  );
+  renderStatusBar(statusBar, [
+    { text: 'markdown' },
+    { text: 'Preview' },
+    { text: `${lines} lines` },
+    { text: 'Right-click tab to edit', isHint: true },
+  ]);
 }

--- a/src/utils/skills-view-renderer.js
+++ b/src/utils/skills-view-renderer.js
@@ -5,6 +5,7 @@
  */
 
 import { _el, renderList } from './dom.js';
+import { buildViewHeader } from './view-header.js';
 
 /**
  * Build the top header bar with action buttons.
@@ -19,39 +20,41 @@ export function renderHeader(rootPath, handlers) {
     textContent: rootPath || '…',
   });
 
-  const header = _el('div', 'skills-header',
-    _el('div', 'skills-header-left',
-      _el('h2', 'skills-title', 'Skills'),
-      rootBadgeEl,
-    ),
-    _el('div', 'skills-header-right',
-      _el('button', {
-        className: 'skills-btn skills-btn-secondary',
-        textContent: 'Configurer le chemin…',
-        onClick: handlers.onConfigurePath,
-      }),
-      _el('button', {
-        className: 'skills-btn skills-btn-secondary',
-        textContent: 'Ouvrir le dossier',
-        onClick: handlers.onOpenRoot,
-      }),
-      _el('button', {
-        className: 'skills-btn skills-btn-secondary',
-        textContent: 'Importer',
-        onClick: handlers.onImport,
-      }),
-      _el('button', {
-        className: 'skills-btn skills-btn-primary',
-        textContent: '+ Nouveau skill',
-        onClick: handlers.onCreate,
-      }),
-      _el('button', {
-        className: 'skills-btn skills-btn-secondary',
-        textContent: 'Rafraîchir',
-        onClick: handlers.onRefresh,
-      }),
-    ),
+  const actions = _el('div', 'skills-header-right',
+    _el('button', {
+      className: 'skills-btn skills-btn-secondary',
+      textContent: 'Configurer le chemin…',
+      onClick: handlers.onConfigurePath,
+    }),
+    _el('button', {
+      className: 'skills-btn skills-btn-secondary',
+      textContent: 'Ouvrir le dossier',
+      onClick: handlers.onOpenRoot,
+    }),
+    _el('button', {
+      className: 'skills-btn skills-btn-secondary',
+      textContent: 'Importer',
+      onClick: handlers.onImport,
+    }),
+    _el('button', {
+      className: 'skills-btn skills-btn-primary',
+      textContent: '+ Nouveau skill',
+      onClick: handlers.onCreate,
+    }),
+    _el('button', {
+      className: 'skills-btn skills-btn-secondary',
+      textContent: 'Rafraîchir',
+      onClick: handlers.onRefresh,
+    }),
   );
+
+  const header = buildViewHeader({
+    baseClass: 'skills',
+    title: 'Skills',
+    wrapLeft: true,
+    leftExtra: [rootBadgeEl],
+    actions,
+  });
 
   return { header, rootBadgeEl };
 }

--- a/src/utils/view-header.js
+++ b/src/utils/view-header.js
@@ -1,0 +1,83 @@
+/**
+ * Shared DOM builders for view chrome — header bars and status bars.
+ *
+ * Several views (flow, skills, usage, git) build a header with the same
+ * skeleton: a container, a title on the left, and an actions zone on the
+ * right. Two file-viewer renderers build a status bar as a run of
+ * `status-item` spans. These helpers factor those two patterns while
+ * letting each caller keep its own CSS class prefixes and DOM shape.
+ */
+
+import { _el } from './dom.js';
+
+/**
+ * Build a view header: container + title (left) + actions zone (right).
+ *
+ * The DOM shape is driven by options so each view keeps its exact markup:
+ *   - `wrapLeft: false` (flow, git) → title is a direct child of the header.
+ *   - `wrapLeft: true`  (skills, usage) → title (and `leftExtra`) sit inside
+ *     a `${baseClass}-header-left` wrapper.
+ *
+ * @param {{
+ *   baseClass: string,
+ *   title: string,
+ *   titleTag?: string,
+ *   titleClass?: string|null,
+ *   wrapLeft?: boolean,
+ *   leftExtra?: Array<Node>,
+ *   actions: Node,
+ * }} opts
+ *   - baseClass: CSS prefix, e.g. "flow" → header class "flow-header".
+ *   - title: text of the title element.
+ *   - titleTag: tag for the title element (default "h2").
+ *   - titleClass: class for the title; defaults to `${baseClass}-title`.
+ *     Pass `null` for no class (git uses a bare span).
+ *   - wrapLeft: when true, title + leftExtra are wrapped in `-header-left`.
+ *   - leftExtra: extra nodes placed after the title on the left side.
+ *   - actions: pre-built node for the right-hand actions zone.
+ * @returns {HTMLElement} the header element.
+ */
+export function buildViewHeader(opts) {
+  const {
+    baseClass,
+    title,
+    titleTag = 'h2',
+    wrapLeft = false,
+    leftExtra = [],
+    actions,
+  } = opts;
+  const titleClass = opts.titleClass === undefined ? `${baseClass}-title` : opts.titleClass;
+
+  const titleEl = _el(titleTag, titleClass, title);
+  const header = _el('div', `${baseClass}-header`);
+
+  if (wrapLeft) {
+    header.appendChild(_el('div', `${baseClass}-header-left`, titleEl, ...leftExtra));
+  } else {
+    header.appendChild(titleEl);
+    for (const extra of leftExtra) header.appendChild(extra);
+  }
+
+  header.appendChild(actions);
+  return header;
+}
+
+/**
+ * Rebuild a status bar as a run of spans, replacing its current children.
+ *
+ * @param {HTMLElement} statusBar
+ * @param {Array<{ text: string, cls?: string, isHint?: boolean }>} items
+ *   - text: span text content.
+ *   - cls: extra class(es) appended after the base class.
+ *   - isHint: when true, the base class is `status-save-hint`; otherwise
+ *     `status-item`.
+ */
+export function renderStatusBar(statusBar, items) {
+  if (!statusBar) return;
+  statusBar.replaceChildren(
+    ...items.map(({ text, cls, isHint }) => {
+      const base = isHint ? 'status-save-hint' : 'status-item';
+      return _el('span', cls ? `${base} ${cls}` : base, text);
+    }),
+  );
+}


### PR DESCRIPTION
## Refactoring

Deux patterns de construction DOM dupliqués sont factorisés dans un nouveau module dédié `src/utils/view-header.js` (code modulaire — règle CLAUDE.md).

**`buildViewHeader({ baseClass, title, titleTag?, titleClass?, wrapLeft?, leftExtra?, actions })`** — construit le squelette commun « conteneur header + titre à gauche + zone d'actions à droite » pour les 4 vues. Les options pilotent les divergences réelles entre vues afin de préserver le DOM exact :
- `flow` : titre `h2.flow-title` direct dans le header, actions = button bar (style flex conservé).
- `skills` : titre + badge dans un wrapper `skills-header-left`, actions = `skills-header-right`.
- `usage` : titre dans un wrapper `usage-header-left`, actions = bouton `usage-refresh-btn`.
- `git` : titre `span` sans classe, pas de wrapper, actions = span `git-refresh-btn`.

**`renderStatusBar(statusBar, items)`** — factorise le `replaceChildren` + la map de spans `status-item` / `status-save-hint` partagée par `file-editor-renderer.js` et `markdown-preview-renderer.js`.

Aucune logique métier modifiée. Structure DOM et classes CSS de chaque vue préservées à l'identique.

Closes #548

## Fichier(s) modifié(s)

- `src/utils/view-header.js` (nouveau — helpers `buildViewHeader` et `renderStatusBar`)
- `src/utils/flow-view-rendering.js` (call-site header)
- `src/utils/skills-view-renderer.js` (call-site header)
- `src/components/usage-view.js` (call-site header)
- `src/components/git-changes-view.js` (call-site header)
- `src/utils/file-editor-renderer.js` (call-site status bar)
- `src/utils/markdown-preview-renderer.js` (call-site status bar)

## Vérifications

- [x] Build OK (`npm run build` — "Build complete.")
- [x] Tests OK (`npm test` — 406 tests passent)

---

📂 Path local : `/Users/claude/flux/review/pikagent/`
🤖 PR créée automatiquement par l'Agent Refactor