### PR TITLE
refactor: remove dead ipc-helpers code and superfluous exports (closes #549)

### DIFF
--- a/main/ipc-helpers.js
+++ b/main/ipc-helpers.js
@@ -45,31 +45,38 @@ const { forward: FORWARD_TABLE, spread: SPREAD_TABLE } = buildTablesFromSchema(A
 /**
  * @internal
  * Generic handler registration — loops over entries and registers an
- * `ipc.handle` for each one, using `buildCallback` to create the handler.
+ * `ipc.handle` for each one, resolving the target object via `resolveTarget`
+ * and building the handler via `buildCallback`.
+ *
+ * The target method name is always derived from the channel (`domain:method`).
+ * Entries whose target cannot be resolved are skipped.
  *
  * @param {Electron.IpcMain} ipc
- * @param {Record<string, (...args: unknown[]) => unknown>} target
  * @param {Array<[string, string, string[]?]>} entries
- * @param {(target: Record<string, (...args: unknown[]) => unknown>, entry: [string, string, string[]?]) => (event: Electron.IpcMainInvokeEvent, arg: unknown) => unknown} buildCallback
+ * @param {(entry: [string, string, string[]?]) => (Record<string, (...args: unknown[]) => unknown> | undefined)} resolveTarget
+ * @param {(target: Record<string, (...args: unknown[]) => unknown>, method: string, entry: [string, string, string[]?]) => (event: Electron.IpcMainInvokeEvent, arg: unknown) => unknown} buildCallback
  */
-function registerHandlers(ipc, target, entries, buildCallback) {
+function registerHandlers(ipc, entries, resolveTarget, buildCallback) {
   for (const entry of entries) {
     const [channel] = entry;
-    ipc.handle(channel, buildCallback(target, entry));
+    const target = resolveTarget(entry);
+    if (!target) continue;
+    const method = channel.split(':')[1];
+    ipc.handle(channel, buildCallback(target, method, entry));
   }
 }
 
-/** @internal Forward-style: single arg forwarded directly. */
-function registerForward(ipc, target, entries) {
-  registerHandlers(ipc, target, entries, (t, [, method]) =>
-    (_, arg) => t[method](arg),
+/** @internal Forward-style: single arg forwarded directly to `target[method]`. */
+function registerForward(ipc, entries, resolveTarget) {
+  registerHandlers(ipc, entries, resolveTarget, (target, method) =>
+    (_, arg) => target[method](arg),
   );
 }
 
-/** @internal Spread-style: keyed args destructured and spread. */
-function registerSpread(ipc, target, entries) {
-  registerHandlers(ipc, target, entries, (t, [, method, keys]) =>
-    (_, arg) => t[method](...keys.map(k => arg[k])),
+/** @internal Spread-style: keyed args destructured and spread into `target[method]`. */
+function registerSpread(ipc, entries, resolveTarget) {
+  registerHandlers(ipc, entries, resolveTarget, (target, method, [,, keys]) =>
+    (_, arg) => target[method](...keys.map(k => arg[k])),
   );
 }
 
@@ -83,28 +90,12 @@ function registerSpread(ipc, target, entries) {
  * @param {Set<string>} [skip] - Channels to skip (registered as custom handlers elsewhere)
  */
 function registerManagerHandlers(ipc, targets, skip = new Set()) {
-  /**
-   * Shared iteration: resolve domain → target, derive method name from
-   * channel, then delegate to `buildCallback` for the handler shape.
-   */
-  function registerFromTable(entries, buildCallback) {
-    for (const entry of entries) {
-      const [channel, domain] = entry;
-      if (skip.has(channel)) continue;
-      const target = targets[domain];
-      if (!target) continue;
-      const method = channel.split(':')[1];
-      ipc.handle(channel, buildCallback(target, method, entry));
-    }
-  }
+  // Resolve domain → target object, honoring the skip set.
+  const resolveTarget = ([channel, domain]) =>
+    skip.has(channel) ? undefined : targets[domain];
 
-  registerFromTable(FORWARD_TABLE, (target, method) =>
-    (_, arg) => target[method](arg),
-  );
-
-  registerFromTable(SPREAD_TABLE, (target, method, [,, keys]) =>
-    (_, arg) => target[method](...keys.map(k => arg[k])),
-  );
+  registerForward(ipc, FORWARD_TABLE, resolveTarget);
+  registerSpread(ipc, SPREAD_TABLE, resolveTarget);
 }
 
 module.exports = { safeSend, registerManagerHandlers };

--- a/shared/date-utils.js
+++ b/shared/date-utils.js
@@ -63,15 +63,6 @@ function nowISO() {
 }
 
 /**
- * Return today's date as "YYYY-MM-DD".
- * Replaces `new Date().toISOString().slice(0, 10)`.
- * @returns {string}
- */
-function todayISO() {
-  return new Date().toISOString().slice(0, 10);
-}
-
-/**
  * Convert an ISO timestamp into a filename-safe string by replacing
  * colons and dots with dashes (e.g. "2025-03-29T14-32-00-000Z").
  * Replaces `.toISOString().replace(/[:.]/g, '-')`.
@@ -97,4 +88,4 @@ function toDateString(dateOrTs) {
   return d.toISOString().slice(0, 10);
 }
 
-module.exports = { formatDateTime, extractDateString, generateDateRange, nowISO, todayISO, toLogFilename, toDateString };
+module.exports = { formatDateTime, extractDateString, generateDateRange, nowISO, toLogFilename, toDateString };

--- a/src/utils/file-editor-renderer.js
+++ b/src/utils/file-editor-renderer.js
@@ -15,7 +15,7 @@ import { getCursorPosition, insertTab, SAVE_FLASH_MS, TAB_SPACES } from './edito
  * @param {{ content: string }} file
  * @returns {{ lineNumbers: HTMLElement, highlightLayer: HTMLElement, editorEl: HTMLTextAreaElement }}
  */
-export function createEditorDOM(editorWrapper, file) {
+function createEditorDOM(editorWrapper, file) {
   const lineNumbers = _el('div', 'editor-line-numbers');
   const highlightLayer = _el('pre', 'editor-highlight-layer');
 
@@ -41,7 +41,7 @@ export function createEditorDOM(editorWrapper, file) {
  * @param {{ content: string }} file - mutable file object (content is updated on input)
  * @param {{ onUpdate: () => void, onSave: () => void }} callbacks
  */
-export function bindEditorEvents(editorEl, lineNumbers, highlightLayer, file, { onUpdate, onSave }) {
+function bindEditorEvents(editorEl, lineNumbers, highlightLayer, file, { onUpdate, onSave }) {
   editorEl.addEventListener('input', () => {
     file.content = editorEl.value;
     onUpdate();

--- a/tests/main/date-utils.test.js
+++ b/tests/main/date-utils.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-const { extractDateString, generateDateRange, formatDateTime, nowISO, todayISO, toLogFilename, toDateString } = require('../../shared/date-utils');
+const { extractDateString, generateDateRange, formatDateTime, nowISO, toLogFilename, toDateString } = require('../../shared/date-utils');
 
 describe('date-utils', () => {
   describe('extractDateString', () => {
@@ -73,17 +73,6 @@ describe('date-utils', () => {
       const after = Date.now();
       expect(result).toBeGreaterThanOrEqual(before);
       expect(result).toBeLessThanOrEqual(after);
-    });
-  });
-
-  describe('todayISO', () => {
-    it('returns YYYY-MM-DD format', () => {
-      expect(todayISO()).toMatch(/^\d{4}-\d{2}-\d{2}$/);
-    });
-
-    it('matches current date', () => {
-      const today = new Date().toISOString().slice(0, 10);
-      expect(todayISO()).toBe(today);
     });
   });
 

--- a/tests/main/ipc-helpers.test.js
+++ b/tests/main/ipc-helpers.test.js
@@ -175,17 +175,20 @@ describe('ipc-helpers', () => {
     });
   });
 
+  // registerForward / registerSpread now derive the target method from the
+  // channel suffix (domain:method) and resolve the target via a `resolveTarget`
+  // callback — the same path used in production by registerManagerHandlers.
   describe('registerForward', () => {
     it('registers ipc handlers that forward a single arg to target methods', async () => {
       const handlers = {};
       const ipc = { handle: vi.fn((channel, fn) => { handlers[channel] = fn; }) };
-      const target = { doSomething: vi.fn().mockReturnValue('ok') };
+      const target = { forward: vi.fn().mockReturnValue('ok') };
 
-      registerForward(ipc, target, [['test:forward', 'doSomething']]);
+      registerForward(ipc, [['test:forward', 'test']], () => target);
 
       expect(ipc.handle).toHaveBeenCalledWith('test:forward', expect.any(Function));
       const result = await handlers['test:forward']({}, { foo: 1 });
-      expect(target.doSomething).toHaveBeenCalledWith({ foo: 1 });
+      expect(target.forward).toHaveBeenCalledWith({ foo: 1 });
       expect(result).toBe('ok');
     });
 
@@ -193,10 +196,10 @@ describe('ipc-helpers', () => {
       const ipc = { handle: vi.fn() };
       const target = { a: vi.fn(), b: vi.fn() };
 
-      registerForward(ipc, target, [
-        ['ch:a', 'a'],
-        ['ch:b', 'b'],
-      ]);
+      registerForward(ipc, [
+        ['ch:a', 'ch'],
+        ['ch:b', 'ch'],
+      ], () => target);
 
       expect(ipc.handle).toHaveBeenCalledTimes(2);
       const channels = ipc.handle.mock.calls.map(([ch]) => ch);
@@ -204,25 +207,31 @@ describe('ipc-helpers', () => {
       expect(channels).toContain('ch:b');
     });
 
+    it('skips entries whose target cannot be resolved', () => {
+      const ipc = { handle: vi.fn() };
+      registerForward(ipc, [['ch:a', 'ch']], () => undefined);
+      expect(ipc.handle).not.toHaveBeenCalled();
+    });
+
     it('works with expected forward-style channels like pty:checkAgents and fs:readdir', async () => {
       const handlers = {};
       const ipc = { handle: vi.fn((channel, fn) => { handlers[channel] = fn; }) };
-      const target = {
-        checkAgents: vi.fn().mockReturnValue(['agent1']),
-        readDirectory: vi.fn().mockReturnValue([]),
+      const targets = {
+        pty: { checkAgents: vi.fn().mockReturnValue(['agent1']) },
+        fs: { readdir: vi.fn().mockReturnValue([]) },
       };
 
-      registerForward(ipc, target, [
-        ['pty:checkAgents', 'checkAgents'],
-        ['fs:readdir', 'readDirectory'],
-      ]);
+      registerForward(ipc, [
+        ['pty:checkAgents', 'pty'],
+        ['fs:readdir', 'fs'],
+      ], ([, domain]) => targets[domain]);
 
       const agents = await handlers['pty:checkAgents']({}, '/some/path');
-      expect(target.checkAgents).toHaveBeenCalledWith('/some/path');
+      expect(targets.pty.checkAgents).toHaveBeenCalledWith('/some/path');
       expect(agents).toEqual(['agent1']);
 
       const entries = await handlers['fs:readdir']({}, '/tmp');
-      expect(target.readDirectory).toHaveBeenCalledWith('/tmp');
+      expect(targets.fs.readdir).toHaveBeenCalledWith('/tmp');
       expect(entries).toEqual([]);
     });
   });
@@ -233,7 +242,7 @@ describe('ipc-helpers', () => {
       const ipc = { handle: vi.fn((channel, fn) => { handlers[channel] = fn; }) };
       const target = { write: vi.fn().mockReturnValue(true) };
 
-      registerSpread(ipc, target, [['pty:write', 'write', ['id', 'data']]]);
+      registerSpread(ipc, [['pty:write', 'pty', ['id', 'data']]], () => target);
 
       expect(ipc.handle).toHaveBeenCalledWith('pty:write', expect.any(Function));
       const result = await handlers['pty:write']({}, { id: 'term-1', data: 'hello' });
@@ -245,10 +254,10 @@ describe('ipc-helpers', () => {
       const ipc = { handle: vi.fn() };
       const target = { write: vi.fn(), resize: vi.fn() };
 
-      registerSpread(ipc, target, [
-        ['pty:write', 'write', ['id', 'data']],
-        ['pty:resize', 'resize', ['id', 'cols', 'rows']],
-      ]);
+      registerSpread(ipc, [
+        ['pty:write', 'pty', ['id', 'data']],
+        ['pty:resize', 'pty', ['id', 'cols', 'rows']],
+      ], () => target);
 
       expect(ipc.handle).toHaveBeenCalledTimes(2);
       const channels = ipc.handle.mock.calls.map(([ch]) => ch);
@@ -261,10 +270,16 @@ describe('ipc-helpers', () => {
       const ipc = { handle: vi.fn((channel, fn) => { handlers[channel] = fn; }) };
       const target = { resize: vi.fn() };
 
-      registerSpread(ipc, target, [['pty:resize', 'resize', ['id', 'cols', 'rows']]]);
+      registerSpread(ipc, [['pty:resize', 'pty', ['id', 'cols', 'rows']]], () => target);
 
       await handlers['pty:resize']({}, { id: 'term-1', cols: 80, rows: 24 });
       expect(target.resize).toHaveBeenCalledWith('term-1', 80, 24);
+    });
+
+    it('skips entries whose target cannot be resolved', () => {
+      const ipc = { handle: vi.fn() };
+      registerSpread(ipc, [['pty:write', 'pty', ['id']]], () => undefined);
+      expect(ipc.handle).not.toHaveBeenCalled();
     });
 
     it('has no overlap between forward and spread channel patterns', () => {
@@ -273,10 +288,10 @@ describe('ipc-helpers', () => {
       const spreadHandlers = {};
       const forwardIpc = { handle: vi.fn((ch, fn) => { forwardHandlers[ch] = fn; }) };
       const spreadIpc = { handle: vi.fn((ch, fn) => { spreadHandlers[ch] = fn; }) };
-      const target = { a: vi.fn(), b: vi.fn() };
+      const target = { test: vi.fn() };
 
-      registerForward(forwardIpc, target, [['shared:test', 'a']]);
-      registerSpread(spreadIpc, target, [['spread:test', 'b', ['key1']]]);
+      registerForward(forwardIpc, [['shared:test', 'shared']], () => target);
+      registerSpread(spreadIpc, [['spread:test', 'spread', ['key1']]], () => target);
 
       const forwardChannels = new Set(Object.keys(forwardHandlers));
       const spreadChannels = new Set(Object.keys(spreadHandlers));


### PR DESCRIPTION
## Refactoring

Suppression de code mort et réconciliation interne, sans changement de comportement du code de production.

**`main/ipc-helpers.js`** — `registerForward`/`registerSpread`/`registerHandlers` n'étaient appelés que par le test via `_internals` ; le chemin de prod `registerManagerHandlers` réimplémentait la même logique via un helper inline `registerFromTable`. J'ai unifié les deux : `registerForward`/`registerSpread` prennent désormais `(ipc, entries, resolveTarget)`, dérivent le nom de méthode du suffixe du channel (`domain:method`) et résolvent la cible via un callback. `registerManagerHandlers` les réutilise réellement en passant un `resolveTarget` qui mappe domaine → target et honore le `skip`. Plus de duplication, et le trio testé est maintenant vivant en prod. Comportement de `registerManagerHandlers` strictement identique.

**`src/utils/file-editor-renderer.js`** — `export` retiré de `createEditorDOM` et `bindEditorEvents` (vérifié par grep : importés nulle part, appelés uniquement en interne par `initCodeEditor`). Fonctions conservées, juste plus exportées.

**`shared/date-utils.js`** — `todayISO` supprimé. Choix : suppression plutôt que conservation. Vérifié par grep : aucun usage en production, consommé uniquement par son propre test. Les besoins réels de prod sont couverts par `nowISO`/`toDateString`. Garder un export inutilisé contredirait l'objectif de nettoyage du code mort. Le bloc `describe('todayISO')` et l'import correspondant ont été retirés de `tests/main/date-utils.test.js`.

Le test `tests/main/ipc-helpers.test.js` a été adapté à la nouvelle signature de `registerForward`/`registerSpread` (entries `[channel, domain, keys?]` + `resolveTarget`), avec deux nouveaux cas couvrant le skip d'une cible non résolue.

Closes #549

## Fichier(s) modifié(s)

- `main/ipc-helpers.js` — unification `registerForward`/`registerSpread` ↔ `registerManagerHandlers`
- `tests/main/ipc-helpers.test.js` — adaptation à la nouvelle signature
- `src/utils/file-editor-renderer.js` — `export` superflu retiré
- `shared/date-utils.js` — `todayISO` supprimé
- `tests/main/date-utils.test.js` — bloc de test `todayISO` retiré

## Vérifications

- [x] Build OK (`npm run build` → "Build complete.")
- [x] Tests OK (`npm test` → 27 fichiers, 405 tests passés)

---

📂 Path local : \`/Users/claude/flux/review/pikagent/\`
🤖 PR créée automatiquement par l'Agent Refactor