### PR TITLE
refactor: tighten weak JSDoc types across 17 files (closes #545)

### DIFF
--- a/main/command-utils.js
+++ b/main/command-utils.js
@@ -15,12 +15,12 @@ const execFileAsync = promisify(execFile);
  *
  * @param {string} cmd          - executable name (e.g. 'git')
  * @param {string[]} args       - command arguments
- * @param {object} opts         - options forwarded to execFile
- * @param {{ fallback?: *, trySafe: Function, log: object, label: string }} ctx
+ * @param {import('child_process').ExecFileOptions} opts - options forwarded to execFile
+ * @param {{ fallback?: unknown, trySafe: (fn: () => unknown, defaultValue: unknown, opts: { log: { warn: (msg: string, err?: unknown) => void }, label: string }) => Promise<unknown>, log: { warn: (msg: string, err?: unknown) => void }, label: string }} ctx
  *   trySafe - the trySafe wrapper to use for error handling
  *   log     - logger instance
  *   label   - human-readable label for the log message
- * @returns {Promise<string|*>}
+ * @returns {Promise<string|unknown>}
  */
 async function runCommand(cmd, args, opts, { fallback = null, trySafe, log, label }) {
   return trySafe(

--- a/main/flow-executor-log.js
+++ b/main/flow-executor-log.js
@@ -16,7 +16,7 @@ const ensureLogsDir = ensureDirOnce(LOGS_DIR);
 /**
  * Persists the raw output of a flow run to disk.
  *
- * @param {{ log: object }} deps
+ * @param {{ log: import('./flow-executor').FlowLogger }} deps
  * @param {string} flowId
  * @param {string} runTimestamp
  * @param {string} output
@@ -33,7 +33,7 @@ async function saveLog(deps, flowId, runTimestamp, output) {
 /**
  * Reads a previously saved run log from disk.
  *
- * @param {{ log: object }} deps
+ * @param {{ log: import('./flow-executor').FlowLogger }} deps
  * @param {string} flowId
  * @param {string} timestamp
  * @returns {Promise<string | null>}
@@ -49,7 +49,7 @@ async function getRunLog(deps, flowId, timestamp) {
 /**
  * Removes all log files for a given flow.
  *
- * @param {{ log: object }} deps
+ * @param {{ log: import('./flow-executor').FlowLogger }} deps
  * @param {string} flowId
  */
 async function cleanLogs(deps, flowId) {

--- a/main/flow-executor-run.js
+++ b/main/flow-executor-run.js
@@ -10,7 +10,7 @@ const { nowISO, extractDateString } = require('../shared/date-utils');
 /**
  * Appends a run record to the flow's history.
  *
- * @param {{ getFlow: Function, saveFlow: Function }} deps
+ * @param {{ getFlow: (id: string) => Promise<import('./flow-executor').Flow|null>, saveFlow: (flow: import('./flow-executor').Flow) => Promise<unknown> }} deps
  * @param {string} flowId
  * @param {string} status
  * @param {string} runTimestamp

--- a/main/flow-executor.js
+++ b/main/flow-executor.js
@@ -19,14 +19,48 @@ const { saveLog, getRunLog, cleanLogs } = require('./flow-executor-log');
 const { recordRun } = require('./flow-executor-run');
 const { toLogFilename } = require('../shared/date-utils');
 
+// --- Shared typedefs ---
+
+/**
+ * @typedef {object} PtyProcess
+ * @property {(cb: (data: string) => void) => void} onData   - subscribe to PTY output
+ * @property {(cb: (info: { exitCode: number }) => void) => void} onExit - subscribe to PTY exit
+ */
+
+/**
+ * @typedef {object} Flow
+ * @property {string} id
+ * @property {string} [name]
+ * @property {string} [agent]
+ * @property {string} [cwd]
+ * @property {Array<{ date: string, timestamp: string, logTimestamp?: string, status: string }>} [runs]
+ */
+
+/**
+ * @typedef {object} FlowLogger
+ * @property {(msg: string, err?: unknown) => void} error
+ * @property {(msg: string, err?: unknown) => void} warn
+ */
+
+/**
+ * @typedef {object} RunningFlowEntry
+ * @property {string} ptyId
+ * @property {PtyProcess} proc
+ * @property {ReturnType<typeof setTimeout>} timeout
+ */
+
+/**
+ * @typedef {Map<string, RunningFlowEntry>} RunningFlows
+ */
+
 // --- Top-level helpers ---
 
 /**
  * Cleans up a finished flow process: clears timeout, removes PTY,
  * and notifies the renderer.
  *
- * @param {{ getPtyManager: Function, sendToWindow: Function }} deps
- * @param {Map<string, {ptyId: string, proc: object, timeout: ReturnType<typeof setTimeout>}>} runningFlows
+ * @param {{ getPtyManager: () => { processes: Map<string, unknown> }, sendToWindow: (channel: string, payload: object) => void }} deps
+ * @param {RunningFlows} runningFlows
  * @param {string} flowId
  * @param {string} ptyId
  * @param {number} exitCode
@@ -43,10 +77,10 @@ function cleanupFlowProcess(deps, runningFlows, flowId, ptyId, exitCode) {
 /**
  * Wires up PTY data/exit listeners for a running flow process.
  *
- * @param {{ sendToWindow: Function, getPtyManager: Function, getFlow: Function, saveFlow: Function, log: object }} deps
- * @param {Map<string, {ptyId: string, proc: object, timeout: ReturnType<typeof setTimeout>}>} runningFlows
- * @param {object} proc
- * @param {object} flow
+ * @param {{ sendToWindow: (channel: string, payload: object) => void, getPtyManager: () => { processes: Map<string, unknown> }, getFlow: (id: string) => Promise<Flow|null>, saveFlow: (flow: Flow) => Promise<unknown>, log: FlowLogger }} deps
+ * @param {RunningFlows} runningFlows
+ * @param {PtyProcess} proc
+ * @param {Flow} flow
  * @param {string} ptyId
  * @param {string} runTimestamp
  */
@@ -71,9 +105,9 @@ function setupPtyListeners(deps, runningFlows, proc, flow, ptyId, runTimestamp) 
 /**
  * Executes a single flow inside a new PTY process.
  *
- * @param {{ getPtyManager: Function, sendToWindow: Function, log: object, getFlow: Function, saveFlow: Function }} deps
- * @param {Map<string, {ptyId: string, proc: object, timeout: ReturnType<typeof setTimeout>}>} runningFlows
- * @param {object} flow
+ * @param {{ getPtyManager: () => { create: (opts: object) => PtyProcess, kill: (id: string) => void, write: (id: string, data: string) => void } | null, sendToWindow: (channel: string, payload: object) => void, log: FlowLogger, getFlow: (id: string) => Promise<Flow|null>, saveFlow: (flow: Flow) => Promise<unknown> }} deps
+ * @param {RunningFlows} runningFlows
+ * @param {Flow} flow
  */
 function execute(deps, runningFlows, flow) {
   const ptyManager = deps.getPtyManager();
@@ -120,8 +154,8 @@ function execute(deps, runningFlows, flow) {
 /**
  * Kills all running flow processes and clears the map.
  *
- * @param {{ getPtyManager: Function }} deps
- * @param {Map<string, {ptyId: string, proc: object, timeout: ReturnType<typeof setTimeout>}>} runningFlows
+ * @param {{ getPtyManager: () => { kill: (id: string) => void } | null }} deps
+ * @param {RunningFlows} runningFlows
  */
 function stopAll(deps, runningFlows) {
   const ptyManager = deps.getPtyManager();
@@ -135,7 +169,7 @@ function stopAll(deps, runningFlows) {
 /**
  * Returns a plain object mapping flow IDs to their PTY IDs.
  *
- * @param {Map<string, {ptyId: string, proc: object, timeout: ReturnType<typeof setTimeout>}>} runningFlows
+ * @param {RunningFlows} runningFlows
  * @returns {Record<string, string>}
  */
 function getRunning(runningFlows) {
@@ -152,13 +186,13 @@ function getRunning(runningFlows) {
  * @param {{
  *   getPtyManager: () => object | null,
  *   sendToWindow: (channel: string, payload: object) => void,
- *   getFlow: (id: string) => Promise<object | null>,
- *   saveFlow: (flow: object) => Promise<object>,
- *   log: { error: (msg: string, err?: unknown) => void, warn: (msg: string, err?: unknown) => void },
+ *   getFlow: (id: string) => Promise<Flow | null>,
+ *   saveFlow: (flow: Flow) => Promise<unknown>,
+ *   log: FlowLogger,
  * }} deps
  * @returns {{
- *   execute: (flow: object) => void,
- *   runningFlows: Map<string, { ptyId: string, proc: object, timeout: ReturnType<typeof setTimeout> }>,
+ *   execute: (flow: Flow) => void,
+ *   runningFlows: RunningFlows,
  *   stopAll: () => void,
  *   getRunning: () => Record<string, string>,
  *   getRunLog: (flowId: string, timestamp: string) => Promise<string | null>,

--- a/main/flow-scheduler.js
+++ b/main/flow-scheduler.js
@@ -13,10 +13,10 @@ const { SCHEDULER_INTERVAL_MS, shouldRun } = require('./flow-helpers');
  * Creates a flow scheduler that polls at a fixed interval and invokes
  * `executeFn(flow)` for every enabled flow whose schedule is due.
  *
- * @param {{ list: () => Promise<Array<object>>, isRunning: (id: string) => boolean }} flowSource
+ * @param {{ list: () => Promise<Array<import('./flow-executor').Flow & { enabled?: boolean }>>, isRunning: (id: string) => boolean }} flowSource
  *   - list()      — returns all saved flows
  *   - isRunning() — returns true if a flow is already executing
- * @param {(flow: object) => void} executeFn — called for each flow that should run
+ * @param {(flow: import('./flow-executor').Flow) => void} executeFn — called for each flow that should run
  * @returns {{ start: () => void, stop: () => void }}
  */
 function createFlowScheduler(flowSource, executeFn) {

--- a/main/manager-init.js
+++ b/main/manager-init.js
@@ -21,9 +21,9 @@
  * replaces the getter with a plain data property, so subsequent reads are
  * zero-cost.
  *
- * @param {object} obj      Target object.
+ * @param {Record<string, unknown>} obj      Target object.
  * @param {string} name     Property name.
- * @param {() => any} factory  Called once to produce the value.
+ * @param {() => unknown} factory  Called once to produce the value.
  */
 function lazyProp(obj, name, factory) {
   Object.defineProperty(obj, name, {

--- a/main/safe-handler.js
+++ b/main/safe-handler.js
@@ -39,7 +39,7 @@ async function runSafe(fn, onError) {
  * - `log` + `label`: if both provided, `log.warn('<label> failed', err)` is
  *   called on failure.
  *
- * @param {{ envelope?: boolean, defaultValue?: unknown, log?: { warn: Function }, label?: string }} [opts]
+ * @param {{ envelope?: boolean, defaultValue?: unknown, log?: { warn: (msg: string, err?: unknown) => void }, label?: string }} [opts]
  * @returns {(fn: (...args: unknown[]) => Promise<unknown>) => (...args: unknown[]) => Promise<unknown>}
  */
 function createSafeWrapper({ envelope = false, defaultValue, log, label } = {}) {

--- a/shared/aggregation-utils.js
+++ b/shared/aggregation-utils.js
@@ -201,10 +201,10 @@ function computeNumericStats(values) {
  * of items and merges any extra fields supplied by the caller.
  *
  * @param {Array<{ status?: string, [key: string]: unknown }>} items
- * @param {{ rateFn: (items: Array) => Record<string, unknown>,
+ * @param {{ rateFn: (items: Array<unknown>) => Record<string, unknown>,
  *           durationMapper: (item: unknown) => number|null,
  *           dateExtractor: (item: unknown) => string,
- *           perDayFn: (items: Array, dateExtractor: Function, days: number) => Array,
+ *           perDayFn: (items: Array<unknown>, dateExtractor: (item: unknown) => string, days: number) => Array<unknown>,
  *           days?: number,
  *           extra?: Record<string, unknown> }} config
  * @returns {Record<string, unknown>}
@@ -226,10 +226,10 @@ function buildMetrics(items, { rateFn, durationMapper, dateExtractor, perDayFn, 
  *   const buildMetrics = createDomainMetricsBuilder({ rateFn, perDayFn, days });
  *   buildMetrics(items, { durationMapper, dateExtractor, extra });
  *
- * @param {{ rateFn: (items: Array) => Record<string, unknown>,
- *           perDayFn: (items: Array, dateExtractor: Function, days: number) => Array,
+ * @param {{ rateFn: (items: Array<unknown>) => Record<string, unknown>,
+ *           perDayFn: (items: Array<unknown>, dateExtractor: (item: unknown) => string, days: number) => Array<unknown>,
  *           days?: number }} domainConfig
- * @returns {(items: Array, opts: { durationMapper: Function, dateExtractor: Function, extra?: Record<string, unknown> }) => Record<string, unknown>}
+ * @returns {(items: Array<unknown>, opts: { durationMapper: (item: unknown) => number|null, dateExtractor: (item: unknown) => string, extra?: Record<string, unknown> }) => Record<string, unknown>}
  */
 function createDomainMetricsBuilder({ rateFn, perDayFn, days = 30 }) {
   return function domainBuildMetrics(items, { durationMapper, dateExtractor, extra = {} }) {

--- a/src/components/flow-card-terminal.js
+++ b/src/components/flow-card-terminal.js
@@ -32,12 +32,12 @@ export class FlowCardTerminalManager {
   /**
    * Create a readonly terminal, register it in the given map, and run an
    * optional setup callback.  Returns the terminal record.
-   * @param {Map<string, {term: object, fitAddon: object, containerEl: HTMLElement}>} map - target map (_liveTerminals or _logTerminals)
+   * @param {Map<string, { term: import('@xterm/xterm').Terminal, fitAddon: import('@xterm/addon-fit').FitAddon, resizeObs: ResizeObserver|null, unsubData: (() => void)|null, containerEl: HTMLElement }>} map - target map (_liveTerminals or _logTerminals)
    * @param {string} flowId
    * @param {HTMLElement} containerEl
-   * @param {object} opts - extra terminal options (scrollback, cursorStyle, …)
-   * @param {(record: object) => void} [setupFn] - called with the record before it is stored
-   * @returns {object} the terminal record stored in the map
+   * @param {{ scrollback?: number, cursorStyle?: string, [key: string]: unknown }} opts - extra terminal options (scrollback, cursorStyle, …)
+   * @param {(record: { term: import('@xterm/xterm').Terminal, fitAddon: import('@xterm/addon-fit').FitAddon, resizeObs: ResizeObserver|null, unsubData: (() => void)|null }) => void} [setupFn] - called with the record before it is stored
+   * @returns {{ term: import('@xterm/xterm').Terminal, fitAddon: import('@xterm/addon-fit').FitAddon, resizeObs: ResizeObserver|null, unsubData: (() => void)|null }} the terminal record stored in the map
    */
   _createAndRegister(map, flowId, containerEl, opts, setupFn) {
     const record = createPtyBoundTerminal(containerEl, {

--- a/src/utils/file-tree-dir-ops.js
+++ b/src/utils/file-tree-dir-ops.js
@@ -36,7 +36,7 @@ function collapseDir(dirPath, childContainer, chevron, expandedDirs) {
 
 /**
  * Build the callbacks object for renderDirEntry.
- * @param {object} ft - FileTree instance
+ * @param {import('../components/file-tree.js').FileTree} ft - FileTree instance
  * @param {Set<string>} expandedDirs
  */
 function getDirEntryCallbacks(ft, expandedDirs) {

--- a/src/utils/file-viewer-editor.js
+++ b/src/utils/file-viewer-editor.js
@@ -52,7 +52,7 @@ export function renderFileViewerShell(container, components) {
 
 /**
  * Render the active editor content (code, markdown preview, or error).
- * @param {object} fv - FileViewer-like state: { editorWrapper, statusBar, breadcrumb, openFiles, activeFile }
+ * @param {import('../components/file-viewer.js').FileViewer} fv - FileViewer-like state: { editorWrapper, statusBar, breadcrumb, openFiles, activeFile }
  * @param {{ onUpdate: () => void, onSave: () => void }} callbacks
  * @returns {{ lineNumbers: HTMLElement|null, highlightLayer: HTMLElement|null, editorEl: HTMLElement|null }}
  */
@@ -150,7 +150,7 @@ export function switchMode(fv, mode, webviewMgr, renderModeBar) {
 
 /**
  * Render file tabs bar.
- * @param {object} fv - FileViewer instance (for callbacks)
+ * @param {import('../components/file-viewer.js').FileViewer} fv - FileViewer instance (for callbacks)
  */
 export function renderTabs(fv) {
   doRenderTabs(fv.tabsBar, fv.openFiles, fv.activeFile,

--- a/src/utils/flow-view-rendering.js
+++ b/src/utils/flow-view-rendering.js
@@ -40,7 +40,18 @@ export function renderFlowViewShell(container, handlers) {
 
 /**
  * Build the shared groupParams object for a category section.
- * @param {{ cat: object, flows: Array, isUncat: boolean, collapsedCategories: Set<string>, createCard: Function, onToggleCollapse: Function, onRenameCategory: Function, onDeleteCategory: Function, onDropFlow: Function, dragState: object }} opts
+ * @param {{
+ *   cat: { id: string, name: string },
+ *   flows: Array<import('./flow-card-setup.js').FlowDescriptor>,
+ *   isUncat: boolean,
+ *   collapsedCategories: Set<string>,
+ *   createCard: (flow: import('./flow-card-setup.js').FlowDescriptor, catId: string) => HTMLElement,
+ *   onToggleCollapse: (catId: string) => void,
+ *   onRenameCategory: (catId: string, nameEl: HTMLElement) => void,
+ *   onDeleteCategory: (catId: string) => void,
+ *   onDropFlow: (flowId: string, catId: string, insertIndex: number) => void,
+ *   dragState: { getDragFlowId: () => string|null, clearDrag: () => void },
+ * }} opts
  */
 export function buildGroupParams(opts) {
   const { cat, flows, isUncat, collapsedCategories, createCard, onToggleCollapse, onRenameCategory, onDeleteCategory, onDropFlow, dragState } = opts;
@@ -60,8 +71,19 @@ export function buildGroupParams(opts) {
 
 /**
  * Build the config object for createFlowCard.
- * @param {{ runningMap: object, expandedCards: Set, drag: object, termManager: object, onRenderList: Function, onRun: Function, onToggle: Function, onRefresh: Function, onOpenModal: Function, onDeleteFlow: Function }} deps
- * @param {object} flow
+ * @param {{
+ *   runningMap: Record<string, string>,
+ *   expandedCards: Set<string>,
+ *   drag: { flowId: string|null, catId: string|null },
+ *   termManager: import('../components/flow-card-terminal.js').FlowCardTerminalManager,
+ *   onRenderList: () => void,
+ *   onRun: (flowId: string) => void,
+ *   onToggle: (flowId: string) => Promise<void>,
+ *   onRefresh: () => void,
+ *   onOpenModal: (flow: import('./flow-card-setup.js').FlowDescriptor) => void,
+ *   onDeleteFlow: (flowId: string) => void,
+ * }} deps
+ * @param {import('./flow-card-setup.js').FlowDescriptor} flow
  * @param {string} catId
  * @returns {HTMLElement}
  */
@@ -83,7 +105,15 @@ export function buildFlowCard(deps, flow, catId) {
 
 /**
  * Render the full flow list (categories + uncategorized).
- * @param {{ listEl: HTMLElement, flows: Array, catData: object, termManager: object, runningMap: object, buildParams: (cat: object, flows: Array, isUncat?: boolean) => object, createCard: (flow: object, catId: string) => HTMLElement }} ctx
+ * @param {{
+ *   listEl: HTMLElement,
+ *   flows: Array<import('./flow-card-setup.js').FlowDescriptor>,
+ *   catData: { categories: Array<{ id: string, name: string }>, order: Record<string, string[]> },
+ *   termManager: import('../components/flow-card-terminal.js').FlowCardTerminalManager,
+ *   runningMap: Record<string, string>,
+ *   buildParams: (cat: { id: string, name: string }, flows: Array<import('./flow-card-setup.js').FlowDescriptor>, isUncat?: boolean) => object,
+ *   createCard: (flow: import('./flow-card-setup.js').FlowDescriptor, catId: string) => HTMLElement,
+ * }} ctx
  */
 export function renderFlowList(ctx) {
   const { listEl, flows, catData, termManager, runningMap, buildParams, createCard } = ctx;
@@ -121,9 +151,15 @@ export function renderFlowList(ctx) {
 
 /**
  * Handle the "open modal" flow: prompt user, persist, and refresh.
- * @param {{ existing: object|null, catData: object, moveFlowToCategory: Function, persistCategories: Function, refresh: Function }} ctx
- * @param {() => (existing: object|null, categories: Array<object>) => Promise<object|null>} getOpenFlowModal - returns the openFlowModal component
- * @param {object} flowApi - the flow API service
+ * @param {{
+ *   existing: import('./flow-card-setup.js').FlowDescriptor|null,
+ *   catData: { categories: Array<{ id: string, name: string }>, order: Record<string, string[]> },
+ *   moveFlowToCategory: (flowId: string, catId: string) => void,
+ *   persistCategories: () => Promise<void>,
+ *   refresh: () => void,
+ * }} ctx
+ * @param {() => (existing: import('./flow-card-setup.js').FlowDescriptor|null, categories: Array<{ id: string, name: string }>) => Promise<(import('./flow-card-setup.js').FlowDescriptor & { _category?: string })|null>} getOpenFlowModal - returns the openFlowModal component
+ * @param {{ save: (flow: import('./flow-card-setup.js').FlowDescriptor) => Promise<unknown> }} flowApi - the flow API service
  */
 export async function handleOpenModal(ctx, getOpenFlowModal, flowApi) {
   const { existing, catData, moveFlowToCategory, persistCategories, refresh } = ctx;
@@ -152,9 +188,14 @@ export async function handleOpenModal(ctx, getOpenFlowModal, flowApi) {
 
 /**
  * Delete a flow: dispose terminal, remove from order, persist, delete, refresh.
- * @param {{ termManager: object, catDataOrder: object, persistCategories: Function, refresh: Function }} deps
+ * @param {{
+ *   termManager: import('../components/flow-card-terminal.js').FlowCardTerminalManager,
+ *   catDataOrder: Record<string, string[]>,
+ *   persistCategories: () => Promise<void>,
+ *   refresh: () => void,
+ * }} deps
  * @param {string} flowId
- * @param {object} flowApi
+ * @param {{ deleteFlow: (flowId: string) => Promise<unknown> }} flowApi
  */
 export async function deleteFlow(deps, flowId, flowApi) {
   deps.termManager.disposeLiveTerminal(flowId);

--- a/src/utils/skills-view-actions.js
+++ b/src/utils/skills-view-actions.js
@@ -18,8 +18,8 @@ export async function openRoot(rootPath, shellApi) {
 
 /**
  * Configure the skills root path.
- * @param {object} sv - SkillsView instance (state is mutated)
- * @param {object} deps - { dialogApi, skillsApi }
+ * @param {import('../components/skills-view.js').SkillsView} sv - SkillsView instance (state is mutated)
+ * @param {{ dialogApi: { openFolder: () => Promise<string|null> }, skillsApi: { setRoot: (path: string) => Promise<{ success: boolean, root: string }> } }} deps
  */
 export async function configurePath(sv, deps) {
   const picked = await deps.dialogApi.openFolder();
@@ -35,8 +35,8 @@ export async function configurePath(sv, deps) {
 
 /**
  * Import a skill from a folder.
- * @param {object} sv - SkillsView instance
- * @param {object} deps - { dialogApi, skillsApi }
+ * @param {import('../components/skills-view.js').SkillsView} sv - SkillsView instance
+ * @param {{ dialogApi: { openFolder: () => Promise<string|null> }, skillsApi: { importSkill: (path: string) => Promise<{ success: boolean, id?: string, error?: string }> } }} deps
  */
 export async function importSkill(sv, deps) {
   const picked = await deps.dialogApi.openFolder();
@@ -55,8 +55,8 @@ export async function importSkill(sv, deps) {
 
 /**
  * Create a new skill via prompts.
- * @param {object} sv - SkillsView instance
- * @param {object} skillsApi
+ * @param {import('../components/skills-view.js').SkillsView} sv - SkillsView instance
+ * @param {{ create: (opts: { id: string, description: string }) => Promise<{ success: boolean, id?: string }> }} skillsApi
  */
 export async function createSkill(sv, skillsApi) {
   const id = await showPromptDialog({
@@ -81,9 +81,9 @@ export async function createSkill(sv, skillsApi) {
 
 /**
  * Delete a skill after confirmation.
- * @param {object} sv - SkillsView instance
+ * @param {import('../components/skills-view.js').SkillsView} sv - SkillsView instance
  * @param {string} id - skill id
- * @param {object} skillsApi
+ * @param {{ deleteSkill: (id: string) => Promise<unknown> }} skillsApi
  */
 export async function deleteSkill(sv, id, skillsApi) {
   const ok = await showConfirmDialog(
@@ -98,7 +98,7 @@ export async function deleteSkill(sv, id, skillsApi) {
 
 /**
  * Select a skill (with dirty-check).
- * @param {object} sv - SkillsView instance
+ * @param {import('../components/skills-view.js').SkillsView} sv - SkillsView instance
  * @param {string} id - skill id
  */
 export async function selectSkill(sv, id) {
@@ -117,8 +117,8 @@ export async function selectSkill(sv, id) {
 
 /**
  * Save the active skill.
- * @param {object} sv - SkillsView instance
- * @param {object} skillsApi
+ * @param {import('../components/skills-view.js').SkillsView} sv - SkillsView instance
+ * @param {{ write: (path: string, content: string) => Promise<{ success: boolean }> }} skillsApi
  */
 export async function save(sv, skillsApi) {
   const skill = sv.skills.find((s) => s.id === sv.selectedId);

--- a/src/utils/tab-manager-tab-ops.js
+++ b/src/utils/tab-manager-tab-ops.js
@@ -25,7 +25,7 @@ import { reorderEntries } from './tab-manager-helpers.js';
  * Public standalone exports (`renderTabBar`, `createTab`, `closeTab`)
  * delegate here so existing call sites keep working unchanged.
  *
- * @param {object} tm - TabManager instance
+ * @param {import('../components/tab-manager.js').TabManager} tm - TabManager instance
  */
 export function bindTabOps(tm) {
   // Stable closures over `tm`, captured once.
@@ -72,7 +72,7 @@ export function bindTabOps(tm) {
 
 /**
  * Build the deps and call doRenderTabBar.
- * @param {object} tm - TabManager instance
+ * @param {import('../components/tab-manager.js').TabManager} tm - TabManager instance
  * @returns {Map<string, HTMLElement>} tab element map
  */
 export function renderTabBar(tm) {

--- a/src/utils/tab-navigation.js
+++ b/src/utils/tab-navigation.js
@@ -45,7 +45,7 @@ export function goToColorGroup(tabs, activeTabId, colorGroupId, switchTo) {
  * Move focus in a direction — delegates to board view or terminal panel.
  * @param {string} direction
  * @param {string} sidebarMode
- * @param {object|null} boardView
+ * @param {import('../components/board-view.js').BoardView|null} boardView
  * @param {() => import('./tab-types.js').WorkspaceTab|undefined} getActiveTab
  */
 export function focusDirection(direction, sidebarMode, boardView, getActiveTab) {

--- a/src/utils/terminal-factory.js
+++ b/src/utils/terminal-factory.js
@@ -101,11 +101,11 @@ export function setupTerminalAddons(term, { openExternal, getCwd, homedir, openP
  *   3. Return all handles needed for cleanup.
  *
  * @param {HTMLElement} container - DOM element the terminal opens into.
- * @param {object} options
+ * @param {{ onPtyData?: (cb: (data: string) => void) => (() => void), termOpts?: import('@xterm/xterm').ITerminalOptions, readonly?: boolean, fitDelay?: number }} options
  * @param {(cb: (data: string) => void) => (() => void)} options.onPtyData
  *   Subscribe to PTY output — receives a callback that writes to the
  *   terminal; must return an unsubscribe function.
- * @param {object}  [options.termOpts]  Extra terminal options forwarded to
+ * @param {import('@xterm/xterm').ITerminalOptions}  [options.termOpts]  Extra terminal options forwarded to
  *   createReadonlyTerminal / createTerminal.
  * @param {boolean} [options.readonly=true]  When true (default) the terminal
  *   is created via createReadonlyTerminal; otherwise via createTerminal with

--- a/src/utils/usage-view-helpers.js
+++ b/src/utils/usage-view-helpers.js
@@ -102,14 +102,14 @@ function _runMetricCards(m) {
  * Callers only supply the parts that differ (sliceKey, headerCards, chartTitle,
  * tables builder) — everything else is handled here.
  *
- * @param {object}   metrics          The full metrics object.
+ * @param {Record<string, object>}   metrics          The full metrics object.
  * @param {object}   options
  * @param {string}   options.sliceKey          Key to extract the metrics slice (e.g. 'agent', 'flow').
- * @param {(m: object) => Array}  options.headerCards  Returns the first 2 cards specific to this tab.
+ * @param {(m: object) => Array<object>}  options.headerCards  Returns the first 2 cards specific to this tab.
  * @param {string}   options.chartTitle        Title displayed above the chart.
- * @param {(m: object, metrics: object) => Array} options.tables  Returns table descriptor(s).
+ * @param {(m: object, metrics: Record<string, object>) => Array<object>} options.tables  Returns table descriptor(s).
  * @param {(m: object) => {empty: string[]}|null} [options.emptyGuard]  Optional early-return for empty state.
- * @returns {{ cards: Array, chart: object, tables: Array } | { empty: string[] }}
+ * @returns {{ cards: Array<object>, chart: object, tables: Array<object> } | { empty: string[] }}
  */
 function _createRunBasedTabConfig(metrics, { sliceKey, headerCards, chartTitle, tables, emptyGuard }) {
   const m = metrics[sliceKey];

--- a/src/utils/worktree-dialog.js
+++ b/src/utils/worktree-dialog.js
@@ -106,7 +106,7 @@ function populateModal(modal, { btnNew, btnExisting, els, pathEl, cancel, confir
 
 /**
  * Build all form elements needed by the worktree dialog.
- * @returns {{ els: object, pathEl: HTMLElement, btnNew: HTMLElement, btnExisting: HTMLElement }}
+ * @returns {{ els: { newInput: HTMLInputElement, baseSelect: HTMLSelectElement, baseLabel: HTMLElement, existingSelect: HTMLSelectElement }, pathEl: HTMLElement, btnNew: HTMLElement, btnExisting: HTMLElement }}
  */
 function _buildWorktreeForm({ allBranches, existingBranches, currentBranch }) {
   const els = {


### PR DESCRIPTION
## Refactoring

Resserrage de 68 annotations JSDoc faibles réparties sur 18 fichiers (les 17 listés dans l'issue, plus `flow-executor-log.js` qui réutilise les typedefs de `flow-executor.js`). Aucune logique d'exécution modifiée — JSDoc uniquement.

Deux patterns traités :

1. **Instances de classes documentées `{object}`** → désormais référencées via `import('...').ClassName` :
   - `sv` → `SkillsView` (skills-view-actions.js)
   - `fv` → `FileViewer` (file-viewer-editor.js)
   - `ft` → `FileTree` (file-tree-dir-ops.js)
   - `tm` → `TabManager` (tab-manager-tab-ops.js)
   - `boardView` → `BoardView` (tab-navigation.js)
   - `termManager` → `FlowCardTerminalManager` (flow-view-rendering.js)

2. **`{Function}` sans signature et collections `{Array}`/`{Set}`/`{Map}` sans generics** → signatures complètes et generics ajoutés.

Typedefs partagés extraits dans `main/flow-executor.js` (`Flow`, `PtyProcess`, `FlowLogger`, `RunningFlowEntry`, `RunningFlows`) et réutilisés via `import('./flow-executor')` dans `flow-executor-log.js`, `flow-executor-run.js` et `flow-scheduler.js`. Réutilisation du typedef existant `FlowDescriptor` (flow-card-setup.js) dans `flow-view-rendering.js`.

Closes #545

## Fichier(s) modifié(s)

- `src/utils/skills-view-actions.js`
- `src/utils/flow-view-rendering.js`
- `main/flow-executor.js`
- `shared/aggregation-utils.js`
- `src/utils/usage-view-helpers.js`
- `src/components/flow-card-terminal.js`
- `src/utils/file-viewer-editor.js`
- `main/command-utils.js`
- `main/flow-executor-log.js`
- `main/flow-executor-run.js`
- `src/utils/terminal-factory.js`
- `src/utils/tab-manager-tab-ops.js`
- `main/flow-scheduler.js`
- `main/manager-init.js`
- `main/safe-handler.js`
- `src/utils/file-tree-dir-ops.js`
- `src/utils/tab-navigation.js`
- `src/utils/worktree-dialog.js`

## Vérifications

- [x] Build OK (`npm run build` → "Build complete.")
- [x] Tests OK (405/405 passés)

---

📂 Path local : `/Users/claude/flux/review/pikagent/`
🤖 PR créée automatiquement par l'Agent Refactor

🤖 Generated with [Claude Code](https://claude.com/claude-code)