### PR TITLE
refactor: remove dead tab-ops wrappers and superfluous export (closes #568)

### DIFF
--- a/src/utils/file-viewer-editor.js
+++ b/src/utils/file-viewer-editor.js
@@ -130,7 +130,7 @@ export async function saveActive(openFiles, activeFile, statusBar, callbacks, fs
 /**
  * Set mode visibility on FileViewer DOM elements.
  */
-export function setModeVisibility(fv, mode, webviewMgr) {
+function setModeVisibility(fv, mode, webviewMgr) {
   const visible = new Set(MODE_CONFIG[mode]?.elements || []);
   for (const key of ALL_STATIC_ELEMENTS) {
     fv[key].style.display = visible.has(key) ? '' : 'none';

--- a/src/utils/tab-manager-tab-ops.js
+++ b/src/utils/tab-manager-tab-ops.js
@@ -22,9 +22,6 @@ import { reorderEntries } from './tab-manager-helpers.js';
  * the bound closures over `tm` are shared. This preserves the exact
  * pre-refactor semantics where `renderTabBar(tm)` re-reads tm state.
  *
- * Public standalone exports (`renderTabBar`, `createTab`, `closeTab`)
- * delegate here so existing call sites keep working unchanged.
- *
  * @param {import('../components/tab-manager.js').TabManager} tm - TabManager instance
  */
 export function bindTabOps(tm) {
@@ -68,29 +65,6 @@ export function bindTabOps(tm) {
       configManager: tm.configManager,
     }, createTabFn, switchToFn, id),
   };
-}
-
-/**
- * Build the deps and call doRenderTabBar.
- * @param {import('../components/tab-manager.js').TabManager} tm - TabManager instance
- * @returns {Map<string, HTMLElement>} tab element map
- */
-export function renderTabBar(tm) {
-  return bindTabOps(tm).renderTabBar();
-}
-
-/**
- * Build the deps and call doCreateTab.
- */
-export function createTab(tm, switchTo, name, cwd) {
-  return bindTabOps(tm).createTab(switchTo, name, cwd);
-}
-
-/**
- * Build the deps and call doCloseTab.
- */
-export function closeTab(tm, createTabFn, switchToFn, id) {
-  return bindTabOps(tm).closeTab(createTabFn, switchToFn, id);
 }
 
 /**


### PR DESCRIPTION
## Refactoring

Suppression de code mort identifié par l'Agent Triage (#568) :

- Retrait des trois wrappers standalone `renderTabBar`, `createTab` et `closeTab` de `src/utils/tab-manager-tab-ops.js`. Ces fonctions déléguaient à `bindTabOps` mais n'étaient importées nulle part — le seul consommateur (`src/components/tab-manager.js`) n'utilise que `bindTabOps`, `reorderTab` et `renameTab`. Le paragraphe de JSDoc obsolète qui les mentionnait a aussi été retiré.
- Retrait du mot-clé `export` superflu sur `setModeVisibility` dans `src/utils/file-viewer-editor.js` : la fonction n'est utilisée qu'en interne par `switchMode`.

Aucun changement de comportement runtime — suppression de code mort pur, vérifiée par grep sur tout le codebase et la suite de tests.

Closes #568

## Fichier(s) modifié(s)

- `src/utils/tab-manager-tab-ops.js` (−26 lignes)
- `src/utils/file-viewer-editor.js` (mot-clé `export` retiré)

## Vérifications

- [x] Build OK (`npm run build`)
- [x] Tests OK (`npm test` — 409 tests, 27 fichiers)

---

📂 Path local : `/Users/claude/flux/review/pikagent/`
🤖 PR créée automatiquement par l'Agent Refactor