### PR TITLE
refactor: replace bare {object} JSDoc types with precise typedefs (closes #569)

### DIFF
--- a/main/flow-executor.js
+++ b/main/flow-executor.js
@@ -66,6 +66,14 @@ const { toLogFilename } = require('../shared/date-utils');
  * @property {number} rows  - terminal row count
  */
 
+/**
+ * @typedef {object} PtyManager
+ * @property {Map<string, unknown>} processes - active PTY processes by id
+ * @property {(opts: PtyCreateOpts) => PtyProcess} create - spawn a PTY process
+ * @property {(id: string) => void} kill - kill a PTY process
+ * @property {(id: string, data: string) => void} write - write input to a PTY process
+ */
+
 // --- Top-level helpers ---
 
 /**
@@ -197,8 +205,8 @@ function getRunning(runningFlows) {
  * Creates a flow executor bound to external dependencies.
  *
  * @param {{
- *   getPtyManager: () => object | null,
- *   sendToWindow: (channel: string, payload: object) => void,
+ *   getPtyManager: () => PtyManager | null,
+ *   sendToWindow: SendToWindow,
  *   getFlow: (id: string) => Promise<Flow | null>,
  *   saveFlow: (flow: Flow) => Promise<unknown>,
  *   log: FlowLogger,

--- a/main/flow-executor.js
+++ b/main/flow-executor.js
@@ -53,13 +53,26 @@ const { toLogFilename } = require('../shared/date-utils');
  * @typedef {Map<string, RunningFlowEntry>} RunningFlows
  */
 
+/**
+ * Sends an IPC message to the renderer window.
+ * @typedef {(channel: string, payload: Record<string, unknown>) => void} SendToWindow
+ */
+
+/**
+ * @typedef {object} PtyCreateOpts
+ * @property {string} id    - unique PTY identifier
+ * @property {string} cwd   - working directory for the process
+ * @property {number} cols  - terminal column count
+ * @property {number} rows  - terminal row count
+ */
+
 // --- Top-level helpers ---
 
 /**
  * Cleans up a finished flow process: clears timeout, removes PTY,
  * and notifies the renderer.
  *
- * @param {{ getPtyManager: () => { processes: Map<string, unknown> }, sendToWindow: (channel: string, payload: object) => void }} deps
+ * @param {{ getPtyManager: () => { processes: Map<string, unknown> }, sendToWindow: SendToWindow }} deps
  * @param {RunningFlows} runningFlows
  * @param {string} flowId
  * @param {string} ptyId
@@ -77,7 +90,7 @@ function cleanupFlowProcess(deps, runningFlows, flowId, ptyId, exitCode) {
 /**
  * Wires up PTY data/exit listeners for a running flow process.
  *
- * @param {{ sendToWindow: (channel: string, payload: object) => void, getPtyManager: () => { processes: Map<string, unknown> }, getFlow: (id: string) => Promise<Flow|null>, saveFlow: (flow: Flow) => Promise<unknown>, log: FlowLogger }} deps
+ * @param {{ sendToWindow: SendToWindow, getPtyManager: () => { processes: Map<string, unknown> }, getFlow: (id: string) => Promise<Flow|null>, saveFlow: (flow: Flow) => Promise<unknown>, log: FlowLogger }} deps
  * @param {RunningFlows} runningFlows
  * @param {PtyProcess} proc
  * @param {Flow} flow
@@ -105,7 +118,7 @@ function setupPtyListeners(deps, runningFlows, proc, flow, ptyId, runTimestamp) 
 /**
  * Executes a single flow inside a new PTY process.
  *
- * @param {{ getPtyManager: () => { create: (opts: object) => PtyProcess, kill: (id: string) => void, write: (id: string, data: string) => void } | null, sendToWindow: (channel: string, payload: object) => void, log: FlowLogger, getFlow: (id: string) => Promise<Flow|null>, saveFlow: (flow: Flow) => Promise<unknown> }} deps
+ * @param {{ getPtyManager: () => { create: (opts: PtyCreateOpts) => PtyProcess, kill: (id: string) => void, write: (id: string, data: string) => void } | null, sendToWindow: SendToWindow, log: FlowLogger, getFlow: (id: string) => Promise<Flow|null>, saveFlow: (flow: Flow) => Promise<unknown> }} deps
  * @param {RunningFlows} runningFlows
  * @param {Flow} flow
  */

--- a/src/utils/file-viewer-editor.js
+++ b/src/utils/file-viewer-editor.js
@@ -21,8 +21,8 @@ import { renderTabs as doRenderTabs } from './file-viewer-tabs.js';
 /**
  * Build the FileViewer shell DOM inside `container`.
  * @param {HTMLElement} container
- * @param {{ GitChangesView: Function }} components
- * @returns {{ modeBar: HTMLElement, tabsBar: HTMLElement, breadcrumb: HTMLElement, editorWrapper: HTMLElement, gitViewEl: HTMLElement, gitChanges: object, statusBar: HTMLElement }}
+ * @param {{ GitChangesView: typeof import('../components/git-changes-view.js').GitChangesView }} components
+ * @returns {{ modeBar: HTMLElement, tabsBar: HTMLElement, breadcrumb: HTMLElement, editorWrapper: HTMLElement, gitViewEl: HTMLElement, gitChanges: import('../components/git-changes-view.js').GitChangesView, statusBar: HTMLElement }}
  */
 export function renderFileViewerShell(container, components) {
   container.replaceChildren();

--- a/src/utils/usage-view-helpers.js
+++ b/src/utils/usage-view-helpers.js
@@ -75,6 +75,49 @@ export function createSection(title) {
   );
 }
 
+// --- Tab config typedefs ---
+
+/**
+ * A per-tab metrics slice extracted from the full metrics object. Its shape
+ * varies per tab (agent / flow / token), so it is kept as a loose record.
+ * @typedef {Record<string, unknown>} MetricsSlice
+ */
+
+/**
+ * @typedef {object} UsageCard
+ * @property {string} label         - card label
+ * @property {string|number} value  - card value
+ * @property {string} cls           - CSS class applied to the value
+ * @property {string} [sub]         - optional sub-text shown below the value
+ */
+
+/**
+ * @typedef {object} UsageChart
+ * @property {string} title                                 - chart title
+ * @property {Array<Record<string, unknown>>} data          - per-day data points
+ * @property {Array<{ key: string, cls: string }>} segments - stacked-bar segment definitions
+ * @property {(day: Record<string, unknown>) => string} tooltip - builds the tooltip text for a day
+ */
+
+/**
+ * @typedef {object} UsageTable
+ * @property {string} title      - table title
+ * @property {string[]} headers  - column headers
+ * @property {string} tableCls   - CSS class applied to the <table>
+ * @property {Array<Record<string, unknown>>} data - row data
+ * @property {(row: Record<string, unknown>) => HTMLTableRowElement} renderRow - renders one <tr>
+ */
+
+/**
+ * A built tab configuration.
+ * @typedef {{ cards: UsageCard[], chart: UsageChart, tables: UsageTable[] }} TabConfig
+ */
+
+/**
+ * An empty-state descriptor returned in place of a TabConfig.
+ * @typedef {{ empty: string[] }} EmptyTabConfig
+ */
+
 // --- Tab configurations ---
 
 /**
@@ -102,14 +145,14 @@ function _runMetricCards(m) {
  * Callers only supply the parts that differ (sliceKey, headerCards, chartTitle,
  * tables builder) — everything else is handled here.
  *
- * @param {Record<string, object>}   metrics          The full metrics object.
+ * @param {Record<string, MetricsSlice>}   metrics          The full metrics object.
  * @param {object}   options
  * @param {string}   options.sliceKey          Key to extract the metrics slice (e.g. 'agent', 'flow').
- * @param {(m: object) => Array<object>}  options.headerCards  Returns the first 2 cards specific to this tab.
+ * @param {(m: MetricsSlice) => UsageCard[]}  options.headerCards  Returns the first 2 cards specific to this tab.
  * @param {string}   options.chartTitle        Title displayed above the chart.
- * @param {(m: object, metrics: Record<string, object>) => Array<object>} options.tables  Returns table descriptor(s).
- * @param {(m: object) => {empty: string[]}|null} [options.emptyGuard]  Optional early-return for empty state.
- * @returns {{ cards: Array<object>, chart: object, tables: Array<object> } | { empty: string[] }}
+ * @param {(m: MetricsSlice, metrics: Record<string, MetricsSlice>) => UsageTable[]} options.tables  Returns table descriptor(s).
+ * @param {(m: MetricsSlice) => {empty: string[]}|null} [options.emptyGuard]  Optional early-return for empty state.
+ * @returns {TabConfig | EmptyTabConfig}
  */
 function _createRunBasedTabConfig(metrics, { sliceKey, headerCards, chartTitle, tables, emptyGuard }) {
   const m = metrics[sliceKey];


### PR DESCRIPTION
## Refactoring

Remplacement des types JSDoc `{object}` nus par des types précis, identifié par l'Agent Triage (#569). Aucun changement de comportement runtime — annotations JSDoc uniquement.

**`src/utils/usage-view-helpers.js`** — ajout de 5 typedefs (`MetricsSlice`, `UsageCard`, `UsageChart`, `UsageTable`, `TabConfig`, `EmptyTabConfig`) et remplacement dans la JSDoc de `_createRunBasedTabConfig` :
- `Record<string, object>` → `Record<string, MetricsSlice>`
- `(m: object) => Array<object>` → `(m: MetricsSlice) => UsageCard[]`
- `Array<object>` (tables) → `UsageTable[]`
- `@returns {{ cards: Array<object>, chart: object, tables: Array<object> } | {...}}` → `TabConfig | EmptyTabConfig`

**`main/flow-executor.js`** — ajout des typedefs `SendToWindow` et `PtyCreateOpts`, réutilisés dans les 3 signatures `deps` :
- `sendToWindow: (channel: string, payload: object) => void` → `sendToWindow: SendToWindow` (×3)
- `create: (opts: object) => PtyProcess` → `create: (opts: PtyCreateOpts) => PtyProcess`

**`src/utils/file-viewer-editor.js`** — `renderFileViewerShell` :
- propriété de retour `gitChanges: object` → `gitChanges: GitChangesView` (type importé)
- paramètre `{ GitChangesView: Function }` → typé via `typeof import(...)` pour cohérence

Note : `@param {object} options` (paramètre déstructuré documenté ensuite via `options.xxx`) est conservé — c'est l'idiome JSDoc standard, non un type faible.

Closes #569

## Fichier(s) modifié(s)

- `src/utils/usage-view-helpers.js`
- `main/flow-executor.js`
- `src/utils/file-viewer-editor.js`

## Vérifications

- [x] Build OK (`npm run build`)
- [x] Tests OK (`npm test` — 409 tests, 27 fichiers)

---

📂 Path local : `/Users/claude/flux/review/pikagent/`
🤖 PR créée automatiquement par l'Agent Refactor