### PR TITLE
refactor: extract CachedJsonFile to deduplicate persistence pattern

### DIFF
--- a/main/cached-json-file.js
+++ b/main/cached-json-file.js
@@ -1,0 +1,68 @@
+const { readJson, writeJson } = require('./fs-utils');
+
+/**
+ * A single JSON file backed by an in-memory cache.
+ *
+ * Eliminates the repetitive cache + readJson / writeJson / ensureDir pattern
+ * shared by config-manager (meta file) and session-manager (sessions file).
+ *
+ * Usage:
+ *   const meta = new CachedJsonFile(META_FILE, ensureDirFn, { defaultConfig: null });
+ *   const data = await meta.read();   // cached after first read
+ *   await meta.write(newData);        // updates cache + disk
+ */
+class CachedJsonFile {
+  /**
+   * @param {string} filePath   - absolute path to the JSON file
+   * @param {() => Promise<void>} ensureDirFn - idempotent directory-creation function
+   * @param {T} defaultValue    - value returned when the file does not exist
+   * @template T
+   */
+  constructor(filePath, ensureDirFn, defaultValue) {
+    this._filePath = filePath;
+    this._ensureDir = ensureDirFn;
+    this._default = defaultValue;
+    this._cache = null;
+    this._loaded = false;
+  }
+
+  /** Read the file, returning the cached value after the first successful read. */
+  async read() {
+    if (this._loaded) return this._cache;
+    const data = await readJson(this._filePath);
+    this._cache = data != null ? data : (
+      typeof this._default === 'object' && this._default !== null
+        ? (Array.isArray(this._default) ? [...this._default] : { ...this._default })
+        : this._default
+    );
+    this._loaded = true;
+    return this._cache;
+  }
+
+  /** Write data to disk and update the in-memory cache. */
+  async write(data) {
+    await this._ensureDir();
+    this._cache = data;
+    this._loaded = true;
+    await writeJson(this._filePath, data);
+  }
+
+  /** Return the cached value (or null if not yet loaded). */
+  get() {
+    return this._cache;
+  }
+
+  /** Manually set the cached value without writing to disk. */
+  set(value) {
+    this._cache = value;
+    this._loaded = true;
+  }
+
+  /** Invalidate the cache so the next read() will re-fetch from disk. */
+  invalidate() {
+    this._cache = null;
+    this._loaded = false;
+  }
+}
+
+module.exports = { CachedJsonFile };

--- a/main/config-manager.js
+++ b/main/config-manager.js
@@ -5,7 +5,8 @@ const { DEFAULT_META, buildConfigRecord, formatConfigList } = require('./config-
 // sanitizeSegment (git-ref-safe, hyphen-based) by design; see string-utils.js.
 const { sanitizeName } = require('../shared/string-utils');
 const { trySafe } = require('./logger');
-const { JsonStore, CachedJsonFile } = require('./json-store');
+const { JsonStore } = require('./json-store');
+const { CachedJsonFile } = require('./cached-json-file');
 
 const store = new JsonStore(CONFIG_DIR, 'config-manager', {
   idToFile: (name) => `${sanitizeName(name)}.json`,

--- a/main/json-store.js
+++ b/main/json-store.js
@@ -2,6 +2,7 @@ const path = require('path');
 const fsp = require('fs/promises');
 const { readJson, writeJson, readDirJson, ensureDirOnce } = require('./fs-utils');
 const { createLogger, trySafe } = require('./logger');
+const { CachedJsonFile } = require('./cached-json-file');
 
 /**
  * Reusable JSON-file CRUD store.
@@ -125,63 +126,7 @@ class JsonStore {
   }
 }
 
-/**
- * A single JSON file backed by an in-memory cache.
- *
- * Eliminates the repetitive cache + readJson / writeJson / ensureDir pattern
- * shared by config-manager (meta file) and session-manager (sessions file).
- *
- * Usage:
- *   const meta = new CachedJsonFile(META_FILE, ensureDirFn, { defaultConfig: null });
- *   const data = await meta.read();   // cached after first read
- *   await meta.write(newData);        // updates cache + disk
- */
-class CachedJsonFile {
-  /**
-   * @param {string} filePath   - absolute path to the JSON file
-   * @param {() => Promise<void>} ensureDirFn - idempotent directory-creation function
-   * @param {T} defaultValue    - value returned when the file does not exist
-   * @template T
-   */
-  constructor(filePath, ensureDirFn, defaultValue) {
-    this._filePath = filePath;
-    this._ensureDir = ensureDirFn;
-    this._default = defaultValue;
-    this._cache = null;
-    this._loaded = false;
-  }
-
-  /** Read the file, returning the cached value after the first successful read. */
-  async read() {
-    if (this._loaded) return this._cache;
-    const data = await readJson(this._filePath);
-    this._cache = data != null ? data : (
-      typeof this._default === 'object' && this._default !== null
-        ? { ...this._default }
-        : this._default
-    );
-    this._loaded = true;
-    return this._cache;
-  }
-
-  /** Write data to disk and update the in-memory cache. */
-  async write(data) {
-    await this._ensureDir();
-    this._cache = data;
-    this._loaded = true;
-    await writeJson(this._filePath, data);
-  }
-
-  /** Return the cached value (or null if not yet loaded). */
-  get() {
-    return this._cache;
-  }
-
-  /** Manually set the cached value without writing to disk. */
-  set(value) {
-    this._cache = value;
-    this._loaded = true;
-  }
-}
+// CachedJsonFile has been extracted to its own module (./cached-json-file.js).
+// Re-exported here for backward compatibility.
 
 module.exports = { JsonStore, CachedJsonFile };

--- a/main/session-manager.js
+++ b/main/session-manager.js
@@ -4,7 +4,7 @@ const { ensureDirOnce } = require('./fs-utils');
 const { generateSessionId, isFlowTerminal, buildEndedRecord, buildActiveRecord, trimSessions } = require('./session-helpers');
 const { nowISO } = require('../shared/date-utils');
 const { createPollingManager } = require('../shared/polling-manager');
-const { CachedJsonFile } = require('./json-store');
+const { CachedJsonFile } = require('./cached-json-file');
 const { createLogger, trySafe } = require('./logger');
 
 const log = createLogger('session-manager');


### PR DESCRIPTION
## Refactoring

Extrait une classe CachedJsonFile réutilisable pour remplacer le pattern dupliqué de cache+readJson+writeJson dans les managers.

La classe `CachedJsonFile` vivait auparavant dans `json-store.js` aux côtés de `JsonStore`. Ce PR l'extrait dans son propre module dédié pour une meilleure séparation des responsabilités, et ajoute une méthode `invalidate()` ainsi qu'une correction pour la copie des valeurs par défaut de type tableau.

Closes #573

## Fichier(s) modifié(s)

- `main/cached-json-file.js` (nouveau)
- `main/json-store.js` (classe retirée, re-export pour backward compat)
- `main/config-manager.js` (import mis à jour)
- `main/session-manager.js` (import mis à jour)

## Vérifications

- [x] Build OK
- [x] Tests OK (409 tests passing)

---

PR créée automatiquement par l'Agent Refactor