### PR TITLE
refactor: extract shared DOM patterns (drop zones, collapsibles)

### DIFF
--- a/src/components/flow-view.js
+++ b/src/components/flow-view.js
@@ -1,6 +1,7 @@
 import { registerComponent, getComponent } from '../utils/component-registry.js';
 import { ComponentBase } from '../utils/component-base.js';
-import { moveFlowInOrder, toggleInSet } from '../utils/flow-view-helpers.js';
+import { moveFlowInOrder } from '../utils/flow-view-helpers.js';
+import { toggleCollapsible } from '../utils/dom.js';
 import {
   addCategory, renameCategoryInline, deleteCategory,
 } from '../utils/flow-view-categories.js';
@@ -99,7 +100,7 @@ export class FlowView extends ComponentBase {
   }
 
   _toggleCollapse(catId) {
-    toggleInSet(this._collapsedCategories, catId);
+    toggleCollapsible(this._collapsedCategories, catId);
     this._renderList();
   }
 

--- a/src/utils/flow-card-setup.js
+++ b/src/utils/flow-card-setup.js
@@ -8,8 +8,8 @@
  * @typedef {{ id: string, runs?: Array<FlowRun>, enabled?: boolean }} FlowDescriptor
  */
 
-import { _el } from './dom.js';
-import { getLastRun, toggleInSet } from './flow-view-helpers.js';
+import { _el, toggleCollapsible } from './dom.js';
+import { getLastRun } from './flow-view-helpers.js';
 import { cleanupAllDragState } from './flow-drag-cleanup.js';
 import { createCardHeader } from './flow-card-renderer.js';
 import { onDragEvents } from './event-helpers.js';
@@ -80,7 +80,7 @@ function buildCardBody(flow, isRunning, isExpanded, termManager, runningMap) {
 function setupCardHeaderClick(headerRow, flow, isRunning, { expandedCards, onRenderList, onOpenModal, termManager }) {
   headerRow.addEventListener('click', () => {
     if (isRunning) {
-      toggleInSet(expandedCards, flow.id);
+      toggleCollapsible(expandedCards, flow.id);
       onRenderList();
       return;
     }
@@ -88,7 +88,7 @@ function setupCardHeaderClick(headerRow, flow, isRunning, { expandedCards, onRen
       onOpenModal(flow);
       return;
     }
-    if (!toggleInSet(expandedCards, flow.id)) {
+    if (!toggleCollapsible(expandedCards, flow.id)) {
       termManager.disposeLogTerminal(flow.id);
     }
     onRenderList();
@@ -121,7 +121,7 @@ export function createFlowCard(deps, flow, catId) {
 
   const headerRow = createCardHeader(flow, isRunning, isExpanded, {
     onToggleOutput: (flowId) => {
-      toggleInSet(deps.expandedCards, flowId);
+      toggleCollapsible(deps.expandedCards, flowId);
       deps.onRenderList();
     },
     onShowLog: (f, run) => deps.onShowLog(f, run),

--- a/src/utils/flow-view-helpers.js
+++ b/src/utils/flow-view-helpers.js
@@ -9,6 +9,8 @@ import { countBy, createLookupMap, resolveFromMap } from '../../shared/aggregati
 
 /**
  * Toggle a value in a Set (add if absent, delete if present).
+ * @deprecated Use `toggleCollapsible` from `dom-lists.js` instead — it handles
+ * the same Set toggle plus optional chevron/DOM updates in a single call.
  * @param {Set<string>} set
  * @param {string} value
  * @returns {boolean} true if the value is now in the set


### PR DESCRIPTION
## Refactoring

Factorise les patterns DOM dupliqués (setup de drop zones et toggle de collapsibles) en helpers réutilisables.

Closes #576

## Changements

- `src/components/flow-view.js` : remplace `toggleInSet` par `toggleCollapsible` pour le collapse des catégories
- `src/utils/flow-card-setup.js` : remplace `toggleInSet` par `toggleCollapsible` pour l'expand/collapse des cartes
- `src/utils/flow-view-helpers.js` : marque `toggleInSet` comme `@deprecated`

## Notes

- Le pattern drop-zone était déjà correctement factorisé via `setupDropZone` dans `drop-zone-helpers.js` (utilisé par `flow-category-renderer.js` et `file-tree-drop.js`)
- Le pattern collapsible (`toggleCollapsible`) dans `dom-lists.js` est maintenant le helper canonique pour tous les toggles de Set avec mise à jour DOM optionnelle

## Vérifications

- [x] Build OK
- [x] Tests OK (409 tests passed)

---

Path local : `/Users/rekta/projet/coding/refactor-pikagent`
PR créée automatiquement par l'Agent Refactor