### PR TITLE
refactor: split terminal-panel.js into focused sub-modules (#572)

### DIFF
--- a/src/components/terminal-panel.js
+++ b/src/components/terminal-panel.js
@@ -1,14 +1,26 @@
-import { emitTerminalRemoved } from '../utils/terminal-events.js';
-import { emitLayoutChanged } from '../utils/workspace-events.js';
-import { _el } from '../utils/dom.js';
 import { registerComponent } from '../utils/component-registry.js';
-import { SplitNode, RESIZE_CURSOR, doResize } from '../utils/terminal-panel-helpers.js';
-import { setupDragHandler, setupResizeHandler, DropIndicatorManager, detachElement } from '../utils/terminal-panel-drag.js';
-import { serializeLayout, serializeElement, moveTerminal as moveTerminalHelper, splitTerminal, focusDirection as focusDirectionHelper } from '../utils/terminal-panel-state.js';
+import {
+  setupDragHandler,
+  setupResizeHandler,
+  DropIndicatorManager,
+  detachElement,
+  RESIZE_CURSOR,
+  doResize,
+  emitLayoutChanged,
+} from '../utils/terminal-panel-drag.js';
+import {
+  serializeLayout,
+  serializeElement,
+  moveTerminal as moveTerminalHelper,
+  splitTerminal,
+  focusDirection as focusDirectionHelper,
+  emitTerminalRemoved,
+} from '../utils/terminal-panel-state.js';
 import {
   buildTopBar,
   createTerminalNode as createTerminalNodeHelper,
   buildFromTree as buildFromTreeHelper,
+  createSplitHandle as createSplitHandleHelper,
 } from '../utils/terminal-node-builder.js';
 import { terminalPanelFacade } from '../facades/terminal-panel-facade.js';
 
@@ -38,9 +50,9 @@ export class TerminalPanel {
   // ===== DOM Helpers =====
 
   _createSplitHandle(direction, splitEl) {
-    const handle = _el('div', `split-handle split-handle-${direction}`);
-    this.setupResizeHandle(handle, splitEl, direction);
-    return handle;
+    return createSplitHandleHelper(direction, splitEl, (h, s, d) =>
+      this.setupResizeHandle(h, s, d)
+    );
   }
 
   _findTerminalCwd(el) {

--- a/src/utils/terminal-node-builder.js
+++ b/src/utils/terminal-node-builder.js
@@ -69,6 +69,20 @@ export function createTerminalNode(cwd, defaultCwd, terminals, { buildTopBar: bu
 }
 
 /**
+ * Create a split-handle DOM element and wire up its resize behaviour.
+ *
+ * @param {string} direction - split direction ('horizontal' | 'vertical')
+ * @param {HTMLElement} splitEl - the split container the handle belongs to
+ * @param {(handle: HTMLElement, splitEl: HTMLElement, direction: string) => void} setupResizeHandle - resize wiring callback
+ * @returns {HTMLElement}
+ */
+export function createSplitHandle(direction, splitEl, setupResizeHandle) {
+  const handle = _el('div', `split-handle split-handle-${direction}`);
+  setupResizeHandle(handle, splitEl, direction);
+  return handle;
+}
+
+/**
  * Recursively build a split-panel tree from a serialised layout descriptor.
  *
  * @param {import('./terminal-serializer.js').SplitTreeNode} tree - serialized layout node

--- a/src/utils/terminal-panel-drag.js
+++ b/src/utils/terminal-panel-drag.js
@@ -1,10 +1,21 @@
 /**
- * Terminal panel drag/drop facade.
- * Encapsulates drag-helpers, terminal-drop-indicator, and split-layout
- * to reduce coupling in terminal-panel.js.
+ * Terminal panel drag/drop & resize facade.
+ * Encapsulates drag-helpers, terminal-drop-indicator, split-layout,
+ * resize primitives and the layout-changed event so that
+ * terminal-panel.js does not need to import them directly.
  */
 import { setupDragHandler, setupResizeHandler } from './drag-helpers.js';
 import { DropIndicatorManager } from './terminal-drop-indicator.js';
 import { detachElement } from './split-layout.js';
+import { RESIZE_CURSOR, doResize } from './terminal-panel-helpers.js';
+import { emitLayoutChanged } from './workspace-events.js';
 
-export { setupDragHandler, setupResizeHandler, DropIndicatorManager, detachElement };
+export {
+  setupDragHandler,
+  setupResizeHandler,
+  DropIndicatorManager,
+  detachElement,
+  RESIZE_CURSOR,
+  doResize,
+  emitLayoutChanged,
+};

--- a/src/utils/terminal-panel-state.js
+++ b/src/utils/terminal-panel-state.js
@@ -1,7 +1,8 @@
 /**
  * Terminal panel state/serialization facade.
- * Encapsulates terminal-serializer and terminal-split
- * to reduce coupling in terminal-panel.js.
+ * Encapsulates terminal-serializer, terminal-split and the
+ * terminal-removed event so that terminal-panel.js does not need
+ * to import them directly.
  */
 import { serializeLayout, serializeElement } from './terminal-serializer.js';
 import {
@@ -9,5 +10,13 @@ import {
   splitTerminal,
   focusDirection,
 } from './terminal-split.js';
+import { emitTerminalRemoved } from './terminal-events.js';
 
-export { serializeLayout, serializeElement, moveTerminal, splitTerminal, focusDirection };
+export {
+  serializeLayout,
+  serializeElement,
+  moveTerminal,
+  splitTerminal,
+  focusDirection,
+  emitTerminalRemoved,
+};


### PR DESCRIPTION
## Refactoring

`src/components/terminal-panel.js` passe de 9 à **5 imports** (12 dans l'énoncé initial de l'issue). L'extraction des façades `terminal-panel-drag.js` et `terminal-panel-state.js` avait déjà été amorcée par le PR #580 ; ce PR la complète pour atteindre la cible.

Changements :
- **`terminal-panel-drag.js`** (façade drag/resize) : regroupe désormais aussi `RESIZE_CURSOR`, `doResize` (depuis terminal-panel-helpers) et `emitLayoutChanged` (workspace-events) — le resize relève du domaine drag/resize.
- **`terminal-panel-state.js`** (façade état/sérialisation) : regroupe désormais aussi `emitTerminalRemoved` (terminal-events) — la suppression de terminal est une mutation d'état.
- **`terminal-node-builder.js`** : nouvelle fonction `createSplitHandle()` qui encapsule la création de l'élément DOM `split-handle`, ce qui supprime le besoin d'importer `_el` (dom.js) dans terminal-panel.js.
- **`terminal-panel.js`** : suppression de l'import mort `SplitNode` (jamais utilisé) ; imports directs de `dom.js`, `terminal-panel-helpers.js`, `terminal-events.js` et `workspace-events.js` éliminés, tous routés via les façades.

Refactoring purement structurel : aucune logique métier modifiée (création/split/merge de terminaux, drag&drop, resize, sérialisation de layout inchangés).

Imports finaux de terminal-panel.js : `component-registry`, `terminal-panel-drag`, `terminal-panel-state`, `terminal-node-builder`, `terminal-panel-facade`.

Closes #572

## Fichier(s) modifié(s)

- `src/components/terminal-panel.js`
- `src/utils/terminal-panel-drag.js`
- `src/utils/terminal-panel-state.js`
- `src/utils/terminal-node-builder.js`

## Vérifications

- [x] Build OK
- [x] Tests OK (411 tests passés)

---

📂 Path local : `/Users/claude/flux/review/pikagent/`
🤖 PR créée automatiquement par l'Agent Refactor