### PR TITLE
refactor: dedupe DOM patterns (drop zones, dialogs, chevrons) (#576)

### DIFF
--- a/src/utils/dom-dialogs.js
+++ b/src/utils/dom-dialogs.js
@@ -26,6 +26,29 @@ export function createModalOverlay(overlayClass, modalClass, onClose) {
   return { overlay, modal };
 }
 
+/**
+ * Build a dialog button row containing a cancel button followed by a confirm
+ * button.  Extracts the cancel/confirm pair previously duplicated across
+ * showPromptDialog, showConfirmDialog and the worktree dialog.
+ *
+ * @param {{ containerClass: string,
+ *           confirmLabel?: string, cancelLabel?: string,
+ *           confirmClass?: string, cancelClass?: string,
+ *           onConfirm: () => void, onCancel: () => void }} opts
+ * @returns {HTMLElement} the button-row container element
+ */
+export function buildDialogButtons({
+  containerClass,
+  confirmLabel = 'OK', cancelLabel = 'Cancel',
+  confirmClass, cancelClass,
+  onConfirm, onCancel,
+}) {
+  return _el('div', containerClass,
+    createActionButton({ text: cancelLabel, cls: cancelClass, onClick: onCancel }),
+    createActionButton({ text: confirmLabel, cls: confirmClass, onClick: onConfirm }),
+  );
+}
+
 // ── Dialog lifecycle ──
 
 /**
@@ -78,10 +101,12 @@ export function showPromptDialog({ title, placeholder = '', defaultValue = '', c
       modal.append(
         _el('label', 'prompt-dialog-label', title),
         input,
-        _el('div', 'prompt-dialog-btns',
-          createActionButton({ text: cancelLabel, cls: 'prompt-dialog-cancel', onClick: cancel }),
-          createActionButton({ text: confirmLabel, cls: 'prompt-dialog-confirm', onClick: confirm }),
-        ),
+        buildDialogButtons({
+          containerClass: 'prompt-dialog-btns',
+          confirmLabel, cancelLabel,
+          confirmClass: 'prompt-dialog-confirm', cancelClass: 'prompt-dialog-cancel',
+          onConfirm: confirm, onCancel: cancel,
+        }),
       );
       return () => {
         input.focus();
@@ -123,10 +148,12 @@ export function showConfirmDialog(message, { confirmLabel = 'OK', cancelLabel = 
       if (typeof message === 'string') modal.appendChild(_el('p', null, message));
       else modal.appendChild(message);
 
-      const btnRow = _el('div', 'confirm-buttons',
-        createActionButton({ text: cancelLabel, cls: 'confirm-cancel', onClick: cancel }),
-        createActionButton({ text: confirmLabel, cls: 'confirm-ok', onClick: () => cleanup(true) }),
-      );
+      const btnRow = buildDialogButtons({
+        containerClass: 'confirm-buttons',
+        confirmLabel, cancelLabel,
+        confirmClass: 'confirm-ok', cancelClass: 'confirm-cancel',
+        onConfirm: () => cleanup(true), onCancel: cancel,
+      });
       modal.appendChild(btnRow);
 
       onKeyAction(overlay, {

--- a/src/utils/worktree-dialog.js
+++ b/src/utils/worktree-dialog.js
@@ -10,7 +10,7 @@
  */
 
 import { _el, createActionButton, _vis } from './dom.js';
-import { createDialogBase } from './dom-dialogs.js';
+import { createDialogBase, buildDialogButtons } from './dom-dialogs.js';
 import { onKeyAction } from './event-helpers.js';
 // sanitizeSegment: git-ref-safe sanitization — collapses invalid chars into
 // hyphens, trims leading/trailing hyphens, no spaces allowed.  This differs
@@ -67,10 +67,12 @@ function buildModeButtons(onNew, onExisting) {
 
 /** Build the Cancel / Create action buttons row. */
 function buildActionButtons(cancel, confirm) {
-  return _el('div', 'prompt-dialog-btns',
-    createActionButton({ text: 'Cancel', cls: 'prompt-dialog-cancel', onClick: cancel }),
-    createActionButton({ text: 'Create', cls: 'prompt-dialog-confirm', onClick: confirm }),
-  );
+  return buildDialogButtons({
+    containerClass: 'prompt-dialog-btns',
+    confirmLabel: 'Create', cancelLabel: 'Cancel',
+    confirmClass: 'prompt-dialog-confirm', cancelClass: 'prompt-dialog-cancel',
+    onConfirm: confirm, onCancel: cancel,
+  });
 }
 
 /** Apply visibility for the given mode to the form elements. */


### PR DESCRIPTION
## Refactoring

État des 3 catégories de l'issue après analyse du worktree (basé sur `origin/dev`) :

- **Drop zones** — déjà entièrement factorisées sur `dev`. `setupDropZone({ onDrop, hoverClass, accept, ... })` dans `drop-zone-helpers.js` est utilisé par les 3 call-sites (`flow-category-renderer.js`, `file-tree-drop.js`, et le file-tree via `file-tree-section-dom.js`). Aucun `addEventListener('dragover'/'drop')` brut restant. Pas de changement.
- **Chevrons / Collapsibles** — déjà entièrement factorisées sur `dev`. `buildChevronRow` + `toggleCollapsible` (`dom-lists.js`) couvrent `file-tree-renderer.js`, `file-tree-section-dom.js`, `file-tree-dir-ops.js`, `flow-category-renderer.js` et `flow-view.js`. Pas de changement.
- **Dialogs / Modals** — duplication réelle restante : la paire de boutons cancel/confirm était reconstruite manuellement à 3 endroits (`showPromptDialog`, `showConfirmDialog`, et `worktree-dialog.js`), à chaque fois `_el('div', containerClass, createActionButton(cancel), createActionButton(confirm))`. Extraction d'un helper `buildDialogButtons({ containerClass, confirmLabel, cancelLabel, confirmClass, cancelClass, onConfirm, onCancel })` dans `dom-dialogs.js`, réutilisé par les 3 call-sites. Aucun changement de logique (mêmes classes CSS, mêmes labels, ordre cancel→confirm préservé).

Closes #576

## Fichier(s) modifié(s)

- `src/utils/dom-dialogs.js` — ajout de `buildDialogButtons`, réutilisé par `showPromptDialog` et `showConfirmDialog`
- `src/utils/worktree-dialog.js` — `buildActionButtons` réécrit via `buildDialogButtons`

## Vérifications

- [x] Build OK
- [x] Tests OK (411 tests)

---

📂 Path local : `/Users/claude/flux/review/pikagent/`
🤖 PR créée automatiquement par l'Agent Refactor