### PR TITLE
refactor: remove duplicate render() method in file-viewer.js

### DIFF
--- a/src/components/file-viewer.js
+++ b/src/components/file-viewer.js
@@ -60,7 +60,6 @@ export class FileViewer extends ComponentBase {
 
   static get pinnedFiles() { return pinnedFiles; }
 
-  render() { Object.assign(this, renderFileViewerShell(this.container, this._components)); this.showEmpty(); }
   async loadPinnedFiles() { await doLoadPinnedFiles(this); }
 
   isPinned(filePath) { return isFilePinned(filePath); }


### PR DESCRIPTION
## Refactoring

`FileViewer` définissait `render()` **deux fois**. En JS, la seconde définition (un one-liner sans garde) écrasait silencieusement la première — la version gardée `if (!this._components) return;` était donc du code mort jamais exécuté.

Cette PR supprime le one-liner dupliqué et conserve la version gardée (lignes 41-45).

**Pourquoi garder la version avec garde et non le one-liner ?**
`ComponentBase` appelle automatiquement `render()` dans son cycle de vie (`component-base.js:26`), *avant* que le constructeur de `FileViewer` n'affecte `this._components` (l'affectation suit `super()`). Le garde `if (!this._components) return;` existe précisément pour neutraliser cet appel de cycle de vie ; le `this.render()` explicite du constructeur effectue ensuite le rendu réel une fois `_components` défini. Conserver le one-liner sans garde aurait laissé `renderFileViewerShell` être appelé avec `undefined`.

## Fichier(s) modifié(s)

- `src/components/file-viewer.js`

## Vérifications

- [x] Build OK (`node build.js`)
- [x] Tests OK (`vitest run` — 411 tests passés)

---

📂 Path local : `/Users/claude/flux/review/pikagent/`
🤖 PR créée automatiquement par l'Agent Refactor