### PR TITLE
refactor: drop redundant export keyword on registry-only components

### DIFF
--- a/src/components/config-settings-panel.js
+++ b/src/components/config-settings-panel.js
@@ -10,7 +10,7 @@ import {
 import { registerComponent } from '../utils/component-registry.js';
 import { configFacade as configApi } from '../facades/config-facade.js';
 
-export class ConfigSettingsPanel {
+class ConfigSettingsPanel {
   constructor(tabManager) {
     this.tabManager = tabManager;
     this.currentConfigName = null;

--- a/src/components/diff-viewer.js
+++ b/src/components/diff-viewer.js
@@ -8,7 +8,7 @@ import { registerComponent } from '../utils/component-registry.js';
  * DiffViewer component - renders a side-by-side diff with syntax highlighting,
  * line numbers, and navigation between hunks.
  */
-export class DiffViewer {
+class DiffViewer {
   constructor(container, diffText, filePath) {
     this.container = container;
     this.diffText = diffText;

--- a/src/components/file-viewer-webview.js
+++ b/src/components/file-viewer-webview.js
@@ -10,7 +10,7 @@ import { emitLayoutChanged } from '../utils/workspace-events.js';
 import { parseWebviewUrl } from '../utils/editor-helpers.js';
 import { registerComponent, getComponent } from '../utils/component-registry.js';
 
-export class WebviewManager {
+class WebviewManager {
   /**
    * @param {HTMLElement} container - the file-viewer container element
    * @param {HTMLElement} statusBar - the status bar element (webview containers insert before it)

--- a/src/components/flow-modal.js
+++ b/src/components/flow-modal.js
@@ -247,7 +247,7 @@ function _buildActionBar(existing, fields, bottom, catPicker, state, overlayRef,
   return { actionBar, close };
 }
 
-export function openFlowModal(existing = null, categories = []) {
+function openFlowModal(existing = null, categories = []) {
   return new Promise((resolve) => {
     const state = { selectedCwd: existing?.cwd || '' };
     const overlayRef = {};

--- a/src/components/flow-view.js
+++ b/src/components/flow-view.js
@@ -12,7 +12,7 @@ import {
 import { flowFacade as flowApi } from '../facades/flow-facade.js';
 
 
-export class FlowView extends ComponentBase {
+class FlowView extends ComponentBase {
   constructor(container, tabManager) {
     super(container);
     this.tabManager = tabManager;

--- a/src/components/settings-appearance.js
+++ b/src/components/settings-appearance.js
@@ -74,7 +74,7 @@ function _createThemeCard(name, theme, isActive, tabManager, renderAppearanceFn)
  * @param {import('../components/tab-manager.js').TabManager|null} tabManager
  * @param {() => void} renderAppearanceFn - callback to re-render this section
  */
-export function renderAppearance(contentEl, tabManager, renderAppearanceFn) {
+function renderAppearance(contentEl, tabManager, renderAppearanceFn) {
   // Day/Night mode toggle
   const modeRow = _el('div', 'theme-mode-row');
   modeRow.appendChild(_el('span', 'theme-mode-label', 'Mode'));

--- a/src/components/settings-configs.js
+++ b/src/components/settings-configs.js
@@ -86,7 +86,7 @@ function _createBottomActions(currentName, tabManager, renderConfigsFn) {
  * @param {import('../components/tab-manager.js').TabManager|null} tabManager
  * @param {() => void} renderConfigsFn - callback to re-render this section
  */
-export async function renderConfigs(contentEl, tabManager, renderConfigsFn) {
+async function renderConfigs(contentEl, tabManager, renderConfigsFn) {
   const currentName = tabManager?.configManager?.currentConfigName || 'Default';
 
   // Current loaded config indicator

--- a/src/components/settings-keybindings.js
+++ b/src/components/settings-keybindings.js
@@ -84,7 +84,7 @@ function _renderBindingRow(binding, shortcutManager, startRecordingFn, renderKey
  * @param {(actionId: string, index: number, badgeEl: HTMLElement) => void} startRecordingFn
  * @param {() => void} renderKeybindingsFn - callback to re-render
  */
-export function renderKeybindings(contentEl, shortcutManager, startRecordingFn, renderKeybindingsFn) {
+function renderKeybindings(contentEl, shortcutManager, startRecordingFn, renderKeybindingsFn) {
   const resetBtn = createActionButton({
     text: 'Reset to defaults',
     cls: 'settings-reset-btn',

--- a/src/components/settings-update.js
+++ b/src/components/settings-update.js
@@ -125,7 +125,7 @@ async function runCheck(area, btn) {
  * Render the Update section into the given content element.
  * @param {HTMLElement} contentEl
  */
-export async function renderUpdate(contentEl) {
+async function renderUpdate(contentEl) {
   createSettingsSection(contentEl, { heading: 'Update' });
   const version = await updateApi.version();
   const { area } = renderUpdateUI(contentEl, version);

--- a/src/components/terminal-panel.js
+++ b/src/components/terminal-panel.js
@@ -24,7 +24,7 @@ import {
 } from '../utils/terminal-node-builder.js';
 import { terminalPanelFacade } from '../facades/terminal-panel-facade.js';
 
-export class TerminalPanel {
+class TerminalPanel {
   constructor(container, cwd) {
     this.container = container;
     this.cwd = cwd;

--- a/src/components/usage-view.js
+++ b/src/components/usage-view.js
@@ -7,7 +7,7 @@ import { usageFacade as usageApi } from '../facades/usage-facade.js';
 
 // --- Component ---
 
-export class UsageView extends ComponentBase {
+class UsageView extends ComponentBase {
   constructor(container) {
     super(container);
   }

--- a/src/components/webview-panel.js
+++ b/src/components/webview-panel.js
@@ -16,7 +16,7 @@ import {
 import { registerComponent } from '../utils/component-registry.js';
 import { boardFacade } from '../facades/board-facade.js';
 
-export class WebviewInstance {
+class WebviewInstance {
   constructor(container, url) {
     this.container = container;
     this.url = url;


### PR DESCRIPTION
## Refactoring

L'issue #588 listait 18 composants dont le mot-clé `export` semblait redondant (composant aussi enregistré via `registerComponent`). En vérifiant chaque symbole, **12 sont effectivement du code mort** et 6 ne le sont **pas** (voir ci-dessous). Cette PR retire `export` sur les 12 sûrs uniquement.

### `export` retiré (12 — non consommés)

`ConfigSettingsPanel`, `DiffViewer`, `WebviewManager`, `FlowView`, `TerminalPanel`, `UsageView`, `WebviewInstance`, `openFlowModal`, `renderAppearance`, `renderConfigs`, `renderKeybindings`, `renderUpdate` — aucun import nommé, aucune référence de type. La déclaration reste, seul `export` part ; l'enregistrement `registerComponent(...)` suffit.

### `export` conservé (6 — référencés en types JSDoc)

`BoardView`, `FileTree`, `FileViewer`, `FlowCardTerminalManager`, `GitChangesView`, `SkillsView` sont utilisés dans des annotations de type JSDoc `import('../components/...').Symbole` (dans `tab-navigation.js`, `file-tree-dir-ops.js`, `file-viewer-editor.js`, `flow-view-rendering.js`, `skills-view-actions.js`). Retirer leur `export` casserait silencieusement ces références de type — leur export n'est donc **pas** mort. Le scan de triage de l'issue n'avait pas détecté les imports de type JSDoc.

## Fichier(s) modifié(s)

- `src/components/config-settings-panel.js`, `diff-viewer.js`, `file-viewer-webview.js`, `flow-view.js`, `terminal-panel.js`, `usage-view.js`, `webview-panel.js`, `flow-modal.js`, `settings-appearance.js`, `settings-configs.js`, `settings-keybindings.js`, `settings-update.js`

## Vérifications

- [x] Build OK (`node build.js`)
- [x] Tests OK (`vitest run` — 411 tests passés)

> ℹ️ Le build émet un warning `Duplicate member "render"` dans `file-viewer.js` : il est **préexistant** sur `dev` et corrigé par la PR #591 (issue #587), sans rapport avec cette PR.

---

📂 Path local : `/Users/claude/flux/review/pikagent/`
🤖 PR créée automatiquement par l'Agent Refactor