### PR TITLE
refactor: remove residual dead code (unused export + dead imports)

### DIFF
--- a/main/safe-handler.js
+++ b/main/safe-handler.js
@@ -103,4 +103,4 @@ function trySafe(fn, defaultValue, { log, label } = {}) {
   return createSafeWrapper({ defaultValue, log, label })(fn)();
 }
 
-module.exports = { createSafeWrapper, createSafeHandler, wrapSafe, trySafe };
+module.exports = { createSafeHandler, wrapSafe, trySafe };

--- a/src/utils/flow-category-renderer.js
+++ b/src/utils/flow-category-renderer.js
@@ -6,7 +6,7 @@
 import { _el, buildDomainButtonBar } from './dom.js';
 import { buildChevronRow } from './dom.js';
 import { setupDropZone } from './drop-zone-helpers.js';
-import { CATEGORY_ACTIONS, UNCATEGORIZED } from './flow-view-helpers.js';
+import { CATEGORY_ACTIONS } from './flow-view-helpers.js';
 import { computeInsertionIndex } from './drag-helpers.js';
 import { clearIndicators } from './flow-drag-cleanup.js';
 

--- a/src/utils/workspace-resize.js
+++ b/src/utils/workspace-resize.js
@@ -8,7 +8,7 @@
 
 import { _el } from './dom.js';
 import { setupResizeHandler } from './drag-helpers.js';
-import { PANEL_MIN_WIDTH, FIT_DELAY_MS, WORKSPACE_PANELS } from './tab-constants.js';
+import { FIT_DELAY_MS, WORKSPACE_PANELS } from './tab-constants.js';
 import { clampPanelWidth, panelArrowState } from './tab-manager-helpers.js';
 
 // ── Panel building ──


### PR DESCRIPTION
## Refactoring

Trois éléments de code mort résiduels, tous de même nature (symbole déclaré/importé mais jamais consommé) :

1. **`createSafeWrapper` retiré de `module.exports`** (`main/safe-handler.js`) — la fonction reste vivante (factory interne pour `wrapSafe`/`createSafeHandler`/`trySafe`), mais aucun autre module ne l'importe : sa présence dans `module.exports` était morte.
2. **Import mort `PANEL_MIN_WIDTH` retiré** (`src/utils/workspace-resize.js`) — importé mais jamais référencé dans le fichier.
3. **Import mort `UNCATEGORIZED` retiré** (`src/utils/flow-category-renderer.js`) — importé mais jamais référencé (seul `CATEGORY_ACTIONS` y est utilisé).

Vérifié par `grep` : chaque symbole retiré n'est consommé nulle part ailleurs (les autres usages de `PANEL_MIN_WIDTH`/`UNCATEGORIZED` passent par leurs propres imports dans d'autres fichiers, intacts).

## Fichier(s) modifié(s)

- `main/safe-handler.js`
- `src/utils/workspace-resize.js`
- `src/utils/flow-category-renderer.js`

## Vérifications

- [x] Build OK (`node build.js`)
- [x] Tests OK (`vitest run` — 411 tests passés)

> ℹ️ Warning de build `Duplicate member "render"` (`file-viewer.js`) : préexistant sur `dev`, corrigé par la PR #591, sans rapport avec cette PR.

---

📂 Path local : `/Users/claude/flux/review/pikagent/`
🤖 PR créée automatiquement par l'Agent Refactor