### PR TITLE
refactor: dedup minor patterns (_safeFit reuse + did-navigate handlers)

### DIFF
--- a/src/components/webview-panel.js
+++ b/src/components/webview-panel.js
@@ -88,16 +88,12 @@ export class WebviewInstance {
   }
 
   _setupWebviewListeners() {
-    this.webview.addEventListener('did-navigate', (e) => {
-      this.url = e.url;
-      this.urlInput.value = e.url;
-    });
+    const syncUrl = (url) => { this.url = url; this.urlInput.value = url; };
+
+    this.webview.addEventListener('did-navigate', (e) => syncUrl(e.url));
 
     this.webview.addEventListener('did-navigate-in-page', (e) => {
-      if (e.isMainFrame) {
-        this.url = e.url;
-        this.urlInput.value = e.url;
-      }
+      if (e.isMainFrame) syncUrl(e.url);
     });
 
     this.webview.addEventListener('console-message', (e) => {

--- a/src/utils/sidebar-manager.js
+++ b/src/utils/sidebar-manager.js
@@ -19,6 +19,7 @@
 import { _el, renderList } from './dom.js';
 import { ACTIVITY_BUTTONS, SETTINGS_ICON, SIDE_VIEWS } from './tab-constants.js';
 import { createAsyncHandler } from './event-helpers.js';
+import { _safeFit } from './terminal-factory.js';
 
 function buildActivityButton(label, iconSvg, extraClass = '') {
   const btn = _el('button', `activity-btn ${extraClass}`.trim());
@@ -37,7 +38,7 @@ const SIDE_VIEW_REATTACH_OVERRIDES = {
     const boardView = viewStore.getView('boardView');
     if (!boardView) return;
     for (const [, card] of boardView.cards) {
-      try { card.fitAddon.fit(); } catch (e) { console.warn('card.fitAddon.fit() failed (detached terminal?)', e); }
+      _safeFit(card.fitAddon);
     }
     boardView.resume();
   },


### PR DESCRIPTION
## Refactoring

Deux petites duplications de logique déjà factorisée ailleurs :

1. **`sidebar-manager.js`** — `SIDE_VIEW_REATTACH_OVERRIDES.board` ré-implémentait inline le `try/catch` autour de `fitAddon.fit()`. Remplacé par un appel au helper `_safeFit` de `terminal-factory.js`, déjà réutilisé dans `flow-card-terminal.js` et `board-view.js`.
2. **`webview-panel.js`** — les handlers `did-navigate` et `did-navigate-in-page` exécutaient un corps identique (`this.url = … ; this.urlInput.value = …`). Extrait dans une closure locale `syncUrl(url)`.

Aucun changement de comportement : `_safeFit` exécute exactement le même `try/catch` (seul le préfixe du message de warning passe de `card.fitAddon.fit()` à `fitAddon.fit()`) ; `syncUrl` reproduit à l'identique l'affectation de `url`/`urlInput.value`.

## Fichier(s) modifié(s)

- `src/utils/sidebar-manager.js`
- `src/components/webview-panel.js`

## Vérifications

- [x] Build OK (`node build.js`)
- [x] Tests OK (`vitest run` — 411 tests passés)

> ℹ️ Warning de build `Duplicate member "render"` (`file-viewer.js`) : préexistant sur `dev`, corrigé par la PR #591, sans rapport avec cette PR.

---

📂 Path local : `/Users/claude/flux/review/pikagent/`
🤖 PR créée automatiquement par l'Agent Refactor