### PR TITLE
refactor: remove dead CachedJsonFile re-export from json-store.js

### DIFF
--- a/main/json-store.js
+++ b/main/json-store.js
@@ -2,7 +2,7 @@ const path = require('path');
 const fsp = require('fs/promises');
 const { readJson, writeJson, readDirJson, ensureDirOnce } = require('./fs-utils');
 const { createLogger, trySafe } = require('./logger');
-const { CachedJsonFile } = require('./cached-json-file');
+
 
 /**
  * Reusable JSON-file CRUD store.
@@ -126,7 +126,4 @@ class JsonStore {
   }
 }
 
-// CachedJsonFile has been extracted to its own module (./cached-json-file.js).
-// Re-exported here for backward compatibility.
-
-module.exports = { JsonStore, CachedJsonFile };
+module.exports = { JsonStore };


### PR DESCRIPTION
## Refactoring

Suppression du re-export mort de `CachedJsonFile` dans `json-store.js`. Ce re-export "backward compatibility" n'a jamais eu de consommateur — tous les fichiers importent `CachedJsonFile` directement depuis `./cached-json-file.js`.

Closes #595

## Fichier(s) modifié(s)

- `main/json-store.js` — retrait de l'import et du re-export de `CachedJsonFile`, suppression du commentaire associé

## Vérifications

- [x] Build OK
- [x] Tests OK (411/411)

---

📂 Path local : `/Users/rekta/projet/coding/refactor-pikagent`
🤖 PR créée automatiquement par l'Agent Refactor