### PR TITLE
refactor: disambiguate FIT_DELAY_MS into context-specific constants

### DIFF
--- a/src/components/flow-card-terminal.js
+++ b/src/components/flow-card-terminal.js
@@ -7,7 +7,7 @@ import { createModalOverlay } from '../utils/dom-dialogs.js';
 import { onKeyAction } from '../utils/event-helpers.js';
 import { _safeFit, createPtyBoundTerminal, disposeTerminal, disposeTerminalMap } from '../utils/terminal-factory.js';
 import {
-  FIT_DELAY_MS, LOG_SCROLLBACK, LIVE_SCROLLBACK,
+  FLOW_FIT_DELAY_MS, LOG_SCROLLBACK, LIVE_SCROLLBACK,
   STATUS_LABELS, NO_LOG_MESSAGE, NO_LOG_MODAL_MESSAGE,
   formatRunDateTime,
 } from '../utils/flow-view-helpers.js';
@@ -42,7 +42,7 @@ export class FlowCardTerminalManager {
   _createAndRegister(map, flowId, containerEl, opts, setupFn) {
     const record = createPtyBoundTerminal(containerEl, {
       termOpts: { scrollback: LIVE_SCROLLBACK, ...opts },
-      fitDelay: FIT_DELAY_MS,
+      fitDelay: FLOW_FIT_DELAY_MS,
     });
     if (setupFn) setupFn(record);
     map.set(flowId, { ...record, containerEl });
@@ -54,7 +54,7 @@ export class FlowCardTerminalManager {
   createLiveTerminal(flowId, ptyId) {
     const existing = this._liveTerminals.get(flowId);
     if (existing) {
-      setTimeout(() => _safeFit(existing.fitAddon), FIT_DELAY_MS);
+      setTimeout(() => _safeFit(existing.fitAddon), FLOW_FIT_DELAY_MS);
       return existing.containerEl;
     }
 
@@ -62,7 +62,7 @@ export class FlowCardTerminalManager {
 
     const record = createPtyBoundTerminal(containerEl, {
       termOpts: { scrollback: LIVE_SCROLLBACK, cursorStyle: 'bar' },
-      fitDelay: FIT_DELAY_MS,
+      fitDelay: FLOW_FIT_DELAY_MS,
       onPtyData: (writeFn) => ptyApi.onData(ptyId, writeFn),
     });
 
@@ -115,7 +115,7 @@ export class FlowCardTerminalManager {
 
     const { term, resizeObs } = createPtyBoundTerminal(termContainer, {
       termOpts: { scrollback: LOG_SCROLLBACK },
-      fitDelay: FIT_DELAY_MS,
+      fitDelay: FLOW_FIT_DELAY_MS,
     });
 
     term.write(log || NO_LOG_MODAL_MESSAGE);

--- a/src/utils/flow-view-helpers.js
+++ b/src/utils/flow-view-helpers.js
@@ -7,7 +7,8 @@ import { formatDateTime } from '../../shared/date-utils.js';
 import { getLastRun } from '../../shared/flow-utils.js';
 import { countBy, createLookupMap, resolveFromMap } from '../../shared/aggregation-utils.js';
 
-export const FIT_DELAY_MS = 50;
+/** Delay before fitting xterm in flow cards (shorter — smaller terminals). */
+export const FLOW_FIT_DELAY_MS = 50;
 export const LOG_SCROLLBACK = 5000;
 export const LIVE_SCROLLBACK = 3000;
 

--- a/src/utils/tab-constants.js
+++ b/src/utils/tab-constants.js
@@ -1,7 +1,8 @@
 // ── Layout constants ──
 export const DRAG_THRESHOLD = 5;
 export const PANEL_MIN_WIDTH = 150;
-export const FIT_DELAY_MS = 200;
+/** Delay before fitting xterm after workspace resize (longer — full layout reflow). */
+export const WORKSPACE_FIT_DELAY_MS = 200;
 
 // ── Side panel configuration (single source of truth for side-specific limits & arrows) ──
 export const SIDE_CONFIG = {

--- a/src/utils/workspace-resize.js
+++ b/src/utils/workspace-resize.js
@@ -8,7 +8,7 @@
 
 import { _el } from './dom-core.js';
 import { setupResizeHandler } from './drag-helpers.js';
-import { FIT_DELAY_MS, WORKSPACE_PANELS } from './tab-constants.js';
+import { WORKSPACE_FIT_DELAY_MS, WORKSPACE_PANELS } from './tab-constants.js';
 import { clampPanelWidth, panelArrowState } from './tab-manager-helpers.js';
 
 // ── Panel building ──
@@ -127,7 +127,7 @@ function togglePanel({ getActiveTab, scheduleAutoSave }, panel, side, arrowEl) {
   setTimeout(() => {
     panel.classList.remove('animating');
     getActiveTab()?.terminalPanel?.fitAll();
-  }, FIT_DELAY_MS);
+  }, WORKSPACE_FIT_DELAY_MS);
   scheduleAutoSave();
 }
 


### PR DESCRIPTION
## Refactoring

Les deux constantes `FIT_DELAY_MS` avaient des valeurs différentes (50ms vs 200ms) dans deux fichiers distincts, sans que le nom n'indique la différence intentionnelle.

- Renommé `FIT_DELAY_MS` → `FLOW_FIT_DELAY_MS` (50ms) dans `flow-view-helpers.js` — délai court pour les terminaux de flow cards
- Renommé `FIT_DELAY_MS` → `WORKSPACE_FIT_DELAY_MS` (200ms) dans `tab-constants.js` — délai plus long pour le reflow complet du workspace
- Mis à jour les imports dans les consommateurs

Closes #599

## Fichier(s) modifié(s)

- `src/utils/flow-view-helpers.js`
- `src/utils/tab-constants.js`
- `src/components/flow-card-terminal.js`
- `src/utils/workspace-resize.js`

## Vérifications

- [x] Build OK
- [x] Tests OK (410/410)

---

📂 Path local : `/Users/rekta/projet/coding/refactor-pikagent`
🤖 PR créée automatiquement par l'Agent Refactor