### PR TITLE
refactor: add barrel exports for file-viewer and tab-manager utility families

### DIFF
--- a/src/components/file-viewer.js
+++ b/src/components/file-viewer.js
@@ -1,12 +1,10 @@
 import { emitLayoutChanged } from '../utils/workspace-events.js';
 import { pinnedFiles } from '../utils/editor-helpers.js';
-import { renderModeBar } from '../utils/file-viewer-mode-bar.js';
-import { setupFileViewerListeners } from '../utils/file-viewer-listeners.js';
 import {
+  renderModeBar,
+  setupFileViewerListeners,
   openFileEntry, isModified as isFileModified, isPinned as isFilePinned,
   togglePin as toggleFilePin, isMarkdown as isFileMarkdown, closeFileEntry,
-} from '../utils/file-viewer-files.js';
-import {
   renderFileViewerShell, renderEditor as doRenderEditor,
   showEmpty as doShowEmpty,
   updateLineNumbers as doUpdateLineNumbers,
@@ -16,7 +14,7 @@ import {
   switchMode as doSwitchMode,
   renderTabs as doRenderTabs,
   loadPinnedFiles as doLoadPinnedFiles,
-} from '../utils/file-viewer-editor.js';
+} from '../utils/file-viewer-utils.js';
 import { registerComponent } from '../utils/component-registry.js';
 import { ComponentBase } from '../utils/component-base.js';
 import { tabViewFacade } from '../facades/tab-facade.js';

--- a/src/components/tab-manager.js
+++ b/src/components/tab-manager.js
@@ -1,7 +1,18 @@
 import {
-  initTabManager, setupBusListeners,
-  getComponent,
-} from '../utils/tab-manager-init.js';
+  initTabManager, setupBusListeners, getComponent,
+  renderActivityBar as doRenderActivityBar,
+  setSidebarMode as doSetSidebarMode,
+  renderWorkspace as doRenderWorkspace,
+  buildSwitchToDeps,
+  disposeSideView, disposeAllSideViews, disposeAllTabs,
+  bindTabOps,
+  reorderTab as doReorderTab,
+  renameTab as doRenameTab,
+  nextTab as doNextTab, prevTab as doPrevTab,
+  goToColorGroup as doGoToColorGroup, focusDirection as doFocusDirection,
+  setTabColorGroup as doSetTabColorGroup,
+  toggleNoShortcut as doToggleNoShortcut,
+} from '../utils/tab-manager-utils.js';
 import {
   serialize as doSerialize, restoreConfig as doRestoreConfig,
 } from '../utils/workspace-ops.js';
@@ -11,26 +22,8 @@ import {
   ensureVisibleTabActive as doEnsureVisibleTabActive,
 } from '../utils/tab-color-filter.js';
 import { switchTo as doSwitchTo } from '../utils/tab-lifecycle.js';
-import {
-  nextTab as doNextTab, prevTab as doPrevTab,
-  goToColorGroup as doGoToColorGroup, focusDirection as doFocusDirection,
-  setTabColorGroup as doSetTabColorGroup,
-  toggleNoShortcut as doToggleNoShortcut,
-} from '../utils/tab-navigation.js';
 import { buildPrApi, buildWorktreeApi, buildViewStore } from '../facades/tab-manager-api.js';
 import { tabViewFacade } from '../facades/tab-facade.js';
-import {
-  renderActivityBar as doRenderActivityBar,
-  setSidebarMode as doSetSidebarMode,
-  renderWorkspace as doRenderWorkspace,
-  buildSwitchToDeps,
-  disposeSideView, disposeAllSideViews, disposeAllTabs,
-} from '../utils/tab-manager-sidebar.js';
-import {
-  bindTabOps,
-  reorderTab as doReorderTab,
-  renameTab as doRenameTab,
-} from '../utils/tab-manager-tab-ops.js';
 
 export class TabManager {
   constructor(tabBar, workspaceContainer) {

--- a/src/utils/file-viewer-utils.js
+++ b/src/utils/file-viewer-utils.js
@@ -1,0 +1,17 @@
+/**
+ * Barrel re-export for the file-viewer utility family.
+ *
+ * These modules were extracted from FileViewer to reduce component size.
+ * FileViewer is the sole consumer — this barrel keeps its import block compact.
+ */
+
+export { renderModeBar } from './file-viewer-mode-bar.js';
+export { setupFileViewerListeners } from './file-viewer-listeners.js';
+export {
+  openFileEntry, isModified, isPinned, togglePin, isMarkdown, closeFileEntry,
+} from './file-viewer-files.js';
+export {
+  renderFileViewerShell, renderEditor, showEmpty,
+  updateLineNumbers, updateHighlight, updateStatusBar,
+  saveActive, switchMode, renderTabs, loadPinnedFiles,
+} from './file-viewer-editor.js';

--- a/src/utils/tab-manager-utils.js
+++ b/src/utils/tab-manager-utils.js
@@ -1,0 +1,17 @@
+/**
+ * Barrel re-export for the tab-manager utility family.
+ *
+ * These modules were extracted from TabManager to reduce component size.
+ * TabManager is the primary consumer — this barrel keeps its import block compact.
+ */
+
+export { initTabManager, setupBusListeners, getComponent } from './tab-manager-init.js';
+export {
+  renderActivityBar, setSidebarMode, renderWorkspace,
+  buildSwitchToDeps, disposeSideView, disposeAllSideViews, disposeAllTabs,
+} from './tab-manager-sidebar.js';
+export { bindTabOps, reorderTab, renameTab } from './tab-manager-tab-ops.js';
+export {
+  nextTab, prevTab, goToColorGroup, focusDirection,
+  setTabColorGroup, toggleNoShortcut,
+} from './tab-navigation.js';


### PR DESCRIPTION
## Refactoring

Création de barrels pour les deux familles d'utilitaires les plus fragmentées, réduisant le nombre d'imports dans les composants orchestrateurs :

- **`file-viewer-utils.js`** : réexporte file-viewer-editor, file-viewer-files, file-viewer-listeners, file-viewer-mode-bar → `FileViewer` passe de 4 imports à 1
- **`tab-manager-utils.js`** : réexporte tab-manager-init, tab-manager-sidebar, tab-manager-tab-ops, tab-navigation → `TabManager` passe de 4 imports à 1

Les sous-modules restent inchangés et peuvent toujours être importés directement.

Closes #600

## Fichier(s) modifié(s)

- `src/utils/file-viewer-utils.js` (nouveau — barrel)
- `src/utils/tab-manager-utils.js` (nouveau — barrel)
- `src/components/file-viewer.js` (imports consolidés)
- `src/components/tab-manager.js` (imports consolidés)

## Vérifications

- [x] Build OK
- [x] Tests OK (412/412)

---

📂 Path local : `/Users/rekta/projet/coding/refactor-pikagent`
🤖 PR créée automatiquement par l'Agent Refactor