### PR TITLE
refactor: dedup post-removeWebview sync logic

### DIFF
--- a/src/components/file-viewer-webview.js
+++ b/src/components/file-viewer-webview.js
@@ -50,6 +50,21 @@ class WebviewManager {
     return webviewId; // Return so caller knows which was removed
   }
 
+  /**
+   * Remove a webview then synchronize the viewer: switch to 'files' when the
+   * removed webview was the current mode, otherwise re-render the mode bar.
+   * Emits layout:changed once done. Single entry point shared by callers.
+   * @param {string} webviewId - id of the webview to remove
+   * @param {string} currentMode - the viewer mode active before removal
+   */
+  removeWebviewAndSync(webviewId, currentMode) {
+    const removedId = this.removeWebview(webviewId);
+    if (currentMode === removedId) this._switchMode('files');
+    else this._renderModeBar();
+    /** @fires layout:changed {undefined} — webview removed */
+    emitLayoutChanged();
+  }
+
   _createWebviewContainer(wt) {
     const container = _el('div', 'webview-area');
     container.style.display = 'none';
@@ -86,13 +101,7 @@ class WebviewManager {
     const btn = _el('button', `mode-btn mode-btn-webview${currentMode === wt.id ? ' active' : ''}`);
     btn.appendChild(_el('span', null, wt.label));
     const closeBtn = _el('span', 'mode-btn-close', { textContent: '\u00d7' });
-    onClickStopped(closeBtn, () => {
-      const removedId = this.removeWebview(wt.id);
-      if (currentMode === removedId) this._switchMode('files');
-      else this._renderModeBar();
-      /** @fires layout:changed {undefined} — webview removed */
-      emitLayoutChanged();
-    });
+    onClickStopped(closeBtn, () => this.removeWebviewAndSync(wt.id, currentMode));
     btn.appendChild(closeBtn);
     btn.addEventListener('click', () => this._switchMode(wt.id));
     return btn;

--- a/src/components/file-viewer.js
+++ b/src/components/file-viewer.js
@@ -1,4 +1,3 @@
-import { emitLayoutChanged } from '../utils/workspace-events.js';
 import { pinnedFiles } from '../utils/editor-helpers.js';
 import {
   renderModeBar,
@@ -115,12 +114,7 @@ export class FileViewer extends ComponentBase {
   _renderModeBar() { renderModeBar(this.modeBar, this.mode, { switchMode: (m) => this.switchMode(m) }, this._webviewMgr); }
 
   addWebview(label, url) { this._webviewMgr.addWebview(label, url); }
-  removeWebview(webviewId) {
-    const removedId = this._webviewMgr.removeWebview(webviewId);
-    if (this.mode === removedId) this.switchMode('files');
-    else this._renderModeBar();
-    emitLayoutChanged();
-  }
+  removeWebview(webviewId) { this._webviewMgr.removeWebviewAndSync(webviewId, this.mode); }
   getWebviewTabs() { return this._webviewMgr.getWebviewTabs(); }
   setWebviewTabs(tabs) { this._webviewMgr.setWebviewTabs(tabs); }
 


### PR DESCRIPTION
## Refactoring

Extraction d'un point unique pour la séquence de synchronisation après retrait d'une webview (switch de mode / re-render mode-bar / emitLayoutChanged), précédemment dupliquée entre `file-viewer.js` et `file-viewer-webview.js`.

Closes #604

## Fichier(s) modifié(s)

- `src/components/file-viewer.js`
- `src/components/file-viewer-webview.js`

## Vérifications

- [x] Build OK
- [x] Tests OK

---

📂 Path local : `/Users/claude/flux/review/pikagent/`
🤖 PR créée automatiquement par l'Agent Refactor