### PR TITLE
refactor: drop redundant export keyword on 6 registry-only components

### DIFF
--- a/src/components/board-view.js
+++ b/src/components/board-view.js
@@ -20,7 +20,7 @@ import {
 } from '../utils/board-helpers.js';
 import { boardFacade } from '../facades/board-facade.js';
 
-export class BoardView extends ComponentBase {
+class BoardView extends ComponentBase {
   constructor(container, tabManager) {
     super(container);
     this.tabManager = tabManager;

--- a/src/components/file-tree.js
+++ b/src/components/file-tree.js
@@ -16,7 +16,7 @@ import {
 } from '../utils/file-tree-dir-ops.js';
 import { fileTreeViewFacade } from '../facades/file-tree-facade.js';
 
-export class FileTree extends ComponentBase {
+class FileTree extends ComponentBase {
   constructor(container) {
     super(container);
   }

--- a/src/components/file-viewer.js
+++ b/src/components/file-viewer.js
@@ -19,7 +19,7 @@ import { registerComponent } from '../utils/component-registry.js';
 import { ComponentBase } from '../utils/component-base.js';
 import { tabViewFacade } from '../facades/tab-facade.js';
 
-export class FileViewer extends ComponentBase {
+class FileViewer extends ComponentBase {
   constructor(container, isActive, components = {}) {
     super(container);
     this.isActive = isActive || (() => true);

--- a/src/components/flow-card-terminal.js
+++ b/src/components/flow-card-terminal.js
@@ -14,7 +14,7 @@ import {
 import { registerComponent } from '../utils/component-registry.js';
 import { ptyApi, flowApi } from '../facades/flow-card-terminal-services.js';
 
-export class FlowCardTerminalManager {
+class FlowCardTerminalManager {
   constructor() {
     this._liveTerminals = new Map();
     this._logTerminals = new Map();

--- a/src/components/git-changes-view.js
+++ b/src/components/git-changes-view.js
@@ -7,7 +7,7 @@ import { registerComponent, getComponent } from '../utils/component-registry.js'
 import { ComponentBase } from '../utils/component-base.js';
 import { tabViewFacade } from '../facades/tab-facade.js';
 
-export class GitChangesView extends ComponentBase {
+class GitChangesView extends ComponentBase {
   constructor(container) {
     super(container);
     this.gitCwd = null;

--- a/src/components/skills-view.js
+++ b/src/components/skills-view.js
@@ -10,7 +10,7 @@ import {
 } from '../utils/skills-view-actions.js';
 import { skillsViewFacade } from '../facades/skills-facade.js';
 
-export class SkillsView extends ComponentBase {
+class SkillsView extends ComponentBase {
   constructor(container) {
     super(container);
   }


### PR DESCRIPTION
## Refactoring

Suppression du mot-clé `export` superflu sur 6 composants registry-only (consommés via `getComponent`, jamais importés par leur nom). Cohérent avec le nettoyage déjà fait dans #588/#592.

Closes #607

## Fichier(s) modifié(s)

- `src/components/board-view.js`
- `src/components/file-tree.js`
- `src/components/file-viewer.js`
- `src/components/flow-card-terminal.js`
- `src/components/git-changes-view.js`
- `src/components/skills-view.js`

## Vérifications

- [x] Build OK
- [x] Tests OK

---

📂 Path local : `/Users/claude/flux/review/pikagent/`
🤖 PR créée automatiquement par l'Agent Refactor