### PR TITLE
refactor: tighten weak JSDoc types in usage-view-helpers and pty maps

### DIFF
--- a/main/flow-executor.js
+++ b/main/flow-executor.js
@@ -28,6 +28,11 @@ const { toLogFilename } = require('../shared/date-utils');
  */
 
 /**
+ * Active PTY processes keyed by their PTY id.
+ * @typedef {Map<string, PtyProcess>} PtyProcessMap
+ */
+
+/**
  * @typedef {object} Flow
  * @property {string} id
  * @property {string} [name]
@@ -68,7 +73,7 @@ const { toLogFilename } = require('../shared/date-utils');
 
 /**
  * @typedef {object} PtyManager
- * @property {Map<string, unknown>} processes - active PTY processes by id
+ * @property {PtyProcessMap} processes - active PTY processes by id
  * @property {(opts: PtyCreateOpts) => PtyProcess} create - spawn a PTY process
  * @property {(id: string) => void} kill - kill a PTY process
  * @property {(id: string, data: string) => void} write - write input to a PTY process
@@ -80,7 +85,7 @@ const { toLogFilename } = require('../shared/date-utils');
  * Cleans up a finished flow process: clears timeout, removes PTY,
  * and notifies the renderer.
  *
- * @param {{ getPtyManager: () => { processes: Map<string, unknown> }, sendToWindow: SendToWindow }} deps
+ * @param {{ getPtyManager: () => { processes: PtyProcessMap }, sendToWindow: SendToWindow }} deps
  * @param {RunningFlows} runningFlows
  * @param {string} flowId
  * @param {string} ptyId
@@ -98,7 +103,7 @@ function cleanupFlowProcess(deps, runningFlows, flowId, ptyId, exitCode) {
 /**
  * Wires up PTY data/exit listeners for a running flow process.
  *
- * @param {{ sendToWindow: SendToWindow, getPtyManager: () => { processes: Map<string, unknown> }, getFlow: (id: string) => Promise<Flow|null>, saveFlow: (flow: Flow) => Promise<unknown>, log: FlowLogger }} deps
+ * @param {{ sendToWindow: SendToWindow, getPtyManager: () => { processes: PtyProcessMap }, getFlow: (id: string) => Promise<Flow|null>, saveFlow: (flow: Flow) => Promise<unknown>, log: FlowLogger }} deps
  * @param {RunningFlows} runningFlows
  * @param {PtyProcess} proc
  * @param {Flow} flow

--- a/main/ipc-handlers.js
+++ b/main/ipc-handlers.js
@@ -14,7 +14,7 @@ const CUSTOM_CHANNELS = ['pty:create', 'fs:watch', 'fs:trash', 'dialog:openFolde
  * `manager-init.js`.  This module only cares about IPC dispatching.
  *
  * @param {() => import('electron').BrowserWindow} getWindow
- * @param {{ targets: Record<string, Record<string, (...args: unknown[]) => unknown>>, ptyManager: { create: (opts: { id: string, cwd: string, cols: number, rows: number }) => { pid: number, onData: (cb: (data: string) => void) => void, onExit: (cb: (info: { exitCode: number }) => void) => void }, processes: Map<string, unknown> }, sessionManager: { onTerminalExit: (id: string) => void } }} deps
+ * @param {{ targets: Record<string, Record<string, (...args: unknown[]) => unknown>>, ptyManager: { create: (opts: { id: string, cwd: string, cols: number, rows: number }) => { pid: number, onData: (cb: (data: string) => void) => void, onExit: (cb: (info: { exitCode: number }) => void) => void }, processes: import('./flow-executor.js').PtyProcessMap }, sessionManager: { onTerminalExit: (id: string) => void } }} deps
  */
 function register(getWindow, { targets, ptyManager, sessionManager }) {
   const { shell, dialog } = require('electron');

--- a/src/utils/usage-view-helpers.js
+++ b/src/utils/usage-view-helpers.js
@@ -132,6 +132,18 @@ function _runMetricCards(m) {
 }
 
 /**
+ * Options object describing the tab-specific parts of a run-based tab.
+ * Consumed by {@link _createRunBasedTabConfig}.
+ *
+ * @typedef {object} RunBasedTabOptions
+ * @property {string} sliceKey - Key to extract the metrics slice (e.g. 'agent', 'flow').
+ * @property {(m: MetricsSlice) => UsageCard[]} headerCards - Returns the first 2 cards specific to this tab.
+ * @property {string} chartTitle - Title displayed above the chart.
+ * @property {(m: MetricsSlice, metrics: Record<string, MetricsSlice>) => UsageTable[]} tables - Returns table descriptor(s).
+ * @property {(m: MetricsSlice) => {empty: string[]}|null} [emptyGuard] - Optional early-return for empty state.
+ */
+
+/**
  * Factory that builds the common { cards, chart, tables } shape shared by
  * run-based tabs (agents and flows).
  *
@@ -145,13 +157,8 @@ function _runMetricCards(m) {
  * Callers only supply the parts that differ (sliceKey, headerCards, chartTitle,
  * tables builder) — everything else is handled here.
  *
- * @param {Record<string, MetricsSlice>}   metrics          The full metrics object.
- * @param {object}   options
- * @param {string}   options.sliceKey          Key to extract the metrics slice (e.g. 'agent', 'flow').
- * @param {(m: MetricsSlice) => UsageCard[]}  options.headerCards  Returns the first 2 cards specific to this tab.
- * @param {string}   options.chartTitle        Title displayed above the chart.
- * @param {(m: MetricsSlice, metrics: Record<string, MetricsSlice>) => UsageTable[]} options.tables  Returns table descriptor(s).
- * @param {(m: MetricsSlice) => {empty: string[]}|null} [options.emptyGuard]  Optional early-return for empty state.
+ * @param {Record<string, MetricsSlice>}   metrics  The full metrics object.
+ * @param {RunBasedTabOptions} options  Tab-specific configuration.
  * @returns {TabConfig | EmptyTabConfig}
  */
 function _createRunBasedTabConfig(metrics, { sliceKey, headerCards, chartTitle, tables, emptyGuard }) {


### PR DESCRIPTION
## Refactoring

Resserrage de deux annotations JSDoc faibles : `@param {object}` générique dans `usage-view-helpers.js` remplacé par un typedef précis, et `Map<string, unknown>` des process PTY remplacé par `Map<string, PtyProcess>` dans `flow-executor.js` / `ipc-handlers.js`.

Closes #603

## Fichier(s) modifié(s)

- `src/utils/usage-view-helpers.js`
- `main/flow-executor.js`
- `main/ipc-handlers.js`

## Vérifications

- [x] Build OK
- [x] Tests OK

---

📂 Path local : `/Users/claude/flux/review/pikagent/`
🤖 PR créée automatiquement par l'Agent Refactor