### PR TITLE
refactor: add dom-api barrel export, reduce coupling in 4 UI components

### DIFF
--- a/src/components/board-view.js
+++ b/src/components/board-view.js
@@ -1,9 +1,7 @@
 import {
   onTerminalCreated, onTerminalRemoved, onTerminalExited,
 } from '../utils/terminal-events.js';
-import { _el } from '../utils/dom-core.js';
-import { buildDomainButtonBar } from '../utils/dom-buttons.js';
-import { renderList } from '../utils/dom-lists.js';
+import { _el, buildDomainButtonBar, renderList } from '../utils/dom-api.js';
 import {
   _safeFit, disposeTerminal, disposeTerminalMap, setupTerminalAddons,
   createPtyBoundTerminal,

--- a/src/components/flow-modal.js
+++ b/src/components/flow-modal.js
@@ -1,7 +1,5 @@
 import { generateId } from '../utils/id.js';
-import { _el } from '../utils/dom-core.js';
-import { createActionButton } from '../utils/dom-buttons.js';
-import { createDialogBase } from '../utils/dom-dialogs.js';
+import { _el, createActionButton, createDialogBase } from '../utils/dom-api.js';
 import {
   SCHEDULE_LABELS, DAY_NAMES, WEEKDAY_INDICES, INTERVAL_HOURS,
   DEFAULT_TIME, buildScheduleData,

--- a/src/utils/dom-api.js
+++ b/src/utils/dom-api.js
@@ -1,0 +1,15 @@
+/**
+ * Barrel re-export for the dom-* utility family.
+ *
+ * Groups every DOM primitive under a single import path so that
+ * component files no longer need 3-5 individual dom-*.js imports.
+ */
+
+export { _el, _vis } from './dom-core.js';
+export { createActionButton, renderButtonBar, buildDomainButtonBar } from './dom-buttons.js';
+export { renderList, buildChevronRow, toggleCollapsible, createListItem } from './dom-lists.js';
+export {
+  createModalOverlay, buildDialogButtons, createDialogBase,
+  showPromptDialog, showErrorAlert, showConfirmDialog,
+} from './dom-dialogs.js';
+export { buildTabButton, buildTabBar } from './dom-tabs.js';


### PR DESCRIPTION
## Summary

- **Create `src/utils/dom-api.js`** barrel that re-exports all symbols from `dom-core`, `dom-buttons`, `dom-lists`, `dom-dialogs`, and `dom-tabs` (5 modules → 1 import path)
- **Update `board-view.js`**: 3 individual dom-* imports replaced by a single `dom-api.js` import
- **Update `flow-modal.js`**: 3 individual dom-* imports replaced by a single `dom-api.js` import
- **`file-viewer.js`** and **`tab-manager.js`** already use their existing barrel exports (`file-viewer-utils.js` and `tab-manager-utils.js`) — no changes needed

Reduces direct imports across the 4 components identified in the issue from 9-10 down to 4.

Closes #600

## Test plan

- [x] `npm run build` passes
- [x] `npm test` passes — 27 test files, 413 tests, all green
- [ ] Verify no other consumers are broken by the new barrel (barrel only adds a re-export layer, does not remove any original module)

🤖 Generated with [Claude Code](https://claude.com/claude-code)