### PR TITLE
refactor(terminal): extract _forEachTerminal + reuse _createAndRegister

### DIFF
--- a/src/components/flow-card-terminal.js
+++ b/src/components/flow-card-terminal.js
@@ -36,13 +36,15 @@ class FlowCardTerminalManager {
    * @param {string} flowId
    * @param {HTMLElement} containerEl
    * @param {{ scrollback?: number, cursorStyle?: string, [key: string]: unknown }} opts - extra terminal options (scrollback, cursorStyle, …)
-   * @param {(record: { term: import('@xterm/xterm').Terminal, fitAddon: import('@xterm/addon-fit').FitAddon, resizeObs: ResizeObserver|null, unsubData: (() => void)|null }) => void} [setupFn] - called with the record before it is stored
+   * @param {{ onPtyData?: (cb: (data: string) => void) => (() => void), setupFn?: (record: { term: import('@xterm/xterm').Terminal, fitAddon: import('@xterm/addon-fit').FitAddon, resizeObs: ResizeObserver|null, unsubData: (() => void)|null }) => void }} [extra] - optional PTY data subscriber and/or post-creation callback
    * @returns {{ term: import('@xterm/xterm').Terminal, fitAddon: import('@xterm/addon-fit').FitAddon, resizeObs: ResizeObserver|null, unsubData: (() => void)|null }} the terminal record stored in the map
    */
-  _createAndRegister(map, flowId, containerEl, opts, setupFn) {
+  _createAndRegister(map, flowId, containerEl, opts, extra = {}) {
+    const { onPtyData, setupFn } = typeof extra === 'function' ? { setupFn: extra } : extra;
     const record = createPtyBoundTerminal(containerEl, {
       termOpts: { scrollback: LIVE_SCROLLBACK, ...opts },
       fitDelay: FLOW_FIT_DELAY_MS,
+      ...(onPtyData ? { onPtyData } : {}),
     });
     if (setupFn) setupFn(record);
     map.set(flowId, { ...record, containerEl });
@@ -60,13 +62,14 @@ class FlowCardTerminalManager {
 
     const containerEl = _el('div', 'flow-card-terminal');
 
-    const record = createPtyBoundTerminal(containerEl, {
-      termOpts: { scrollback: LIVE_SCROLLBACK, cursorStyle: 'bar' },
-      fitDelay: FLOW_FIT_DELAY_MS,
-      onPtyData: (writeFn) => ptyApi.onData(ptyId, writeFn),
-    });
+    this._createAndRegister(
+      this._liveTerminals, flowId, containerEl,
+      { cursorStyle: 'bar' },
+      { onPtyData: (writeFn) => ptyApi.onData(ptyId, writeFn) },
+    );
 
-    this._liveTerminals.set(flowId, { ...record, containerEl, ptyId });
+    // Attach ptyId to the stored entry for external reference.
+    this._liveTerminals.get(flowId).ptyId = ptyId;
 
     return containerEl;
   }

--- a/src/components/terminal-panel.js
+++ b/src/components/terminal-panel.js
@@ -47,6 +47,12 @@ class TerminalPanel {
     this._drop = new DropIndicatorManager(this.container);
   }
 
+  // ===== Iteration Helper =====
+
+  _forEachTerminal(fn) {
+    for (const [id, node] of this.terminals) fn(id, node);
+  }
+
   // ===== DOM Helpers =====
 
   _createSplitHandle(direction, splitEl) {
@@ -56,10 +62,11 @@ class TerminalPanel {
   }
 
   _findTerminalCwd(el) {
-    for (const [, node] of this.terminals) {
-      if (node.element === el) return node.terminal.cwd;
-    }
-    return this.cwd;
+    let found = this.cwd;
+    this._forEachTerminal((id, node) => {
+      if (node.element === el) found = node.terminal.cwd;
+    });
+    return found;
   }
 
   _resetContainer() {
@@ -84,9 +91,9 @@ class TerminalPanel {
   }
 
   restoreFromTree(tree) {
-    for (const [id, node] of this.terminals) {
+    this._forEachTerminal((id, node) => {
       node.terminal.dispose();
-    }
+    });
     this.terminals.clear();
 
     this._resetContainer();
@@ -151,9 +158,9 @@ class TerminalPanel {
   setActive(node) {
     if (node.type !== 'terminal') return;
 
-    for (const [, n] of this.terminals) {
+    this._forEachTerminal((id, n) => {
       n.terminal.cwdPollingPaused = true;
-    }
+    });
     node.terminal.cwdPollingPaused = false;
 
     this.container.querySelectorAll('.terminal-wrapper.active').forEach((el) => {
@@ -195,11 +202,11 @@ class TerminalPanel {
 
   fitAll() {
     requestAnimationFrame(() => {
-      for (const [id, node] of this.terminals) {
+      this._forEachTerminal((id, node) => {
         if (node.terminal) {
           node.terminal.fit();
         }
-      }
+      });
     });
   }
 
@@ -238,15 +245,15 @@ class TerminalPanel {
   }
 
   applyTheme(theme) {
-    for (const [id, node] of this.terminals) {
+    this._forEachTerminal((id, node) => {
       node.terminal.terminal.options.theme = theme;
-    }
+    });
   }
 
   dispose() {
-    for (const [id, node] of this.terminals) {
+    this._forEachTerminal((id, node) => {
       node.terminal.dispose();
-    }
+    });
     this.terminals.clear();
   }
 }


### PR DESCRIPTION
## Summary

- **TerminalPanel**: added `_forEachTerminal(fn)` helper and replaced all 6 `for (const [id, node] of this.terminals)` loops with calls to it, reducing duplication and centralising iteration logic.
- **FlowCardTerminalManager**: refactored `createLiveTerminal` to delegate to `_createAndRegister` (with a new `onPtyData` option) instead of duplicating `createPtyBoundTerminal` + `map.set` logic. Backward compatibility for existing callers is preserved.

Closes #615

## Test plan

- [x] `npm run build` passes
- [x] `npm test` — 27 test files, 412 tests all green
- [ ] Manual smoke test: open/split/close terminals in the panel
- [ ] Manual smoke test: run a flow and verify live terminal output

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>