### PR TITLE
refactor: consolidate facade files into declarative registry

### DIFF
--- a/src/facades/board-facade.js
+++ b/src/facades/board-facade.js
@@ -1,16 +1,2 @@
-/**
- * Domain facade for the BoardView component.
- *
- * Aggregates the terminal, shell and fs API methods needed by board-view.js
- * so the component imports a single module instead of multiple services.
- */
-import ptyApi from '../services/terminal-api.js';
-import shellApi from '../services/shell-api.js';
-import fsApi from '../services/fs-api.js';
-import { composeFacade } from './compose-facade.js';
-
-export const boardFacade = composeFacade([
-  [shellApi, ['openExternal', 'openPath']],
-  [fsApi, ['homedir']],
-  [ptyApi, { ptyWrite: 'write', ptyOnData: 'onData', ptyCheckAgents: 'checkAgents' }],
-]);
+/** @see facade-registry.js — canonical definition */
+export { boardFacade } from './facade-registry.js';

--- a/src/facades/config-facade.js
+++ b/src/facades/config-facade.js
@@ -1,12 +1,2 @@
-/**
- * Domain facade for config-related components.
- *
- * Aggregates config API methods used by config-settings-panel.js and
- * settings-configs.js so both components import a single facade module.
- */
-import configApi from '../services/config-api.js';
-import { composeFacade } from './compose-facade.js';
-
-export const configFacade = composeFacade([
-  [configApi, ['save', 'load', 'list', 'setDefault', 'getDefault', 'loadDefault', 'deleteConfig']],
-]);
+/** @see facade-registry.js — canonical definition */
+export { configFacade } from './facade-registry.js';

--- a/src/facades/dialog-facade.js
+++ b/src/facades/dialog-facade.js
@@ -1,12 +1,2 @@
-/**
- * Domain facade for dialog-related components.
- *
- * Wraps dialog API methods used by flow-modal.js so the component
- * imports a single facade module instead of the service directly.
- */
-import dialogApi from '../services/dialog-api.js';
-import { composeFacade } from './compose-facade.js';
-
-export const dialogFacade = composeFacade([
-  [dialogApi, ['openFolder']],
-]);
+/** @see facade-registry.js — canonical definition */
+export { dialogFacade } from './facade-registry.js';

--- a/src/facades/facade-registry.js
+++ b/src/facades/facade-registry.js
@@ -1,0 +1,112 @@
+/**
+ * Declarative facade registry.
+ *
+ * Every domain facade that was previously defined in its own file is now
+ * declared here as a plain data entry and generated in a single pass via
+ * `composeFacade`.  The individual per-domain files (board-facade.js, etc.)
+ * still exist but simply re-export from this module, so no consumer import
+ * paths need to change.
+ *
+ * @see compose-facade.js  — the runtime helper that turns entries into facades
+ * @see https://github.com/agentdouble/pikagent/issues/613
+ */
+
+import { composeFacade } from './compose-facade.js';
+
+// ── services ────────────────────────────────────────────────────────────────
+import clipboardApi from '../services/clipboard-api.js';
+import configApi   from '../services/config-api.js';
+import dialogApi   from '../services/dialog-api.js';
+import flowApi     from '../services/flow-api.js';
+import fsApi       from '../services/fs-api.js';
+import gitApi      from '../services/git-api.js';
+import ptyApi      from '../services/terminal-api.js';
+import shellApi    from '../services/shell-api.js';
+import skillsApi   from '../services/skills-api.js';
+import updateApi   from '../services/update-api.js';
+import usageApi    from '../services/usage-api.js';
+
+// ── registry ────────────────────────────────────────────────────────────────
+// Each entry is  [exportedName, [...composeFacade entries]]
+// so every facade is a pure data declaration.
+
+/** @type {Array<[string, Array<[object, string[] | Record<string, string>]>]>} */
+const definitions = [
+  ['boardFacade', [
+    [shellApi, ['openExternal', 'openPath']],
+    [fsApi, ['homedir']],
+    [ptyApi, { ptyWrite: 'write', ptyOnData: 'onData', ptyCheckAgents: 'checkAgents' }],
+  ]],
+
+  ['tabViewFacade', [
+    [gitApi, { gitBranch: 'branch', gitLocalChanges: 'localChanges', gitFileDiff: 'fileDiff' }],
+    [fsApi, ['homedir', 'readfile', 'writefile']],
+    [configApi, ['getDefault', 'loadDefault']],
+  ]],
+
+  ['fileTreeViewFacade', [
+    [fsApi, ['copy', 'copyTo', 'rename', 'mkdir', 'writefile', 'readdir', 'watch', 'unwatch', 'onChanged', 'trash']],
+    [shellApi, ['showInFolder']],
+    [clipboardApi, { clipboardWrite: 'write' }],
+  ]],
+
+  ['flowFacade', [
+    [flowApi, ['onRunStarted', 'onRunComplete', 'getRunning', 'list', 'getCategories', 'saveCategories', 'runNow', 'toggle', 'save', 'deleteFlow']],
+  ]],
+
+  ['skillsViewFacade', [
+    [skillsApi, ['list', 'getRoot', 'read', 'write', 'importSkill', 'create', 'deleteSkill', 'setRoot']],
+    [shellApi, ['openPath']],
+    [dialogApi, ['openFolder']],
+  ]],
+
+  ['configFacade', [
+    [configApi, ['save', 'load', 'list', 'setDefault', 'getDefault', 'loadDefault', 'deleteConfig']],
+  ]],
+
+  ['dialogFacade', [
+    [dialogApi, ['openFolder']],
+  ]],
+
+  ['usageFacade', [
+    [usageApi, ['getMetrics']],
+  ]],
+
+  ['updateFacade', [
+    [updateApi, ['version', 'check', 'run', 'relaunch', 'onProgress']],
+  ]],
+
+  ['terminalPanelFacade', [
+    [ptyApi, {
+      ptyWrite: 'write',
+      ptyOnData: 'onData',
+      ptyOnExit: 'onExit',
+      ptyCreate: 'create',
+      ptyGetCwd: 'getCwd',
+      ptyResize: 'resize',
+      ptyKill: 'kill',
+    }],
+    [shellApi, ['openExternal', 'openPath']],
+    [fsApi, ['homedir']],
+  ]],
+];
+
+// ── build & export ──────────────────────────────────────────────────────────
+/** @type {Record<string, Record<string, (...a: unknown[]) => unknown>>} */
+const registry = {};
+for (const [name, entries] of definitions) {
+  registry[name] = composeFacade(entries);
+}
+
+export const {
+  boardFacade,
+  tabViewFacade,
+  fileTreeViewFacade,
+  flowFacade,
+  skillsViewFacade,
+  configFacade,
+  dialogFacade,
+  usageFacade,
+  updateFacade,
+  terminalPanelFacade,
+} = registry;

--- a/src/facades/file-tree-facade.js
+++ b/src/facades/file-tree-facade.js
@@ -1,16 +1,2 @@
-/**
- * Domain facade for the FileTree component.
- *
- * Aggregates the fs, shell and clipboard API methods needed by file-tree.js
- * so the component imports a single module instead of multiple services.
- */
-import fsApi from '../services/fs-api.js';
-import shellApi from '../services/shell-api.js';
-import clipboardApi from '../services/clipboard-api.js';
-import { composeFacade } from './compose-facade.js';
-
-export const fileTreeViewFacade = composeFacade([
-  [fsApi, ['copy', 'copyTo', 'rename', 'mkdir', 'writefile', 'readdir', 'watch', 'unwatch', 'onChanged', 'trash']],
-  [shellApi, ['showInFolder']],
-  [clipboardApi, { clipboardWrite: 'write' }],
-]);
+/** @see facade-registry.js — canonical definition */
+export { fileTreeViewFacade } from './facade-registry.js';

--- a/src/facades/flow-facade.js
+++ b/src/facades/flow-facade.js
@@ -1,12 +1,2 @@
-/**
- * Domain facade for the FlowView component.
- *
- * Aggregates flow API methods used by flow-view.js so the component
- * imports a single facade module instead of the service directly.
- */
-import flowApi from '../services/flow-api.js';
-import { composeFacade } from './compose-facade.js';
-
-export const flowFacade = composeFacade([
-  [flowApi, ['onRunStarted', 'onRunComplete', 'getRunning', 'list', 'getCategories', 'saveCategories', 'runNow', 'toggle', 'save', 'deleteFlow']],
-]);
+/** @see facade-registry.js — canonical definition */
+export { flowFacade } from './facade-registry.js';

--- a/src/facades/skills-facade.js
+++ b/src/facades/skills-facade.js
@@ -1,16 +1,2 @@
-/**
- * Domain facade for the SkillsView component.
- *
- * Aggregates the skills, shell and dialog API methods needed by skills-view.js
- * so the component imports a single module instead of multiple services.
- */
-import skillsApi from '../services/skills-api.js';
-import shellApi from '../services/shell-api.js';
-import dialogApi from '../services/dialog-api.js';
-import { composeFacade } from './compose-facade.js';
-
-export const skillsViewFacade = composeFacade([
-  [skillsApi, ['list', 'getRoot', 'read', 'write', 'importSkill', 'create', 'deleteSkill', 'setRoot']],
-  [shellApi, ['openPath']],
-  [dialogApi, ['openFolder']],
-]);
+/** @see facade-registry.js — canonical definition */
+export { skillsViewFacade } from './facade-registry.js';

--- a/src/facades/tab-facade.js
+++ b/src/facades/tab-facade.js
@@ -1,20 +1,2 @@
-/**
- * Tab Facade — domain service facade for tab-manager.js.
- *
- * Wraps git, fs, and config service APIs behind a single object so
- * tab-manager.js does not couple directly to three service modules.
- *
- * Re-exports that previously lived here have been inlined into consumers
- * (see issue #462).
- */
-
-import gitApi from '../services/git-api.js';
-import fsApi from '../services/fs-api.js';
-import configApi from '../services/config-api.js';
-import { composeFacade } from './compose-facade.js';
-
-export const tabViewFacade = composeFacade([
-  [gitApi, { gitBranch: 'branch', gitLocalChanges: 'localChanges', gitFileDiff: 'fileDiff' }],
-  [fsApi, ['homedir', 'readfile', 'writefile']],
-  [configApi, ['getDefault', 'loadDefault']],
-]);
+/** @see facade-registry.js — canonical definition */
+export { tabViewFacade } from './facade-registry.js';

--- a/src/facades/terminal-panel-facade.js
+++ b/src/facades/terminal-panel-facade.js
@@ -1,24 +1,2 @@
-/**
- * Domain facade for the TerminalPanel component.
- *
- * Aggregates the shell, fs and pty API methods needed by terminal-panel.js
- * so the component imports a single module instead of multiple services.
- */
-import ptyApi from '../services/terminal-api.js';
-import shellApi from '../services/shell-api.js';
-import fsApi from '../services/fs-api.js';
-import { composeFacade } from './compose-facade.js';
-
-export const terminalPanelFacade = composeFacade([
-  [shellApi, ['openExternal', 'openPath']],
-  [fsApi, ['homedir']],
-  [ptyApi, {
-    ptyWrite: 'write',
-    ptyOnData: 'onData',
-    ptyOnExit: 'onExit',
-    ptyCreate: 'create',
-    ptyGetCwd: 'getCwd',
-    ptyResize: 'resize',
-    ptyKill: 'kill',
-  }],
-]);
+/** @see facade-registry.js — canonical definition */
+export { terminalPanelFacade } from './facade-registry.js';

--- a/src/facades/update-facade.js
+++ b/src/facades/update-facade.js
@@ -1,12 +1,2 @@
-/**
- * Domain facade for the settings-update component.
- *
- * Wraps update API methods used by settings-update.js so the component
- * imports a single facade module instead of the service directly.
- */
-import updateApi from '../services/update-api.js';
-import { composeFacade } from './compose-facade.js';
-
-export const updateFacade = composeFacade([
-  [updateApi, ['version', 'check', 'run', 'relaunch', 'onProgress']],
-]);
+/** @see facade-registry.js — canonical definition */
+export { updateFacade } from './facade-registry.js';

--- a/src/facades/usage-facade.js
+++ b/src/facades/usage-facade.js
@@ -1,12 +1,2 @@
-/**
- * Domain facade for the UsageView component.
- *
- * Wraps usage API methods used by usage-view.js so the component
- * imports a single facade module instead of the service directly.
- */
-import usageApi from '../services/usage-api.js';
-import { composeFacade } from './compose-facade.js';
-
-export const usageFacade = composeFacade([
-  [usageApi, ['getMetrics']],
-]);
+/** @see facade-registry.js — canonical definition */
+export { usageFacade } from './facade-registry.js';


### PR DESCRIPTION
## Summary

- Created `src/facades/facade-registry.js` — a single declarative registry that imports all 8 services once and declares 10 facade definitions as pure data, generated via `composeFacade` in one pass.
- Reduced 10 individual facade files to one-line re-export stubs, preserving all existing import paths for consumers (zero breaking changes).
- Left `flow-card-terminal-services.js` unchanged as it uses a different pattern (direct service re-exports, not `composeFacade`).

Closes #613

## Test plan

- [x] `npm run build` passes
- [x] `npm test` — 27 test files, 412 tests all passing
- [ ] Verify no consumer import paths broke (all existing imports unchanged by design)

🤖 Generated with [Claude Code](https://claude.com/claude-code)