### PR TITLE
refactor: generalize trySafe wrapper with createManagerSafe

### DIFF
--- a/main/config-manager.js
+++ b/main/config-manager.js
@@ -4,7 +4,7 @@ const { DEFAULT_META, buildConfigRecord, formatConfigList } = require('./config-
 // special chars with underscores, truncates at 64 chars.  This differs from
 // sanitizeSegment (git-ref-safe, hyphen-based) by design; see string-utils.js.
 const { sanitizeName } = require('../shared/string-utils');
-const { trySafe } = require('./logger');
+const { createManagerSafe } = require('./logger');
 const { JsonStore } = require('./json-store');
 const { CachedJsonFile } = require('./cached-json-file');
 
@@ -12,6 +12,7 @@ const store = new JsonStore(CONFIG_DIR, 'config-manager', {
   idToFile: (name) => `${sanitizeName(name)}.json`,
 });
 const _meta = new CachedJsonFile(META_FILE, () => store.ensureDir(), DEFAULT_META);
+const _safe = createManagerSafe(store.log, 'config-manager');
 
 const readMeta = () => _meta.read();
 const writeMeta = (meta) => _meta.write(meta);
@@ -30,15 +31,14 @@ async function load(name) {
 
 async function list() {
   const meta = await readMeta();
-  return trySafe(
+  return _safe(
     async () => formatConfigList(await store.list(), meta.defaultConfig),
     [],
-    { log: store.log, label: 'list' },
   );
 }
 
 async function remove(name) {
-  return trySafe(
+  return _safe(
     async () => {
       await store.removeOrThrow(name);
       const meta = await readMeta();
@@ -49,7 +49,6 @@ async function remove(name) {
       return true;
     },
     false,
-    { log: store.log, label: 'remove' },
   );
 }
 

--- a/main/flow-manager.js
+++ b/main/flow-manager.js
@@ -12,8 +12,10 @@ const { buildTimestampedRecord } = require('./record-helpers');
 const { JsonStore } = require('./json-store');
 const { createFlowScheduler } = require('./flow-scheduler');
 const { createFlowExecutor } = require('./flow-executor');
+const { createManagerSafe } = require('./logger');
 
 const store = new JsonStore(FLOWS_DIR, 'flow-manager');
+const _safe = createManagerSafe(store.log, 'flow-manager');
 const CATEGORIES_FILE = store.resolve('categories.json');
 
 class FlowManager {
@@ -77,14 +79,13 @@ class FlowManager {
   }
 
   async remove(id) {
-    return store.trySafe(
+    return _safe(
       async () => {
         await store.removeOrThrow(id);
         await this._cleanLogs(id);
         return true;
       },
       false,
-      'remove',
     );
   }
 

--- a/main/logger.js
+++ b/main/logger.js
@@ -1,4 +1,4 @@
-const { trySafe } = require('./safe-handler');
+const { trySafe, createManagerSafe } = require('./safe-handler');
 
 /**
  * Lightweight logger factory for main-process modules.
@@ -27,6 +27,6 @@ function createLogger(module) {
   };
 }
 
-// Re-export trySafe from safe-handler.js so existing consumers that import
-// { trySafe } from './logger' continue to work without changes.
-module.exports = { createLogger, trySafe };
+// Re-export trySafe and createManagerSafe from safe-handler.js so existing
+// consumers that import from './logger' continue to work without changes.
+module.exports = { createLogger, trySafe, createManagerSafe };

--- a/main/safe-handler.js
+++ b/main/safe-handler.js
@@ -103,4 +103,16 @@ function trySafe(fn, defaultValue, { log, label } = {}) {
   return createSafeWrapper({ defaultValue, log, label })(fn)();
 }
 
-module.exports = { createSafeHandler, wrapSafe, trySafe };
+/**
+ * Factory that returns a pre-bound `trySafe` for a specific manager.
+ * Eliminates repetitive `{ log, label }` options at every call site.
+ *
+ * @param {{ warn: (msg: string, err?: unknown) => void }} log
+ * @param {string} managerName
+ * @returns {(fn: () => unknown, fallback: unknown) => Promise<unknown>}
+ */
+function createManagerSafe(log, managerName) {
+  return (fn, fallback) => trySafe(fn, fallback, { log, label: managerName });
+}
+
+module.exports = { createSafeHandler, wrapSafe, trySafe, createManagerSafe };

--- a/main/session-manager.js
+++ b/main/session-manager.js
@@ -5,9 +5,10 @@ const { generateSessionId, isFlowTerminal, buildEndedRecord, buildActiveRecord, 
 const { nowISO } = require('../shared/date-utils');
 const { createPollingManager } = require('../shared/polling-manager');
 const { CachedJsonFile } = require('./cached-json-file');
-const { createLogger, trySafe } = require('./logger');
+const { createLogger, createManagerSafe } = require('./logger');
 
 const log = createLogger('session-manager');
+const _safe = createManagerSafe(log, 'session-manager');
 const POLL_INTERVAL_MS = 5000;
 
 const ensureDir = ensureDirOnce(BASE_DIR);
@@ -43,7 +44,7 @@ class SessionManager {
     if (!this._ptyManager || this._polling) return;
     this._polling = true;
     try {
-      await trySafe(async () => {
+      await _safe(async () => {
         const currentAgents = await this._ptyManager.checkAgents();
 
         for (const [termId, agentName] of Object.entries(currentAgents)) {
@@ -59,7 +60,7 @@ class SessionManager {
         }
 
         this._previousAgents = { ...currentAgents };
-      }, undefined, { log, label: 'poll' });
+      }, undefined);
     } finally {
       this._polling = false;
     }
@@ -68,10 +69,9 @@ class SessionManager {
   async _startSession(termId, agentName) {
     if (isFlowTerminal(termId)) return;
 
-    const cwd = await trySafe(
+    const cwd = await _safe(
       () => this._ptyManager.getCwd(termId),
       null,
-      { log, label: 'getCwd' },
     );
 
     this._activeSessions[termId] = {
@@ -102,10 +102,9 @@ class SessionManager {
     const current = this._sessionsFile.get() || [];
     const sessions = trimSessions([...current, record]);
 
-    trySafe(
+    _safe(
       () => this._sessionsFile.write(sessions),
       undefined,
-      { log, label: 'write' },
     );
   }
 

--- a/main/skills-manager.js
+++ b/main/skills-manager.js
@@ -4,7 +4,7 @@ const path = require('path');
 const os = require('os');
 const { BASE_DIR } = require('./paths');
 const { ensureDirOnce, listDirNames } = require('./fs-utils');
-const { trySafe } = require('./logger');
+const { createManagerSafe } = require('./logger');
 const { pathExists } = require('./fs-manager-helpers');
 const { JsonStore } = require('./json-store');
 const { CachedJsonFile } = require('./cached-json-file');
@@ -19,8 +19,10 @@ const SETTINGS_FILE = path.join(BASE_DIR, 'skills-settings.json');
 const _metaFile = new CachedJsonFile(SETTINGS_FILE, () => store.ensureDir(), null);
 let _ensureRootDir = ensureDirOnce(DEFAULT_SKILLS_DIR);
 
+const _managerSafe = createManagerSafe(log, 'skills-manager');
+
 /**
- * Higher-order function that wraps `fn` with trySafe.
+ * Higher-order function that wraps `fn` with the manager-level safe handler.
  * Returns a new function with the same signature that catches errors
  * and returns `fallback` instead, logging via the module logger.
  *
@@ -31,7 +33,7 @@ let _ensureRootDir = ensureDirOnce(DEFAULT_SKILLS_DIR);
  * @returns {(...args: A) => Promise<T>}    - wrapped function
  */
 const _safe = (fn, fallback) => (...args) =>
-  trySafe(() => fn(...args), fallback, { log, label: fn.name || 'skills-op' });
+  _managerSafe(() => fn(...args), fallback);
 
 function parseFrontmatter(md) {
   if (!md.startsWith('---')) return {};


### PR DESCRIPTION
## Summary

- Add `createManagerSafe(log, managerName)` factory to `safe-handler.js` that returns a pre-bound `trySafe`, eliminating repetitive `{ log, label }` options at every call site
- Refactor 4 managers (`config-manager`, `session-manager`, `flow-manager`, `skills-manager`) to use the new factory instead of inline `trySafe` calls
- Re-export `createManagerSafe` from `logger.js` for backward-compatible imports

## Changes

| File | Before | After |
|---|---|---|
| `safe-handler.js` | — | New `createManagerSafe` factory + export |
| `logger.js` | re-exports `trySafe` | also re-exports `createManagerSafe` |
| `config-manager.js` | 2× `trySafe(fn, fb, { log, label })` | `_safe(fn, fb)` via `createManagerSafe` |
| `session-manager.js` | 3× `trySafe(fn, fb, { log, label })` | `_safe(fn, fb)` via `createManagerSafe` |
| `flow-manager.js` | 1× `store.trySafe(fn, fb, label)` | `_safe(fn, fb)` via `createManagerSafe` |
| `skills-manager.js` | local `_safe` using raw `trySafe` | `_safe` delegates to `_managerSafe` from `createManagerSafe` |

## Test plan

- [x] `npm run build` passes
- [x] `npm test` — 412 tests passing (27 files)
- [ ] Verify error logging still shows manager name in warnings

Closes #614

🤖 Generated with [Claude Code](https://claude.com/claude-code)