### PR TITLE
refactor: unify ID generation into shared/id-utils.js

### DIFF
--- a/main/flow-executor.js
+++ b/main/flow-executor.js
@@ -18,6 +18,7 @@ const {
 const { saveLog, getRunLog, cleanLogs } = require('./flow-executor-log');
 const { recordRun } = require('./flow-executor-run');
 const { toLogFilename } = require('../shared/date-utils');
+const { generateId } = require('../shared/id-utils');
 
 // --- Shared typedefs ---
 
@@ -139,7 +140,7 @@ function execute(deps, runningFlows, flow) {
   const ptyManager = deps.getPtyManager();
   if (!ptyManager) return;
 
-  const ptyId = `flow-${flow.id}-${Date.now()}`;
+  const ptyId = generateId(`flow-${flow.id}`);
   const cwd = flow.cwd || os.homedir();
   const runTimestamp = toLogFilename();
 

--- a/main/session-helpers.js
+++ b/main/session-helpers.js
@@ -1,13 +1,13 @@
 const { buildRecord } = require('./record-helpers');
 const { nowISO } = require('../shared/date-utils');
+const { generateId } = require('../shared/id-utils');
 
 const MAX_SESSIONS = 200;
 const MS_PER_SEC = 1000;
 const FLOW_PREFIX = 'flow-';
-const ID_RAND_LEN = 8;
 
 function generateSessionId() {
-  return `session-${Date.now()}-${Math.random().toString(36).slice(2, 2 + ID_RAND_LEN)}`;
+  return generateId('session');
 }
 
 function durationSec(startedAt) {

--- a/shared/id-utils.js
+++ b/shared/id-utils.js
@@ -1,0 +1,14 @@
+/**
+ * Unified ID generation utility used by both main and renderer processes.
+ * CommonJS format so main/ can require() it directly;
+ * esbuild resolves it for the renderer bundle.
+ */
+
+let counter = 0;
+const RAND_LEN = 6;
+
+function generateId(prefix = 'id') {
+  return `${prefix}-${++counter}-${Date.now()}-${Math.random().toString(36).slice(2, 2 + RAND_LEN)}`;
+}
+
+module.exports = { generateId };

--- a/src/utils/id.js
+++ b/src/utils/id.js
@@ -1,5 +1,1 @@
-let counter = 0;
-
-export function generateId(prefix = 'id') {
-  return `${prefix}_${++counter}_${Date.now()}`;
-}
+export { generateId } from '../../shared/id-utils.js';

--- a/tests/main/session-helpers.test.js
+++ b/tests/main/session-helpers.test.js
@@ -4,7 +4,7 @@ const { generateSessionId, isFlowTerminal, buildEndedRecord, buildActiveRecord, 
 describe('session-helpers', () => {
   describe('generateSessionId', () => {
     it('starts with "session-"', () => {
-      expect(generateSessionId()).toMatch(/^session-\d+-[a-z0-9]+$/);
+      expect(generateSessionId()).toMatch(/^session-\d+-\d+-[a-z0-9]+$/);
     });
 
     it('generates unique ids', () => {


### PR DESCRIPTION
## Refactoring

Consolidation des 3 stratégies de génération d'IDs en un utilitaire partagé unique (`shared/id-utils.js`) combinant counter + timestamp + random pour une unicité maximale.

- `src/utils/id.js` → réexporte depuis shared
- `main/session-helpers.js` → utilise `generateId('session')` au lieu d'une implémentation locale
- `main/flow-executor.js` → utilise `generateId('flow-<id>')` au lieu d'un template literal inline

Closes #624

## Fichier(s) modifié(s)

- `shared/id-utils.js` (nouveau — utilitaire partagé)
- `src/utils/id.js` (simplifié en réexport)
- `main/session-helpers.js` (suppression de `generateSessionId` local, délégation à shared)
- `main/flow-executor.js` (remplacement du template inline)
- `tests/main/session-helpers.test.js` (mise à jour regex du format)

## Vérifications

- [x] Build OK
- [x] Tests OK (413/413)

---

📂 Path local : `/Users/rekta/projet/coding/refactor-pikagent`
🤖 PR créée automatiquement par l'Agent Refactor