### PR TITLE
refactor: add readJsonSync helper and reuse in update-manager

### DIFF
--- a/main/fs-utils.js
+++ b/main/fs-utils.js
@@ -1,9 +1,18 @@
+const fs = require('fs');
 const fsp = require('fs/promises');
 const path = require('path');
 
 async function readJson(filePath) {
   try {
     return JSON.parse(await fsp.readFile(filePath, 'utf-8'));
+  } catch {
+    return null;
+  }
+}
+
+function readJsonSync(filePath) {
+  try {
+    return JSON.parse(fs.readFileSync(filePath, 'utf-8'));
   } catch {
     return null;
   }
@@ -38,4 +47,4 @@ async function writeJson(filePath, data) {
   await fsp.writeFile(filePath, JSON.stringify(data, null, 2), 'utf-8');
 }
 
-module.exports = { readJson, writeJson, ensureDirOnce, readDirJson, listDirNames };
+module.exports = { readJson, readJsonSync, writeJson, ensureDirOnce, readDirJson, listDirNames };

--- a/main/update-manager.js
+++ b/main/update-manager.js
@@ -3,6 +3,7 @@ const { app } = require('electron');
 const path = require('path');
 const fs = require('fs');
 const { BASE_DIR } = require('./paths');
+const { readJsonSync } = require('./fs-utils');
 
 const SOURCE_CONFIG_FILE = path.join(BASE_DIR, 'source-config.json');
 
@@ -16,22 +17,14 @@ function init() {
   }
 }
 
-function _loadConfig() {
-  try {
-    return JSON.parse(fs.readFileSync(SOURCE_CONFIG_FILE, 'utf8'));
-  } catch {
-    return null;
-  }
-}
-
 function _getProjectRoot() {
   if (!app.isPackaged) return app.getAppPath();
-  return _loadConfig()?.root || null;
+  return readJsonSync(SOURCE_CONFIG_FILE)?.root || null;
 }
 
 function _getShellPath() {
   if (!app.isPackaged) return process.env.PATH;
-  return _loadConfig()?.shellPath || process.env.PATH;
+  return readJsonSync(SOURCE_CONFIG_FILE)?.shellPath || process.env.PATH;
 }
 
 // --- Shell execution ---


### PR DESCRIPTION
## Refactoring

Ajoute `readJsonSync(filePath)` dans `main/fs-utils.js` (miroir synchrone de `readJson`) et remplace le pattern dupliqué `_loadConfig()` dans `main/update-manager.js`.

Closes #626

## Fichier(s) modifié(s)

- `main/fs-utils.js` — nouvelle fonction `readJsonSync` exportée
- `main/update-manager.js` — utilise `readJsonSync` au lieu de réimplémenter le pattern try/catch + JSON.parse

## Vérifications

- [x] Build OK
- [x] Tests OK

---

Path local : `/Users/claude/flux/review/pikagent/`
PR créée automatiquement par l'Agent Refactor