### PR TITLE
refactor: drop generateSessionId wrapper

### DIFF
--- a/main/session-helpers.js
+++ b/main/session-helpers.js
@@ -1,14 +1,9 @@
 const { buildRecord } = require('./record-helpers');
 const { nowISO } = require('../shared/date-utils');
-const { generateId } = require('../shared/id-utils');
 
 const MAX_SESSIONS = 200;
 const MS_PER_SEC = 1000;
 const FLOW_PREFIX = 'flow-';
-
-function generateSessionId() {
-  return generateId('session');
-}
 
 function durationSec(startedAt) {
   return Math.round((Date.now() - new Date(startedAt).getTime()) / MS_PER_SEC);
@@ -37,4 +32,4 @@ function trimSessions(sessions, max = MAX_SESSIONS) {
   return sessions.length > max ? sessions.slice(-max) : sessions;
 }
 
-module.exports = { generateSessionId, isFlowTerminal, buildEndedRecord, buildActiveRecord, trimSessions };
+module.exports = { isFlowTerminal, buildEndedRecord, buildActiveRecord, trimSessions };

--- a/main/session-manager.js
+++ b/main/session-manager.js
@@ -1,8 +1,9 @@
 const os = require('os');
 const { BASE_DIR, SESSIONS_FILE } = require('./paths');
 const { ensureDirOnce } = require('./fs-utils');
-const { generateSessionId, isFlowTerminal, buildEndedRecord, buildActiveRecord, trimSessions } = require('./session-helpers');
+const { isFlowTerminal, buildEndedRecord, buildActiveRecord, trimSessions } = require('./session-helpers');
 const { nowISO } = require('../shared/date-utils');
+const { generateId } = require('../shared/id-utils');
 const { createPollingManager } = require('../shared/polling-manager');
 const { CachedJsonFile } = require('./cached-json-file');
 const { createLogger, createManagerSafe } = require('./logger');
@@ -75,7 +76,7 @@ class SessionManager {
     );
 
     this._activeSessions[termId] = {
-      id: generateSessionId(),
+      id: generateId('session'),
       termId,
       agent: agentName,
       cwd: cwd || os.homedir(),

--- a/tests/main/session-helpers.test.js
+++ b/tests/main/session-helpers.test.js
@@ -1,19 +1,7 @@
 import { describe, it, expect, vi } from 'vitest';
-const { generateSessionId, isFlowTerminal, buildEndedRecord, buildActiveRecord, trimSessions } = require('../../main/session-helpers');
+const { isFlowTerminal, buildEndedRecord, buildActiveRecord, trimSessions } = require('../../main/session-helpers');
 
 describe('session-helpers', () => {
-  describe('generateSessionId', () => {
-    it('starts with "session-"', () => {
-      expect(generateSessionId()).toMatch(/^session-\d+-\d+-[a-z0-9]+$/);
-    });
-
-    it('generates unique ids', () => {
-      const a = generateSessionId();
-      const b = generateSessionId();
-      expect(a).not.toBe(b);
-    });
-  });
-
   describe('isFlowTerminal', () => {
     it('returns true for flow- prefix', () => {
       expect(isFlowTerminal('flow-abc-123')).toBe(true);


### PR DESCRIPTION
## Refactoring

Supprime le wrapper `generateSessionId()` de `main/session-helpers.js` (1 seul call site en prod). Le site d'appel utilise désormais `generateId('session')` directement depuis `shared/id-utils.js`, supprimant une indirection inutile.

Closes #627

## Fichier(s) modifié(s)

- `main/session-manager.js` — utilise `generateId('session')` au lieu de `generateSessionId()`
- `main/session-helpers.js` — supprime le wrapper et son export
- `tests/main/session-helpers.test.js` — retire le bloc \`describe('generateSessionId', ...)\`

## Vérifications

- [x] Build OK
- [x] Tests OK

---

Path local : \`/Users/claude/flux/review/pikagent/\`
PR créée automatiquement par l'Agent Refactor