### PR TITLE
refactor: route dom-core through dom-api barrel (fan-in 51 -> 5)

### DIFF
--- a/src/components/diff-viewer.js
+++ b/src/components/diff-viewer.js
@@ -1,5 +1,5 @@
 import { detectLanguage } from '../utils/file-icons.js';
-import { _el } from '../utils/dom-core.js';
+import { _el } from '../utils/dom-api.js';
 import { parseDiff, buildSideBySideRows, wordDiff, countDiffStats, UNIFIED_CHANGE_CONFIG, VIEW_MODES, HUNK_FLASH_DURATION_MS } from '../utils/diff-parser.js';
 import { NAV_BUTTONS, WORD_DIFF_CLASS, capitalize } from '../utils/diff-viewer-helpers.js';
 import { registerComponent } from '../utils/component-registry.js';

--- a/src/components/file-tree.js
+++ b/src/components/file-tree.js
@@ -1,4 +1,4 @@
-import { _el } from '../utils/dom-core.js';
+import { _el } from '../utils/dom-api.js';
 import { registerComponent } from '../utils/component-registry.js';
 import { ComponentBase } from '../utils/component-base.js';
 import {

--- a/src/components/file-viewer-webview.js
+++ b/src/components/file-viewer-webview.js
@@ -3,7 +3,7 @@
  * Extracted from file-viewer.js to reduce component size.
  */
 import { onClickStopped } from '../utils/event-helpers.js';
-import { _el } from '../utils/dom-core.js';
+import { _el } from '../utils/dom-api.js';
 import { setupInlineInput } from '../utils/form-helpers.js';
 import { generateId } from '../utils/id.js';
 import { emitLayoutChanged } from '../utils/workspace-events.js';

--- a/src/components/flow-card-terminal.js
+++ b/src/components/flow-card-terminal.js
@@ -2,7 +2,7 @@
  * Terminal management for flow cards: live terminals, inline log terminals, and log modal.
  * Extracted from FlowView to reduce component size.
  */
-import { _el } from '../utils/dom-core.js';
+import { _el } from '../utils/dom-api.js';
 import { createModalOverlay } from '../utils/dom-dialogs.js';
 import { onKeyAction } from '../utils/event-helpers.js';
 import { _safeFit, createPtyBoundTerminal, disposeTerminal, disposeTerminalMap } from '../utils/terminal-factory.js';

--- a/src/components/git-changes-view.js
+++ b/src/components/git-changes-view.js
@@ -1,5 +1,5 @@
 import { emitFileOpen } from '../utils/workspace-events.js';
-import { _el } from '../utils/dom-core.js';
+import { _el } from '../utils/dom-api.js';
 import { buildViewHeader } from '../utils/view-header.js';
 import { onClickStopped } from '../utils/event-helpers.js';
 import { STATUS_LABELS, CHEVRON, CHANGE_SECTIONS, computeTotalChanges, buildFileKey } from '../utils/git-changes-helpers.js';

--- a/src/components/settings-appearance.js
+++ b/src/components/settings-appearance.js
@@ -4,7 +4,7 @@
  */
 import { TERMINAL_THEMES, getTerminalThemeName, setTerminalTheme, getTerminalTheme, switchTerminalForMode } from '../utils/terminal-themes.js';
 import { getAppTheme, setAppTheme } from '../utils/app-theme.js';
-import { _el } from '../utils/dom-core.js';
+import { _el } from '../utils/dom-api.js';
 import { createActionButton } from '../utils/dom-buttons.js';
 import { MODE_BUTTONS, THEME_PREVIEW_LINES, COLOR_DOT_KEYS } from '../utils/settings-helpers.js';
 import { buildSettingsSection, createSettingsItem } from '../utils/settings-section-builder.js';

--- a/src/components/settings-configs.js
+++ b/src/components/settings-configs.js
@@ -2,7 +2,7 @@
  * Workspace Configs section renderer for SettingsModal.
  * Extracted from settings-modal.js to reduce component size.
  */
-import { _el } from '../utils/dom-core.js';
+import { _el } from '../utils/dom-api.js';
 import { CONFIG_ACTIONS, BOTTOM_CONFIG_BUTTONS, formatConfigMeta } from '../utils/settings-helpers.js';
 import { buildSettingsSection, createActionBar, createSettingsItem } from '../utils/settings-section-builder.js';
 import { registerComponent } from '../utils/component-registry.js';

--- a/src/components/settings-keybindings.js
+++ b/src/components/settings-keybindings.js
@@ -3,7 +3,7 @@
  * Extracted from settings-modal.js to reduce component size.
  */
 import { formatCombo } from '../utils/shortcut-helpers.js';
-import { _el } from '../utils/dom-core.js';
+import { _el } from '../utils/dom-api.js';
 import { createActionButton } from '../utils/dom-buttons.js';
 import { onClickStopped } from '../utils/event-helpers.js';
 import { buildSettingsSection, createSettingsItem } from '../utils/settings-section-builder.js';

--- a/src/components/settings-modal.js
+++ b/src/components/settings-modal.js
@@ -1,5 +1,5 @@
 import { formatCombo, eventToCombo } from '../utils/shortcut-helpers.js';
-import { _el } from '../utils/dom-core.js';
+import { _el } from '../utils/dom-api.js';
 import { createActionButton } from '../utils/dom-buttons.js';
 import { buildTabBar } from '../utils/dom-tabs.js';
 import { createModalOverlay } from '../utils/dom-dialogs.js';

--- a/src/components/settings-update.js
+++ b/src/components/settings-update.js
@@ -2,7 +2,7 @@
  * Update section renderer for SettingsModal.
  * Handles version display, update check, diff preview, install, and relaunch.
  */
-import { _el } from '../utils/dom-core.js';
+import { _el } from '../utils/dom-api.js';
 import { createSettingsSection } from '../utils/settings-section-builder.js';
 import { registerComponent } from '../utils/component-registry.js';
 import { updateFacade as updateApi } from '../facades/update-facade.js';

--- a/src/components/skills-view.js
+++ b/src/components/skills-view.js
@@ -1,4 +1,4 @@
-import { _el } from '../utils/dom-core.js';
+import { _el } from '../utils/dom-api.js';
 import { registerComponent } from '../utils/component-registry.js';
 import { ComponentBase } from '../utils/component-base.js';
 import {

--- a/src/components/usage-view.js
+++ b/src/components/usage-view.js
@@ -1,4 +1,4 @@
-import { _el } from '../utils/dom-core.js';
+import { _el } from '../utils/dom-api.js';
 import { buildTabBar } from '../utils/dom-tabs.js';
 import { buildViewHeader } from '../utils/view-header.js';
 import { TABS, getTabConfig, createSection } from '../utils/usage-view-helpers.js';

--- a/src/components/webview-panel.js
+++ b/src/components/webview-panel.js
@@ -1,4 +1,4 @@
-import { _el } from '../utils/dom-core.js';
+import { _el } from '../utils/dom-api.js';
 import { onKeyAction } from '../utils/event-helpers.js';
 import { setupResizeHandler } from '../utils/drag-helpers.js';
 import {

--- a/src/utils/context-menu.js
+++ b/src/utils/context-menu.js
@@ -2,7 +2,7 @@
  * @typedef {{ label?: string, action?: () => void, separator?: boolean, shortcut?: string, colorDot?: string, children?: Array<ContextMenuItem> }} ContextMenuItem
  */
 
-import { _el } from './dom-core.js';
+import { _el } from './dom-api.js';
 import { renderList, createListItem } from './dom-lists.js';
 import { onKeyAction } from './event-helpers.js';
 import { addListener } from './drag-helpers.js';

--- a/src/utils/file-editor-renderer.js
+++ b/src/utils/file-editor-renderer.js
@@ -3,7 +3,7 @@
  * Extracted from file-viewer.js to reduce component size.
  */
 
-import { _el } from './dom-core.js';
+import { _el } from './dom-api.js';
 import { renderStatusBar } from './view-header.js';
 import { getCursorPosition, insertTab, SAVE_FLASH_MS, TAB_SPACES } from './editor-helpers.js';
 

--- a/src/utils/file-tree-dir-ops.js
+++ b/src/utils/file-tree-dir-ops.js
@@ -5,7 +5,7 @@
  * management (setTerminalRoot, removeTerminal, refreshSection).
  */
 
-import { _el } from './dom-core.js';
+import { _el } from './dom-api.js';
 import { toggleCollapsible } from './dom-lists.js';
 import {
   CHEVRON_EXPANDED, CHEVRON_COLLAPSED,

--- a/src/utils/file-tree-drop.js
+++ b/src/utils/file-tree-drop.js
@@ -4,7 +4,7 @@
  */
 
 import { emitFileOpen } from './workspace-events.js';
-import { _el } from './dom-core.js';
+import { _el } from './dom-api.js';
 import { setupInlineInput, startInlineRename } from './form-helpers.js';
 import { setupDropZone as _setupDropZone } from './drop-zone-helpers.js';
 import { INPUT_BLUR_DELAY, computeIndent, getBaseName } from './file-tree-helpers.js';

--- a/src/utils/file-tree-renderer.js
+++ b/src/utils/file-tree-renderer.js
@@ -4,7 +4,7 @@
  */
 
 import { emitFileOpen } from './workspace-events.js';
-import { _el } from './dom-core.js';
+import { _el } from './dom-api.js';
 import { createActionButton } from './dom-buttons.js';
 import { buildChevronRow } from './dom-lists.js';
 import { computeIndent, CHEVRON_EXPANDED, CHEVRON_COLLAPSED, SVG_ICONS, HEADER_ACTIONS } from './file-tree-helpers.js';

--- a/src/utils/file-tree-section-dom.js
+++ b/src/utils/file-tree-section-dom.js
@@ -8,7 +8,7 @@
  * @typedef {{ setupDropZone: (el: HTMLElement, targetDir: string|(() => string|null)) => void, promptNewEntry: (dirPath: string, cEl: HTMLElement, depth: number, eDirs: Set<string>, type: string) => void, promptRename: (path: string, nameEl: HTMLElement) => void, refreshSection: (cwd: string) => void, contextMenuApi: unknown }} SectionDOMCallbacks
  */
 
-import { _el } from './dom-core.js';
+import { _el } from './dom-api.js';
 import { buildChevronRow, toggleCollapsible } from './dom-lists.js';
 import { attachContextMenu } from './context-menu.js';
 import { emitWorkspaceCreateWorktree, emitWorkspaceOpenPr } from './workspace-events.js';

--- a/src/utils/file-viewer-editor.js
+++ b/src/utils/file-viewer-editor.js
@@ -5,7 +5,7 @@
  * line numbers, and file close logic.  State is passed in, never owned here.
  */
 
-import { _el } from './dom-core.js';
+import { _el } from './dom-api.js';
 import { EMPTY_MESSAGE, MODE_CONFIG, ALL_STATIC_ELEMENTS, MODE_ACTIVATE } from './editor-helpers.js';
 import { pinnedFiles } from './editor-helpers.js';
 import {

--- a/src/utils/file-viewer-tabs.js
+++ b/src/utils/file-viewer-tabs.js
@@ -3,7 +3,7 @@
  * Extracted from file-viewer.js to reduce component size.
  */
 
-import { _el } from './dom-core.js';
+import { _el } from './dom-api.js';
 import { renderList } from './dom-lists.js';
 import { attachContextMenu } from './context-menu.js';
 import { createTabElement } from './tab-renderer.js';

--- a/src/utils/flow-card-renderer.js
+++ b/src/utils/flow-card-renderer.js
@@ -2,7 +2,7 @@
  * Pure rendering helpers for flow cards.
  * Extracted from flow-view.js to reduce component size.
  */
-import { _el } from './dom-core.js';
+import { _el } from './dom-api.js';
 import { createActionButton, buildDomainButtonBar } from './dom-buttons.js';
 import { formatSchedule } from './flow-schedule-helpers.js';
 import { MAX_VISIBLE_RUNS, buildDotTooltip, buildCardActionEntries } from './flow-view-helpers.js';

--- a/src/utils/flow-card-setup.js
+++ b/src/utils/flow-card-setup.js
@@ -8,7 +8,7 @@
  * @typedef {{ id: string, runs?: Array<FlowRun>, enabled?: boolean }} FlowDescriptor
  */
 
-import { _el } from './dom-core.js';
+import { _el } from './dom-api.js';
 import { toggleCollapsible } from './dom-lists.js';
 import { getLastRun } from './flow-view-helpers.js';
 import { cleanupAllDragState } from './flow-drag-cleanup.js';

--- a/src/utils/flow-category-renderer.js
+++ b/src/utils/flow-category-renderer.js
@@ -3,7 +3,7 @@
  * Handles category headers, collapse state, and drag-drop zone setup.
  * Extracted from flow-view.js to reduce component size.
  */
-import { _el } from './dom-core.js';
+import { _el } from './dom-api.js';
 import { buildDomainButtonBar } from './dom-buttons.js';
 import { buildChevronRow } from './dom-lists.js';
 import { setupDropZone } from './drop-zone-helpers.js';

--- a/src/utils/flow-modal-helpers.js
+++ b/src/utils/flow-modal-helpers.js
@@ -1,4 +1,4 @@
-import { _el, _vis as _visGeneric } from './dom-core.js';
+import { _el, _vis as _visGeneric } from './dom-api.js';
 import { buildSelect } from './form-helpers.js';
 import { SCHEDULE_TYPE_CONFIG } from './flow-schedule-helpers.js';
 // --- Constants ---

--- a/src/utils/flow-view-rendering.js
+++ b/src/utils/flow-view-rendering.js
@@ -12,7 +12,7 @@ import {
 } from './flow-view-helpers.js';
 import { createCategoryGroup } from './flow-category-renderer.js';
 import { createFlowCard } from './flow-card-setup.js';
-import { _el } from './dom-core.js';
+import { _el } from './dom-api.js';
 import { buildDomainButtonBar } from './dom-buttons.js';
 import { buildViewHeader } from './view-header.js';
 

--- a/src/utils/form-helpers.js
+++ b/src/utils/form-helpers.js
@@ -4,7 +4,7 @@
  * Provides utilities for inline <input> wiring and inline rename workflows.
  */
 
-import { _el } from './dom-core.js';
+import { _el } from './dom-api.js';
 import { onClickStopped, onKeyAction } from './event-helpers.js';
 
 /**

--- a/src/utils/markdown-preview-renderer.js
+++ b/src/utils/markdown-preview-renderer.js
@@ -4,7 +4,7 @@
  * instead of an editable textarea.
  */
 
-import { _el } from './dom-core.js';
+import { _el } from './dom-api.js';
 import { renderStatusBar } from './view-header.js';
 import { renderMarkdown } from './markdown-renderer.js';
 

--- a/src/utils/open-pr-flow.js
+++ b/src/utils/open-pr-flow.js
@@ -7,7 +7,7 @@
  */
 
 import { showConfirmDialog, showErrorAlert } from './dom-dialogs.js';
-import { _el } from './dom-core.js';
+import { _el } from './dom-api.js';
 import { gitFlowStep } from './git-flow-helpers.js';
 
 /**

--- a/src/utils/settings-section-builder.js
+++ b/src/utils/settings-section-builder.js
@@ -3,7 +3,7 @@
  * Abstracts the heading + content + action buttons pattern
  * shared across settings-appearance, settings-configs, and settings-keybindings.
  */
-import { _el } from './dom-core.js';
+import { _el } from './dom-api.js';
 import { renderButtonBar } from './dom-buttons.js';
 import { renderList } from './dom-lists.js';
 import { createAsyncHandler } from './event-helpers.js';

--- a/src/utils/sidebar-manager.js
+++ b/src/utils/sidebar-manager.js
@@ -16,7 +16,7 @@
  * @typedef {{ getActiveTab: () => import('./tab-types.js').WorkspaceTab|null, capturePanelWidths: (tab: import('./tab-types.js').WorkspaceTab) => void, viewStore: SideViewStore }} DetachDeps
  */
 
-import { _el } from './dom-core.js';
+import { _el } from './dom-api.js';
 import { renderList } from './dom-lists.js';
 import { ACTIVITY_BUTTONS, SETTINGS_ICON, SIDE_VIEWS } from './tab-constants.js';
 import { createAsyncHandler } from './event-helpers.js';

--- a/src/utils/skills-view-renderer.js
+++ b/src/utils/skills-view-renderer.js
@@ -4,7 +4,7 @@
  * Pure DOM-construction functions. State is passed in, never owned here.
  */
 
-import { _el } from './dom-core.js';
+import { _el } from './dom-api.js';
 import { renderList } from './dom-lists.js';
 import { buildViewHeader } from './view-header.js';
 

--- a/src/utils/tab-bar-renderer.js
+++ b/src/utils/tab-bar-renderer.js
@@ -6,7 +6,7 @@
  * @typedef {{ tabBar: HTMLElement, tabs: Map<string, import('./tab-types.js').WorkspaceTab>, activeTabId: string|null, activeColorFilter: string|null, excludedColors: Set<string>, switchTo: (id: string) => void, closeTab: (id: string) => void, renameTab: (id: string, nameEl: HTMLElement) => void, setTabColorGroup: (id: string, colorGroupId: string|null) => void, toggleNoShortcut: (id: string) => void, setColorFilter: (colorGroupId: string) => void, toggleExcludeColor: (colorGroupId: string) => void, createTab: () => void, reorderTab: (fromId: string, toId: string, before: boolean) => void, isTabVisible: (tab: import('./tab-types.js').WorkspaceTab) => boolean, renderTabBar: () => void, clearColorFilters: () => void }} RenderTabBarDeps
  */
 
-import { _el } from './dom-core.js';
+import { _el } from './dom-api.js';
 import { renderList } from './dom-lists.js';
 import { buildColorFilters } from './tab-color-filter.js';
 import { buildTabElement } from './tab-renderer.js';

--- a/src/utils/tab-color-filter.js
+++ b/src/utils/tab-color-filter.js
@@ -2,7 +2,7 @@
  * Color filter logic for tab manager.
  * Extracted from tab-manager.js to reduce component size.
  */
-import { _el } from './dom-core.js';
+import { _el } from './dom-api.js';
 import { COLOR_GROUPS } from './tab-constants.js';
 import { attachContextMenu } from './context-menu.js';
 

--- a/src/utils/tab-lifecycle.js
+++ b/src/utils/tab-lifecycle.js
@@ -16,7 +16,7 @@
  */
 
 import { generateId } from './id.js';
-import { _el } from './dom-core.js';
+import { _el } from './dom-api.js';
 import { showConfirmDialog } from './dom-dialogs.js';
 import { emitWorkspaceActivated, emitTabWorktreeClosed } from './workspace-events.js';
 import { WorkspaceTab } from './tab-types.js';

--- a/src/utils/tab-renderer.js
+++ b/src/utils/tab-renderer.js
@@ -7,7 +7,7 @@
  *
  * @typedef {{ activeTabId: string|null, tabs: Map<string, import('./tab-types.js').WorkspaceTab>, switchTo: (id: string) => void, closeTab: (id: string) => void, renameTab: (id: string, nameEl: HTMLElement) => void, setTabColorGroup: (id: string, colorGroupId: string|null) => void, toggleNoShortcut: (id: string) => void, dragDeps: import('./tab-drag.js').TabDragDeps }} TabElementDeps
  */
-import { _el } from './dom-core.js';
+import { _el } from './dom-api.js';
 import { buildChevronRow } from './dom-lists.js';
 import { startInlineRename } from './form-helpers.js';
 import { COLOR_GROUPS } from './tab-constants.js';

--- a/src/utils/terminal-drop-indicator.js
+++ b/src/utils/terminal-drop-indicator.js
@@ -2,7 +2,7 @@
  * Drop indicator management for terminal panel drag-and-drop.
  * Extracted from terminal-panel.js to reduce component size.
  */
-import { _el } from './dom-core.js';
+import { _el } from './dom-api.js';
 import { detectDropSide, computeIndicatorRect } from './split-primitives.js';
 
 export class DropIndicatorManager {

--- a/src/utils/terminal-node-builder.js
+++ b/src/utils/terminal-node-builder.js
@@ -4,7 +4,7 @@
  */
 
 import { emitTerminalCreated } from './terminal-events.js';
-import { _el } from './dom-core.js';
+import { _el } from './dom-api.js';
 import { onClickStopped } from './event-helpers.js';
 import { SplitNode, DRAG_GRIP, createSplitContainer } from './terminal-panel-helpers.js';
 import { TerminalInstance } from './terminal-instance.js';

--- a/src/utils/terminal-panel-helpers.js
+++ b/src/utils/terminal-panel-helpers.js
@@ -1,5 +1,5 @@
 /* Pure helpers and constants for terminal-panel. */
-import { _el } from './dom-core.js';
+import { _el } from './dom-api.js';
 import { computeResizeRatio } from './split-primitives.js';
 import { getPanels } from './split-layout.js';
 

--- a/src/utils/usage-view-flows-tab.js
+++ b/src/utils/usage-view-flows-tab.js
@@ -3,7 +3,7 @@
  * Builds the cards / chart / tables descriptor consumed by the view.
  */
 
-import { _el } from './dom-core.js';
+import { _el } from './dom-api.js';
 import { formatDuration, rateColor } from './usage-formatters.js';
 import { buildTableRow, createRunBasedTabConfig } from './usage-view-shared.js';
 

--- a/src/utils/usage-view-shared.js
+++ b/src/utils/usage-view-shared.js
@@ -3,7 +3,7 @@
  * No side-effect dependencies — safe to unit-test in isolation.
  */
 
-import { _el } from './dom-core.js';
+import { _el } from './dom-api.js';
 import { formatDuration, formatTokens, runTooltip, rateCls } from './usage-formatters.js';
 
 // --- Tab definitions ---

--- a/src/utils/view-header.js
+++ b/src/utils/view-header.js
@@ -8,7 +8,7 @@
  * letting each caller keep its own CSS class prefixes and DOM shape.
  */
 
-import { _el } from './dom-core.js';
+import { _el } from './dom-api.js';
 
 /**
  * Build a view header: container + title (left) + actions zone (right).

--- a/src/utils/workspace-layout.js
+++ b/src/utils/workspace-layout.js
@@ -11,7 +11,7 @@
  */
 
 import { emitWorkspaceActivated } from './workspace-events.js';
-import { _el } from './dom-core.js';
+import { _el } from './dom-api.js';
 import { WORKSPACE_PANELS } from './tab-constants.js';
 import {
   buildSidePanel, buildCenterPanel,

--- a/src/utils/workspace-resize.js
+++ b/src/utils/workspace-resize.js
@@ -6,7 +6,7 @@
  * @typedef {{ getActiveTab: () => import('./tab-types.js').WorkspaceTab|null, scheduleAutoSave: () => void }} PanelInteractionDeps
  */
 
-import { _el } from './dom-core.js';
+import { _el } from './dom-api.js';
 import { setupResizeHandler } from './drag-helpers.js';
 import { WORKSPACE_FIT_DELAY_MS, WORKSPACE_PANELS } from './tab-constants.js';
 import { clampPanelWidth, panelArrowState } from './tab-manager-helpers.js';

--- a/src/utils/worktree-dialog.js
+++ b/src/utils/worktree-dialog.js
@@ -9,7 +9,7 @@
  * Returns a Promise<{ branch, createBranch, targetPath } | null>.
  */
 
-import { _el, _vis } from './dom-core.js';
+import { _el, _vis } from './dom-api.js';
 import { createActionButton } from './dom-buttons.js';
 import { createDialogBase, buildDialogButtons } from './dom-dialogs.js';
 import { onKeyAction } from './event-helpers.js';

--- a/src/utils/worktree-flow.js
+++ b/src/utils/worktree-flow.js
@@ -9,7 +9,7 @@
 
 import { showWorktreeDialog } from './worktree-dialog.js';
 import { showConfirmDialog } from './dom-dialogs.js';
-import { _el } from './dom-core.js';
+import { _el } from './dom-api.js';
 import { gitFlowStep } from './git-flow-helpers.js';
 
 /**


### PR DESCRIPTION
## Refactoring

\`src/utils/dom-core.js\` était importé par 51 fichiers — hotspot critique flaggé dans #633 (régression de #541/#596).

Cette PR redirige les imports des composants et utilitaires non-DOM vers le barrel existant \`dom-api.js\` (qui ré-exporte déjà \`_el\` et \`_vis\`). \`dom-core.js\` n'est désormais importé que par les **5 modules internes de la couche dom** : \`dom-api.js\`, \`dom-buttons.js\`, \`dom-lists.js\`, \`dom-tabs.js\`, \`dom-dialogs.js\`.

Aucune logique modifiée : seuls les chemins d'import ont changé (46 fichiers, 46 lignes modifiées).

**Fan-in direct sur dom-core : 51 → 5** (objectif issue : <25).

Closes #633

## Fichier(s) modifié(s)

- 38 fichiers dans \`src/utils/\` (sauf dom-api/dom-buttons/dom-lists/dom-tabs/dom-dialogs)
- 12 composants dans \`src/components/\`

## Vérifications

- [x] Build OK (\`npm run build\`)
- [x] Tests OK (\`npm test\` — 415 tests, 27 suites)
- [x] dom-core fan-in vérifié : 5 importateurs restants (tous internes)

---

📂 Path local : \`/Users/claude/flux/review/pikagent/\`
🤖 PR créée automatiquement par l'Agent Refactor