### PR TITLE
refactor: reuse splitLines() in update-manager and git-metrics-collector

### DIFF
--- a/main/git-metrics-collector.js
+++ b/main/git-metrics-collector.js
@@ -6,6 +6,7 @@ const {
 } = require('./usage-helpers');
 const { createLogger, trySafe } = require('./logger');
 const { runCommand } = require('./command-utils');
+const { splitLines } = require('./parse-utils');
 
 const log = createLogger('git-metrics-collector');
 
@@ -18,7 +19,7 @@ async function getMostModifiedFiles(cwds) {
         { cwd, encoding: 'utf-8', timeout: GIT_TIMEOUT_MS },
         { fallback: '', trySafe, log, label: `git log in ${cwd}` },
       );
-      const files = stdout ? stdout.split('\n').map((l) => l.trim()).filter(Boolean) : [];
+      const files = stdout ? splitLines(stdout, (l) => l.trim()).filter(Boolean) : [];
       return { cwd, files };
     })
   );

--- a/main/update-manager.js
+++ b/main/update-manager.js
@@ -4,6 +4,7 @@ const path = require('path');
 const fs = require('fs');
 const { BASE_DIR } = require('./paths');
 const { readJsonSync } = require('./fs-utils');
+const { splitLines } = require('./parse-utils');
 
 const SOURCE_CONFIG_FILE = path.join(BASE_DIR, 'source-config.json');
 
@@ -58,7 +59,7 @@ async function checkForUpdates() {
   try {
     await _run('git fetch origin', root);
     const log = await _run(`git log HEAD..origin/${UPDATE_BRANCH} --oneline`, root);
-    const commits = log ? log.split('\n').filter(Boolean) : [];
+    const commits = log ? splitLines(log) : [];
     return { available: commits.length > 0, commits, count: commits.length };
   } catch (err) {
     return { available: false, error: err.message };


### PR DESCRIPTION
## Refactoring

Deux call sites de `main/` réécrivaient à la main le pattern `split('\n').filter(Boolean)` que `parse-utils.splitLines()` factorise déjà (et que `git-helpers.js` et `pty-helpers.js` utilisent correctement).

- `main/update-manager.js:61` — `log.split('\n').filter(Boolean)` → `splitLines(log)`
- `main/git-metrics-collector.js:21` — `stdout.split('\n').map(trim).filter(Boolean)` → `splitLines(stdout, trim).filter(Boolean)` *(filtre final conservé pour exclure les lignes devenues vides après trim — `splitLines` filtre AVANT le map)*

Aucun changement de logique. 4 lignes ajoutées (2 imports + 2 réécritures), 2 lignes supprimées.

Closes #636

## Fichier(s) modifié(s)

- `main/update-manager.js`
- `main/git-metrics-collector.js`

## Vérifications

- [x] Build OK (`npm run build`)
- [x] Tests OK (`npm test` — 415 tests, 27 suites)

---

📂 Path local : `/Users/claude/flux/review/pikagent/`
🤖 PR créée automatiquement par l'Agent Refactor