### PR TITLE
refactor: drop unused exports in usage-view-shared.js (#638)

### DIFF
--- a/src/utils/usage-view-shared.js
+++ b/src/utils/usage-view-shared.js
@@ -16,7 +16,7 @@ export const TABS = [
 
 // --- Chart segment definitions ---
 
-export const RUN_CHART_SEGMENTS = [
+const RUN_CHART_SEGMENTS = [
   { key: 'success', cls: 'usage-chart-bar-success' },
   { key: 'error', cls: 'usage-chart-bar-error' },
   { key: 'running', cls: 'usage-chart-bar-running' },
@@ -124,7 +124,7 @@ export function createSection(title) {
  * Build the two run-metric cards shared by agents and flows tabs:
  * success rate + average duration (with min/max sub-text).
  */
-export function runMetricCards(m) {
+function runMetricCards(m) {
   return [
     { label: 'Taux succès', value: `${m.rate.rate}%`, cls: rateCls(m.rate.rate) },
     { label: 'Durée moy.', value: formatDuration(m.duration.avg), cls: 'usage-stat-value-blue', sub: m.duration.count > 0 ? `min: ${formatDuration(m.duration.min)} · max: ${formatDuration(m.duration.max)}` : '' },


### PR DESCRIPTION
## Refactoring

`RUN_CHART_SEGMENTS` et `runMetricCards` étaient exportés mais utilisés uniquement à l'intérieur de `usage-view-shared.js` (par `createRunBasedTabConfig()`). Aucun import externe n'existait. Le mot-clé `export` est retiré ; les symboles deviennent locaux au module.

Closes #638

## Fichier(s) modifié(s)

- `src/utils/usage-view-shared.js`

## Vérifications

- [x] Build OK (`npm run build`)
- [x] Tests OK (415/415 — `npm test`)

---

📂 Path local : `/Users/claude/flux/review/pikagent/`
🤖 PR créée automatiquement par l'Agent Refactor